### PR TITLE
adds "short description" field to lists

### DIFF
--- a/app/assets/stylesheets/styles/lists.scss
+++ b/app/assets/stylesheets/styles/lists.scss
@@ -26,6 +26,12 @@ td.lists_table_name {
   font-weight: 300;
 }
 
+#list-long-description {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 300;
+}
+
 .list-actions .twitter-typeahead {
   width: 400px;
   top: -6px;

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -260,7 +260,7 @@ class ListsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def list_params
-      params.require(:list).permit(:name, :description, :is_ranked, :is_admin, :is_featured, :is_private, :custom_field_name)
+      params.require(:list).permit(:name, :description, :is_ranked, :is_admin, :is_featured, :is_private, :custom_field_name, :short_description)
     end
 
     def interlocks_results(options)

--- a/app/indices/list_index.rb
+++ b/app/indices/list_index.rb
@@ -1,6 +1,7 @@
 ThinkingSphinx::Index.define :list, :with => :active_record, :delta => ThinkingSphinx::Deltas::DelayedDelta do
   indexes name, sortable: true
   indexes description
+  indexes short_description
 
   has is_deleted, facet: true
   has is_admin, facet: true

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -31,6 +31,7 @@ class List < ActiveRecord::Base
   has_one :default_topic, class_name: 'Topic', inverse_of: :default_list, foreign_key: 'default_list_id'
 
   validates_presence_of :name
+  validates :short_description, length: { maximum: 255 }
 
   scope :public_scope, -> { where(is_private: false) }
   scope :private_scope, -> { where(is_private: true) }

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -20,6 +20,14 @@
 
   <div class="row form-group">
       <div class="col-sm-10 col-md-8">
+    <%= f.label :short_description %>
+    <%= f.text_field :short_description, class: "form-control" %>
+    </div>
+  </div>
+
+
+  <div class="row form-group">
+      <div class="col-sm-10 col-md-8">
     <%= f.label :description %>
 	  <%= f.text_area :description, class: "textarea_medium form-control", size: '6x8' %>
 	  </div>

--- a/app/views/lists/_header.html.erb
+++ b/app/views/lists/_header.html.erb
@@ -1,6 +1,7 @@
 <div id="list-header">
   <div id="list-name"><%= list_link(list) %></div>
-  <div id="list-description"><%= list.description %></div>
+  <div id="list-description"><%= list.short_description %></div>
+  <div id="list-long-description"><%= list.description %></div>
 </div>
 
 <% if list.default_topic.present? %>

--- a/app/views/lists/_list_actions.html.erb
+++ b/app/views/lists/_list_actions.html.erb
@@ -5,7 +5,7 @@
 		<%= link_to('edit', edit_list_path(list), class: 'btn btn-default') %>
 	    <% end %>
 	    <% if has_legacy_permission('admin') %>
-		<%= link_to('delete', delete_list_path(list), class: 'btn btn-default', method: :post, data: { confirm: 'Are you sure yu want to delete this list?' }) %>
+		<%= link_to('delete', delete_list_path(list), class: 'btn btn-default', method: :post, data: { confirm: 'Are you sure you want to delete this list?' }) %>
 	    <% end %>
 	    <% if has_legacy_permission('bulker') %>
 		<%= link_to('add bulk', list.legacy_url('addBulk'), class: 'btn btn-default') %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -29,7 +29,11 @@
       <tr>
         <td class="lists_table_name"><%= list_link(list) %></td>
         <td><%= list.entity_count %></td>
-        <td><%= list.description %></td>
+        <% if list.short_description %>
+          <td><%= list.short_description %></td>
+        <% else %>
+          <td><%= list.description %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/lists/new.html.erb
+++ b/app/views/lists/new.html.erb
@@ -15,6 +15,11 @@
         <%= f.label(:class, "List Name*") %>
         <%= f.text_field :name, class: "form-control"%>
     </div>
+
+    <div class="field">
+        <%= f.label(:short_description, "Short description") %>
+        <%= f.text_field :short_description, class: "form-control"%>
+    </div>
     
     <div class="field">
         <%= f.label(:description, "Description") %>

--- a/db/migrate/20170626212039_add_short_description_to_lists.rb
+++ b/db/migrate/20170626212039_add_short_description_to_lists.rb
@@ -1,0 +1,5 @@
+class AddShortDescriptionToLists < ActiveRecord::Migration
+  def change
+  	add_column	:ls_list, :short_description, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+
 ActiveRecord::Schema.define(version: 20170706142752) do
 
   create_table "address", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20170706142752) do
 
   create_table "address", force: :cascade do |t|

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2529,7 +2529,7 @@ CREATE TABLE `sessions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sessions_on_session_id` (`session_id`),
   KEY `index_sessions_on_updated_at` (`updated_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2654,7 +2654,7 @@ CREATE TABLE `sf_guard_user` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   KEY `is_active_idx_idx` (`is_active`)
-) ENGINE=InnoDB AUTO_INCREMENT=340 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=346 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2740,7 +2740,7 @@ CREATE TABLE `sf_guard_user_profile` (
   UNIQUE KEY `unique_public_name_idx` (`public_name`),
   KEY `user_id_public_name_idx` (`user_id`,`public_name`),
   CONSTRAINT `sf_guard_user_profile_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `sf_guard_user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2983,7 +2983,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_username` (`username`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
   UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=294 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=300 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3020,7 +3020,7 @@ CREATE TABLE `versions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-07-06 14:30:49
+-- Dump completed on 2017-07-06 20:10:03
 INSERT INTO schema_migrations (version) VALUES ('20131031182415');
 
 INSERT INTO schema_migrations (version) VALUES ('20131031182500');

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -13,6 +13,8 @@ describe List do
     expect(l).to be_valid
   end
 
+  it { should validate_length_of(:short_description).is_at_most(255) }
+
   context "active relationships" do
     it 'joins entities via ListEntity' do
       list_entity_count = ListEntity.count

--- a/spec/views/lists/new.html.erb_spec.rb
+++ b/spec/views/lists/new.html.erb_spec.rb
@@ -11,8 +11,8 @@ describe 'lists/new.html.erb' do
       expect(rendered).to have_selector('form', :count => 1 )
     end
 
-    it 'contains 3 text inputs' do
-      expect(rendered).to have_selector('input[type=text]', :count => 3 )
+    it 'contains 4 text inputs' do
+      expect(rendered).to have_selector('input[type=text]', :count => 4 )
     end
 
     it 'contains 1 text_area' do


### PR DESCRIPTION
Let me know how you like the display choices for short description vs [full] description. On the show page for a list, I have both; the index of lists shows long description only if a short description doesn't exist (which is the case for basically all lists, currently).