### PR TITLE
Restricted Users + Fight Spam

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -4,6 +4,7 @@ class EntitiesController < ApplicationController
   before_action :set_entity_with_eager_loading, only: [:show]
   before_action :set_current_user, only: [:show, :political, :match_donations]
   before_action :importers_only, only: [:match_donation, :match_donations, :review_donations, :match_ny_donations, :review_ny_donations]
+  before_action -> { check_permission('contributor') }, only: [:create]
 
   def show
     @similar_entities = @entity.similar_entities

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -17,7 +17,15 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
         UserMailer.welcome_email(user).deliver_later
         NotificationMailer.signup_email(user).deliver_later
         user.create_default_permissions
-        user.delay.create_chat_account
+
+        # If the user's request is from a spamy ip address then automatically restrict the user
+        # and don't create a chat account
+        if IpBlocker.restricted?(request.remote_ip)
+          user.update(is_restricted: true)
+        else
+          user.delay.create_chat_account
+        end
+
       end
     end
   end
@@ -33,4 +41,5 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   def after_confirmation_path_for(resource_name, resource)
     home_dashboard_path
   end
+
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -16,6 +16,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       if user.errors.empty?
         UserMailer.welcome_email(user).deliver_later
         NotificationMailer.signup_email(user).deliver_later
+        user.create_default_permissions
         user.delay.create_chat_account
       end
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -29,7 +29,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
       resource.sf_guard_user_profile.save
       resource.save
       if resource.persisted?
-        resource.create_default_permissions
         if resource.active_for_authentication?
           set_flash_message! :notice, :signed_up
           sign_up(resource_name, resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,12 @@ class User < ActiveRecord::Base
     has_legacy_permission 'bulker'
   end
 
+  def restricted?
+    is_restricted
+  end
+
+  ################
+  
   def in_group?(group)
   	GroupUser.where(group_id: group.id, user_id: id).count > 0
   end

--- a/app/utility/ip_blocker.rb
+++ b/app/utility/ip_blocker.rb
@@ -1,0 +1,20 @@
+# Checks if ip in blacklist.yml
+module IpBlocker
+  if File.exist?(Rails.root.join('config', 'blacklist.yml'))
+
+    IPS = YAML.load(File.new(Rails.root.join('config', 'blacklist.yml')).read).map do |ip|
+      begin
+        IPAddr.new(ip)
+      rescue IPAddr::InvalidAddressError
+        nil
+      end
+    end.compact
+
+    define_singleton_method('blocked?') do |ip|
+      
+    end
+
+  else
+    define_singleton_method('blocked?') { |ip| false }
+  end
+end

--- a/app/utility/ip_blocker.rb
+++ b/app/utility/ip_blocker.rb
@@ -1,8 +1,10 @@
 # Checks if ip in blacklist.yml
 module IpBlocker
-  if File.exist?(Rails.root.join('config', 'blacklist.yml'))
+  if APP_CONFIG['restricted_ips'].blank?
+    define_singleton_method(:restricted?) { |ip| false }
+  else
 
-    IPS = YAML.load(File.new(Rails.root.join('config', 'blacklist.yml')).read).map do |ip|
+    IPS = APP_CONFIG['restricted_ips'].map do |ip|
       begin
         IPAddr.new(ip)
       rescue IPAddr::InvalidAddressError
@@ -10,11 +12,10 @@ module IpBlocker
       end
     end.compact
 
-    define_singleton_method('blocked?') do |ip|
-      
+    define_singleton_method(:restricted?) do |ip|
+      IPS.each { |blocked_ip| return true if blocked_ip.include?(ip) }
+      return false
     end
-
-  else
-    define_singleton_method('blocked?') { |ip| false }
+    
   end
 end

--- a/app/views/users/admin.html.erb
+++ b/app/views/users/admin.html.erb
@@ -29,6 +29,7 @@
       <th>Joined</th>
       <th>Permissions</th>
       <th>Edit Permissions</th>
+      <th>Restrict</th>
       <th>Delete</th>
     </tr>
   </thead>
@@ -57,6 +58,19 @@
             <%= user.legacy_permissions.join(", ") %>
         </td>
 	<td><%= link_to "Edit", "/users/#{user.id}/edit_permissions" %></td>
+	<td>
+	    <% unless user.admin? %>
+		<%= form_tag "/users/#{user.id}/restrict", method: :post, :id => "restrict_#{user.id}" do %>
+		    <% if user.restricted?  %>
+			<input type="hidden" name="status" value="permit" />
+			<%= button_tag "Remove restriction", class: 'btn btn-primary btn-sm' %>
+		    <% else %>
+			<input type="hidden" name="status" value="restrict" />
+			<%= button_tag "Restrict this user", class: ' btn btn-warning' %>
+		    <% end %>
+		<% end %>
+	    <% end %>
+	</td>
 	<td><%= link_to "DELETE","/users/#{user.id}/destroy",  :method => :delete, data: { confirm: "Are you sure you want to delete this user? This cannot be undone" } %></td>
       </tr>
     <% end %>

--- a/config/lilsis.yml.sample
+++ b/config/lilsis.yml.sample
@@ -45,13 +45,15 @@ defaults: &defaults
   notification_to:
   legacy_cache_connection: "memcached:11211"
   carousel_list_id: 404
+  restricted_ips:
   chat:
     chat_url: "http://localhost:3000"
     mongo_url: "mongo:27017"
     api_url: "rocketchat:3000"
     admin_username: 
     admin_password:
-    
+  
+  
 
 
 test:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,9 +84,10 @@ Lilsis::Application.routes.draw do
   get '/groups/:id(/:group_tabs_selected_tab)' => 'groups#show'
 
   resources :users, only: [:index] do
-    member do 
-      get 'edit_permissions' 
+    member do
+      get 'edit_permissions'
       post 'add_permission'
+      post 'restrict'
       delete 'delete_permission'
       delete 'destroy'
     end

--- a/db/migrate/20170706142752_add_is_restricted_to_user.rb
+++ b/db/migrate/20170706142752_add_is_restricted_to_user.rb
@@ -1,0 +1,5 @@
+class AddIsRestrictedToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :is_restricted, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170612172624) do
+ActiveRecord::Schema.define(version: 20170706142752) do
 
   create_table "address", force: :cascade do |t|
     t.integer  "entity_id",    limit: 8,                   null: false
@@ -240,6 +240,88 @@ ActiveRecord::Schema.define(version: 20170612172624) do
   add_index "chat_user", ["room", "updated_at", "user_id"], name: "room_updated_at_user_id_idx", using: :btree
   add_index "chat_user", ["room", "user_id"], name: "room_user_id_idx", unique: true, using: :btree
   add_index "chat_user", ["user_id"], name: "user_id_idx", using: :btree
+
+  create_table "clean_sf_guard_user", force: :cascade do |t|
+    t.string   "username",       limit: 128,                  null: false
+    t.string   "algorithm",      limit: 128, default: "sha1", null: false
+    t.string   "salt",           limit: 128
+    t.string   "password",       limit: 128
+    t.boolean  "is_active",                  default: true
+    t.boolean  "is_super_admin",             default: false
+    t.datetime "last_login"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean  "is_deleted",                 default: false,  null: false
+  end
+
+  add_index "clean_sf_guard_user", ["is_active"], name: "is_active_idx_idx", using: :btree
+  add_index "clean_sf_guard_user", ["username"], name: "username", unique: true, using: :btree
+
+  create_table "clean_sf_guard_user_profile", force: :cascade do |t|
+    t.integer  "user_id",                    limit: 4,                          null: false
+    t.string   "name_first",                 limit: 50,                         null: false
+    t.string   "name_last",                  limit: 50,                         null: false
+    t.string   "email",                      limit: 50,                         null: false
+    t.text     "reason",                     limit: 4294967295
+    t.text     "analyst_reason",             limit: 4294967295
+    t.boolean  "is_visible",                                    default: true,  null: false
+    t.string   "invitation_code",            limit: 50
+    t.boolean  "enable_announcements",                          default: true,  null: false
+    t.boolean  "enable_html_editor",                            default: true,  null: false
+    t.boolean  "enable_recent_views",                           default: true,  null: false
+    t.boolean  "enable_favorites",                              default: true,  null: false
+    t.boolean  "enable_pointers",                               default: true,  null: false
+    t.string   "public_name",                limit: 50,                         null: false
+    t.text     "bio",                        limit: 4294967295
+    t.boolean  "is_confirmed",                                  default: false, null: false
+    t.string   "confirmation_code",          limit: 100
+    t.string   "filename",                   limit: 100
+    t.boolean  "ranking_opt_out",                               default: false, null: false
+    t.boolean  "watching_opt_out",                              default: false, null: false
+    t.boolean  "enable_notes_list",                             default: true,  null: false
+    t.boolean  "enable_notes_notifications",                    default: true,  null: false
+    t.integer  "score",                      limit: 8
+    t.boolean  "show_full_name",                                default: false, null: false
+    t.integer  "unread_notes",               limit: 4,          default: 0
+    t.integer  "home_network_id",            limit: 4,                          null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "clean_sf_guard_user_profile", ["email"], name: "unique_email_idx", unique: true, using: :btree
+  add_index "clean_sf_guard_user_profile", ["public_name"], name: "unique_public_name_idx", unique: true, using: :btree
+  add_index "clean_sf_guard_user_profile", ["user_id", "public_name"], name: "user_id_public_name_idx", using: :btree
+  add_index "clean_sf_guard_user_profile", ["user_id"], name: "unique_user_idx", unique: true, using: :btree
+
+  create_table "clean_users", force: :cascade do |t|
+    t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "reset_password_token",   limit: 255
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          limit: 4,   default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip",     limit: 255
+    t.string   "last_sign_in_ip",        limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "default_network_id",     limit: 4
+    t.integer  "sf_guard_user_id",       limit: 4,                null: false
+    t.string   "username",               limit: 255,              null: false
+    t.string   "remember_token",         limit: 255
+    t.string   "confirmation_token",     limit: 255
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.boolean  "newsletter"
+    t.string   "chatid",                 limit: 255
+  end
+
+  add_index "clean_users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
+  add_index "clean_users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "clean_users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "clean_users", ["sf_guard_user_id"], name: "index_users_on_sf_guard_user_id", unique: true, using: :btree
+  add_index "clean_users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   create_table "couple", force: :cascade do |t|
     t.integer "entity_id",   limit: 4, null: false
@@ -565,6 +647,7 @@ ActiveRecord::Schema.define(version: 20170612172624) do
   end
 
   add_index "link", ["category_id"], name: "category_id_idx", using: :btree
+  add_index "link", ["entity1_id", "category_id", "is_reverse"], name: "e1_cat_rev_idx", using: :btree
   add_index "link", ["entity1_id", "category_id", "is_reverse"], name: "index_link_on_entity1_id_and_category_id_and_is_reverse", using: :btree
   add_index "link", ["entity1_id", "category_id"], name: "index_link_on_entity1_id_and_category_id", using: :btree
   add_index "link", ["entity1_id"], name: "entity1_id_idx", using: :btree
@@ -641,6 +724,7 @@ ActiveRecord::Schema.define(version: 20170612172624) do
     t.boolean  "delta",                                default: true,  null: false
     t.boolean  "is_private",                           default: false
     t.integer  "creator_user_id",   limit: 4
+    t.string   "short_description", limit: 255
   end
 
   add_index "ls_list", ["delta"], name: "index_ls_list_on_delta", using: :btree
@@ -863,9 +947,45 @@ ActiveRecord::Schema.define(version: 20170612172624) do
   add_index "ny_disclosures", ["contrib_code"], name: "index_ny_disclosures_on_contrib_code", using: :btree
   add_index "ny_disclosures", ["delta"], name: "index_ny_disclosures_on_delta", using: :btree
   add_index "ny_disclosures", ["e_year"], name: "index_ny_disclosures_on_e_year", using: :btree
+  add_index "ny_disclosures", ["filer_id", "report_id", "transaction_id", "schedule_transaction_date", "e_year"], name: "big_idx", using: :btree
   add_index "ny_disclosures", ["filer_id", "report_id", "transaction_id", "schedule_transaction_date", "e_year"], name: "index_filer_report_trans_date_e_year", using: :btree
   add_index "ny_disclosures", ["filer_id"], name: "index_ny_disclosures_on_filer_id", using: :btree
   add_index "ny_disclosures", ["original_date"], name: "index_ny_disclosures_on_original_date", using: :btree
+
+  create_table "ny_disclosures_staging", force: :cascade do |t|
+    t.string   "filer_id",                  limit: 10,  null: false
+    t.string   "report_id",                 limit: 1,   null: false
+    t.string   "transaction_code",          limit: 1,   null: false
+    t.string   "e_year",                    limit: 4,   null: false
+    t.integer  "transaction_id",            limit: 8,   null: false
+    t.date     "schedule_transaction_date",             null: false
+    t.date     "original_date"
+    t.string   "contrib_code",              limit: 4
+    t.string   "contrib_type_code",         limit: 1
+    t.string   "corp_name",                 limit: 255
+    t.string   "first_name",                limit: 255
+    t.string   "mid_init",                  limit: 255
+    t.string   "last_name",                 limit: 255
+    t.string   "address",                   limit: 255
+    t.string   "city",                      limit: 255
+    t.string   "state",                     limit: 2
+    t.string   "zip",                       limit: 5
+    t.string   "check_number",              limit: 255
+    t.string   "check_date",                limit: 255
+    t.float    "amount1",                   limit: 24
+    t.float    "amount2",                   limit: 24
+    t.string   "description",               limit: 255
+    t.string   "other_recpt_code",          limit: 255
+    t.string   "purpose_code1",             limit: 255
+    t.string   "purpose_code2",             limit: 255
+    t.string   "explanation",               limit: 255
+    t.string   "transfer_type",             limit: 1
+    t.string   "bank_loan_check_box",       limit: 1
+    t.string   "crerec_uid",                limit: 255
+    t.datetime "crerec_date"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "ny_filer_entities", force: :cascade do |t|
     t.integer  "ny_filer_id",    limit: 4
@@ -1321,6 +1441,7 @@ ActiveRecord::Schema.define(version: 20170612172624) do
   add_index "relationship", ["entity1_id", "category_id"], name: "entity1_category_idx", using: :btree
   add_index "relationship", ["entity1_id", "entity2_id"], name: "entity_idx", using: :btree
   add_index "relationship", ["entity1_id"], name: "entity1_id_idx", using: :btree
+  add_index "relationship", ["entity2_id", "category_id", "amount"], name: "entity2_cat_amount", using: :btree
   add_index "relationship", ["entity2_id"], name: "entity2_id_idx", using: :btree
   add_index "relationship", ["is_deleted", "entity2_id", "category_id", "amount"], name: "index_relationship_is_d_e2_cat_amount", using: :btree
   add_index "relationship", ["last_user_id"], name: "last_user_id_idx", using: :btree
@@ -1619,8 +1740,8 @@ ActiveRecord::Schema.define(version: 20170612172624) do
   add_index "transaction", ["relationship_id"], name: "relationship_id_idx", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "", null: false
-    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "email",                  limit: 255, default: "",    null: false
+    t.string   "encrypted_password",     limit: 255, default: "",    null: false
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -1632,14 +1753,15 @@ ActiveRecord::Schema.define(version: 20170612172624) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "default_network_id",     limit: 4
-    t.integer  "sf_guard_user_id",       limit: 4,                null: false
-    t.string   "username",               limit: 255,              null: false
+    t.integer  "sf_guard_user_id",       limit: 4,                   null: false
+    t.string   "username",               limit: 255,                 null: false
     t.string   "remember_token",         limit: 255
     t.string   "confirmation_token",     limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.boolean  "newsletter"
     t.string   "chatid",                 limit: 255
+    t.boolean  "is_restricted",                      default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
@@ -1758,6 +1880,7 @@ ActiveRecord::Schema.define(version: 20170612172624) do
   add_foreign_key "sf_guard_user_group", "sf_guard_user", column: "user_id", name: "sf_guard_user_group_ibfk_1", on_delete: :cascade
   add_foreign_key "sf_guard_user_permission", "sf_guard_permission", column: "permission_id", name: "sf_guard_user_permission_ibfk_2", on_delete: :cascade
   add_foreign_key "sf_guard_user_permission", "sf_guard_user", column: "user_id", name: "sf_guard_user_permission_ibfk_1", on_delete: :cascade
+  add_foreign_key "sf_guard_user_profile", "sf_guard_user", column: "user_id", name: "sf_guard_user_profile_ibfk_1", on_update: :cascade, on_delete: :cascade
   add_foreign_key "social", "relationship", name: "social_ibfk_1", on_update: :cascade, on_delete: :cascade
   add_foreign_key "transaction", "entity", column: "contact1_id", name: "transaction_ibfk_3", on_update: :cascade, on_delete: :nullify
   add_foreign_key "transaction", "entity", column: "contact2_id", name: "transaction_ibfk_2", on_update: :cascade, on_delete: :nullify

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,7 @@ CREATE TABLE `alias` (
   KEY `name_idx` (`name`),
   CONSTRAINT `alias_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `alias_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=351 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -166,7 +166,7 @@ CREATE TABLE `api_tokens` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_api_tokens_on_token` (`token`),
   UNIQUE KEY `index_api_tokens_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -346,7 +346,7 @@ CREATE TABLE `business` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `business_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -382,7 +382,7 @@ CREATE TABLE `business_person` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `business_person_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -529,7 +529,7 @@ CREATE TABLE `delayed_jobs` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -563,7 +563,7 @@ CREATE TABLE `donation` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `donation_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `donation_ibfk_2` FOREIGN KEY (`bundler_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -584,7 +584,7 @@ CREATE TABLE `education` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `education_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `education_ibfk_2` FOREIGN KEY (`degree_id`) REFERENCES `degree` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -606,7 +606,7 @@ CREATE TABLE `elected_representative` (
   KEY `entity_id_idx` (`entity_id`),
   KEY `crp_id_idx` (`crp_id`),
   CONSTRAINT `elected_representative_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -670,7 +670,7 @@ CREATE TABLE `entity` (
   KEY `index_entity_on_delta` (`delta`),
   CONSTRAINT `entity_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `entity_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=20016 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -732,7 +732,7 @@ CREATE TABLE `extension_record` (
   CONSTRAINT `extension_record_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `extension_record_ibfk_2` FOREIGN KEY (`definition_id`) REFERENCES `extension_definition` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `extension_record_ibfk_3` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=206 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -884,7 +884,7 @@ CREATE TABLE `government_body` (
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `government_body_ibfk_1` FOREIGN KEY (`state_id`) REFERENCES `address_state` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `government_body_ibfk_2` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -902,7 +902,7 @@ CREATE TABLE `group_lists` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_group_lists_on_group_id_and_list_id` (`group_id`,`list_id`),
   KEY `index_group_lists_on_list_id` (`list_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -954,7 +954,7 @@ CREATE TABLE `groups` (
   UNIQUE KEY `index_groups_on_slug` (`slug`),
   KEY `index_groups_on_delta` (`delta`),
   KEY `index_groups_on_campaign_id` (`campaign_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1004,7 +1004,7 @@ CREATE TABLE `image` (
   KEY `index_image_on_address_id` (`address_id`),
   CONSTRAINT `image_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `image_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1067,7 +1067,7 @@ CREATE TABLE `link` (
   CONSTRAINT `link_ibfk_2` FOREIGN KEY (`entity2_id`) REFERENCES `entity` (`id`),
   CONSTRAINT `link_ibfk_3` FOREIGN KEY (`entity1_id`) REFERENCES `entity` (`id`),
   CONSTRAINT `link_ibfk_4` FOREIGN KEY (`category_id`) REFERENCES `relationship_category` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=195 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1221,6 +1221,7 @@ CREATE TABLE `ls_list` (
   `delta` tinyint(1) NOT NULL DEFAULT '1',
   `is_private` tinyint(1) DEFAULT '0',
   `creator_user_id` int(11) DEFAULT NULL,
+  `short_description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `last_user_id_idx` (`last_user_id`),
   KEY `featured_list_id` (`featured_list_id`),
@@ -1228,7 +1229,7 @@ CREATE TABLE `ls_list` (
   KEY `index_ls_list_on_name` (`name`),
   CONSTRAINT `ls_list_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `ls_list_ibfk_2` FOREIGN KEY (`featured_list_id`) REFERENCES `ls_list` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=84 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=139 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1258,7 +1259,7 @@ CREATE TABLE `ls_list_entity` (
   CONSTRAINT `ls_list_entity_ibfk_1` FOREIGN KEY (`list_id`) REFERENCES `ls_list` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `ls_list_entity_ibfk_2` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `ls_list_entity_ibfk_3` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=384 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1296,7 +1297,7 @@ CREATE TABLE `membership` (
   PRIMARY KEY (`id`),
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `membership_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1384,7 +1385,7 @@ CREATE TABLE `network_map` (
   PRIMARY KEY (`id`),
   KEY `user_id_idx` (`user_id`),
   KEY `index_network_map_on_delta` (`delta`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1580,7 +1581,7 @@ CREATE TABLE `ny_disclosures` (
   KEY `index_ny_disclosures_on_original_date` (`original_date`),
   KEY `index_ny_disclosures_on_delta` (`delta`),
   KEY `index_filer_report_trans_date_e_year` (`filer_id`,`report_id`,`transaction_id`,`schedule_transaction_date`,`e_year`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=29 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1625,7 +1626,7 @@ CREATE TABLE `ny_disclosures_staging` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1652,7 +1653,7 @@ CREATE TABLE `ny_filer_entities` (
   KEY `index_ny_filer_entities_on_is_committee` (`is_committee`),
   KEY `index_ny_filer_entities_on_cmte_entity_id` (`cmte_entity_id`),
   KEY `index_ny_filer_entities_on_filer_id` (`filer_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1682,7 +1683,7 @@ CREATE TABLE `ny_filers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_ny_filers_on_filer_id` (`filer_id`),
   KEY `index_ny_filers_on_filer_type` (`filer_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1706,7 +1707,7 @@ CREATE TABLE `ny_matches` (
   KEY `index_ny_matches_on_donor_id` (`donor_id`),
   KEY `index_ny_matches_on_recip_id` (`recip_id`),
   KEY `index_ny_matches_on_relationship_id` (`relationship_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1753,7 +1754,7 @@ CREATE TABLE `org` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `org_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=123 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1835,7 +1836,7 @@ CREATE TABLE `os_committees` (
   KEY `index_os_committees_on_cmte_id` (`cmte_id`),
   KEY `index_os_committees_on_recipid` (`recipid`),
   KEY `index_os_committees_on_cmte_id_and_cycle` (`cmte_id`,`cycle`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1894,7 +1895,7 @@ CREATE TABLE `os_donations` (
   KEY `index_os_donations_on_recipid` (`recipid`),
   KEY `index_os_donations_on_recipid_and_amount` (`recipid`,`amount`),
   KEY `index_os_donations_on_zip` (`zip`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=80 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2020,7 +2021,7 @@ CREATE TABLE `os_matches` (
   KEY `index_os_matches_on_cmte_id` (`cmte_id`),
   KEY `index_os_matches_on_relationship_id` (`relationship_id`),
   KEY `index_os_matches_on_reference_id` (`reference_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=32 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2058,7 +2059,7 @@ CREATE TABLE `pages` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_pages_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2091,7 +2092,7 @@ CREATE TABLE `person` (
   CONSTRAINT `person_ibfk_1` FOREIGN KEY (`party_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `person_ibfk_2` FOREIGN KEY (`gender_id`) REFERENCES `gender` (`id`),
   CONSTRAINT `person_ibfk_3` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=40 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2142,7 +2143,7 @@ CREATE TABLE `political_candidate` (
   KEY `house_fec_id_idx` (`house_fec_id`),
   KEY `crp_id_idx` (`crp_id`),
   CONSTRAINT `political_candidate_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2185,7 +2186,7 @@ CREATE TABLE `political_fundraising` (
   CONSTRAINT `political_fundraising_ibfk_1` FOREIGN KEY (`type_id`) REFERENCES `political_fundraising_type` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `political_fundraising_ibfk_2` FOREIGN KEY (`state_id`) REFERENCES `address_state` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `political_fundraising_ibfk_3` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2222,7 +2223,7 @@ CREATE TABLE `position` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `position_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `position_ibfk_2` FOREIGN KEY (`boss_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2256,7 +2257,7 @@ CREATE TABLE `public_company` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `public_company_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2307,7 +2308,7 @@ CREATE TABLE `reference` (
   KEY `object_idx` (`object_model`,`object_id`,`updated_at`),
   KEY `index_reference_on_object_model_and_object_id_and_ref_type` (`object_model`,`object_id`,`ref_type`),
   CONSTRAINT `reference_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=81 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2329,7 +2330,7 @@ CREATE TABLE `reference_excerpt` (
   KEY `last_user_id_idx` (`last_user_id`),
   CONSTRAINT `reference_excerpt_ibfk_1` FOREIGN KEY (`reference_id`) REFERENCES `reference` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `reference_excerpt_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2371,7 +2372,7 @@ CREATE TABLE `relationship` (
   CONSTRAINT `relationship_ibfk_2` FOREIGN KEY (`entity1_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `relationship_ibfk_3` FOREIGN KEY (`category_id`) REFERENCES `relationship_category` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `relationship_ibfk_4` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=101 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2489,7 +2490,7 @@ CREATE TABLE `school` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `school_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2653,7 +2654,7 @@ CREATE TABLE `sf_guard_user` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   KEY `is_active_idx_idx` (`is_active`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=340 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2739,7 +2740,7 @@ CREATE TABLE `sf_guard_user_profile` (
   UNIQUE KEY `unique_public_name_idx` (`public_name`),
   KEY `user_id_public_name_idx` (`user_id`,`public_name`),
   CONSTRAINT `sf_guard_user_profile_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `sf_guard_user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2846,7 +2847,7 @@ CREATE TABLE `toolkit_pages` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_toolkit_pages_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2975,13 +2976,14 @@ CREATE TABLE `users` (
   `confirmation_sent_at` datetime DEFAULT NULL,
   `newsletter` tinyint(1) DEFAULT NULL,
   `chatid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `is_restricted` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_sf_guard_user_id` (`sf_guard_user_id`),
   UNIQUE KEY `index_users_on_username` (`username`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
   UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=294 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3006,7 +3008,7 @@ CREATE TABLE `versions` (
   KEY `index_versions_on_item_type_and_item_id` (`item_type`,`item_id`),
   KEY `index_versions_on_entity1_id` (`entity1_id`),
   KEY `index_versions_on_entity2_id` (`entity2_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=42 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -3018,7 +3020,7 @@ CREATE TABLE `versions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-06-12 17:30:23
+-- Dump completed on 2017-07-06 14:30:49
 INSERT INTO schema_migrations (version) VALUES ('20131031182415');
 
 INSERT INTO schema_migrations (version) VALUES ('20131031182500');
@@ -3222,4 +3224,8 @@ INSERT INTO schema_migrations (version) VALUES ('20170508151516');
 INSERT INTO schema_migrations (version) VALUES ('20170612163321');
 
 INSERT INTO schema_migrations (version) VALUES ('20170612172624');
+
+INSERT INTO schema_migrations (version) VALUES ('20170626212039');
+
+INSERT INTO schema_migrations (version) VALUES ('20170706142752');
 

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -2,4 +2,5 @@ module Exceptions
   class PermissionError < StandardError; end
   class NotFoundError < StandardError; end
   class MissingApiTokenError < StandardError; end
+  class RestrictedUserError < StandardError; end
 end

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -173,12 +173,12 @@ describe EntitiesController, type: :controller do
         end
       end
     end
-    
+
     context 'user is not logged in' do
       it 'does not create a new entity' do
         expect { post :create, params_add_relationship_page }.not_to change { Entity.count }
       end
-      
+
       it 'redirects to login page' do
         post :create, params
         expect(response.location).to include 'login'
@@ -193,14 +193,26 @@ describe EntitiesController, type: :controller do
         expect { post :create, params }.not_to change { Entity.count }
       end
 
-           
       it 'returns http status 403' do
         post :create, params
         expect(response).to have_http_status 403
       end
     end
 
-  end  # end of create
+    context 'user is restricted' do
+      login_restricted_user
+
+      it 'does not create a new entity' do
+        expect { post :create, params }.not_to change { Entity.count }
+      end
+
+      it 'redirects to login page' do
+        post :create, params
+        expect(response).to have_http_status 302
+        expect(response.location).to include '/home/dashboard'
+      end
+    end
+  end # end of create
 
   describe 'Political' do
     before { @entity = create(:mega_corp_inc, updated_at: Time.now) }

--- a/spec/controllers/users_confirmations_controllers_spec.rb
+++ b/spec/controllers/users_confirmations_controllers_spec.rb
@@ -10,6 +10,7 @@ describe Users::ConfirmationsController, type: :controller do
     expect(NotificationMailer).to receive(:signup_email)
                             .with(user).and_return(double(:deliver_later => nil))
 
+    expect(user).to receive(:create_default_permissions).once
     expect(user).to receive(:delay).once.and_return(double(:create_chat_account => nil))
 
     get :show

--- a/spec/controllers/users_confirmations_controllers_spec.rb
+++ b/spec/controllers/users_confirmations_controllers_spec.rb
@@ -3,18 +3,31 @@ require 'rails_helper'
 describe Users::ConfirmationsController, type: :controller do
   before do
     request.env['devise.mapping'] = Devise.mappings[:user]
-    user = build(:user)
-    expect(User).to receive(:confirm_by_token).and_return(user)
+    @user = build(:user)
+    expect(User).to receive(:confirm_by_token).and_return(@user)
     expect(UserMailer).to receive(:welcome_email)
-                            .with(user).and_return(double(:deliver_later => nil))
+                            .with(@user).and_return(double(:deliver_later => nil))
     expect(NotificationMailer).to receive(:signup_email)
-                            .with(user).and_return(double(:deliver_later => nil))
-
-    expect(user).to receive(:create_default_permissions).once
-    expect(user).to receive(:delay).once.and_return(double(:create_chat_account => nil))
-
-    get :show
+                            .with(@user).and_return(double(:deliver_later => nil))
+    expect(@user).to receive(:create_default_permissions).once
   end
 
-  it { should respond_with(302) }
+  context 'request is not from a restricted ip' do
+    before do
+      expect(@user).not_to receive(:update)
+      expect(@user).to receive(:delay).once.and_return(double(:create_chat_account => nil))
+      get :show
+    end
+    it { should respond_with(302) }
+  end
+
+  context 'request is from a restricted ip' do
+    before do
+      expect(IpBlocker).to receive(:restricted?).with('0.0.0.0').and_return(true)
+      expect(@user).to receive(:update).with(is_restricted: true)
+      expect(@user).not_to receive(:delay)
+      get :show
+    end
+    it { should respond_with(302) }
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -6,37 +6,39 @@ describe UsersController, type: :controller do
 
   describe 'GET #index' do
     login_admin
-    before { get :index } 
+    before { get :index }
     it { should render_template('index') }
   end
-  
+
   describe 'GET #admin' do
-    context 'as an admin' do 
+    it { should route(:get, '/users/admin').to(action: :admin) }
+
+    context 'as an admin' do
       login_admin
       before { get :admin }
       it { should render_template('admin') }
     end
-    context 'as an regular user' do 
+    context 'as a regular user' do
       login_user
       before { get :admin }
       it { should respond_with(403) }
     end
   end
-  
-  describe 'GET #edit_permissions' do 
-    context 'as an admin' do 
+
+  describe 'GET #edit_permissions' do
+    context 'as an admin' do
       login_admin
-      before do 
+      before do
         expect(User).to receive(:find).with('1')
-        get :edit_permissions, :id => '1' 
+        get :edit_permissions, :id => '1'
       end
       it { should render_template 'edit_permissions' }
     end
   end
 
-  describe 'POST #add_permission' do 
+  describe 'POST #add_permission' do
     login_admin
-    before do 
+    before do
       expect(User).to receive(:find).with('1').and_return(double(:sf_guard_user_id => 2, :id => 1))
       expect(SfGuardUserPermission).to receive(:create!).with(permission_id: 5, user_id: 2)
       post :add_permission, :id => '1', :permission => '5'
@@ -44,9 +46,9 @@ describe UsersController, type: :controller do
     it { should redirect_to(edit_permissions_user_path) }
   end
 
-  describe 'DELETE #delete_permission' do 
+  describe 'DELETE #delete_permission' do
     login_admin
-    before do 
+    before do
       expect(User).to receive(:find).with('1').and_return(double(:sf_guard_user_id => 2, :id => 1))
       expect(SfGuardUserPermission).to receive(:remove_permission).with(permission_id: 5, user_id: 2)
       delete :delete_permission, :id => '1', :permission => '5'
@@ -54,19 +56,23 @@ describe UsersController, type: :controller do
     it { should redirect_to(edit_permissions_user_path) }
   end
 
-  describe 'DELETE #destory' do 
+  describe 'POST #restrict' do
+    login_admin
+    it { should route(:post, '/users/123/restrict').to(action: :restrict, id: '123') }
+  end
 
+  describe 'DELETE #destory' do
     # describe 'logged in as regular user' do 
     #   login_user
     #   before { delete :destroy, :id => '1234' }
     #   it { should respond_with(403) }
     # end
     
-    describe 'logged in as admin' do 
+    describe 'logged in as admin' do
       login_admin
 
-      context 'Deleting a user' do 
-        before(:each) do 
+      context 'Deleting a user' do
+        before(:each) do
           @sf_user = create(:sf_guard_user, is_deleted: false, username: "user#{rand(1000)}")
           @user = create(:user, sf_guard_user_id: @sf_user.id, email: "user#{rand(1000)}@email.com" , username: "user#{rand(1000)}")
           SfGuardUserPermission.create!(permission_id: 3, user_id: @sf_user.id)
@@ -84,46 +90,44 @@ describe UsersController, type: :controller do
           expect(SfGuardUser.unscoped.find(@sf_user.id).is_deleted).to be true
         end
         
-        it 'updates last_user_id on entities' do 
+        it 'updates last_user_id on entities' do
           expect(Entity.find(@entity.id).last_user_id).to eql @sf_user.id
           delete :destroy, :id => @user.id
           expect(Entity.find(@entity.id).last_user_id).to eql 1
         end
 
-        it 'updates last_user_id on relationships' do 
+        it 'updates last_user_id on relationships' do
           expect(Relationship).to receive(:where).with(last_user_id: @sf_user.id).and_return(double(:update_all => nil))
           delete :destroy, :id => @user.id
         end
 
-        it 'destroys user' do 
+        it 'destroys user' do
           expect { delete :destroy, :id => @user.id }.to change { User.count }.by(-1)
         end
 
-        context 'afterwards' do 
+        context 'afterwards' do
           before { delete :destroy, :id => @user.id  }
           it { should redirect_to(admin_users_path) }
         end
       end
       
       context 'Trying to delete an admin' do
-        before do 
+        before do
           @sf_user = create(:sf_guard_user, is_deleted: false, username: "user#{rand(1000)}")
           @user = create(:user, sf_guard_user_id: @sf_user.id, email: "user#{rand(1000)}@email.com" , username: "user#{rand(1000)}")
           SfGuardUserPermission.create!(permission_id: 1, user_id: @sf_user.id)
         end
-        
-        it 'does not delete user' do 
+
+        it 'does not delete user' do
           expect { delete :destroy, :id => @user.id }.not_to change { User.count }
-        end 
-        
-        context 'afterwards' do 
-          before { delete :destroy, :id => @user.id  }
-          it { should redirect_to(admin_users_path) }
         end
 
+        context 'afterwards' do
+          before { delete :destroy, :id => @user.id }
+          it { should redirect_to(admin_users_path) }
+        end
       end
 
     end
   end
-  
 end

--- a/spec/factories/sf_guard_user_profile.rb
+++ b/spec/factories/sf_guard_user_profile.rb
@@ -3,10 +3,11 @@ FactoryGirl.define do
   factory :sf_guard_user_profile, class: SfGuardUserProfile do
     name_first 'first'
     name_last 'last'
+    is_confirmed true
     sequence(:public_name) { |n| "user_#{n}" }
     home_network_id 79
     sequence(:email) { |n| "user_#{n}@littlesis.org" }
     reason 'research'
   end
-  
+
 end

--- a/spec/factories/sf_guard_user_profile.rb
+++ b/spec/factories/sf_guard_user_profile.rb
@@ -3,9 +3,9 @@ FactoryGirl.define do
   factory :sf_guard_user_profile, class: SfGuardUserProfile do
     name_first 'first'
     name_last 'last'
-    public_name 'public_name'
+    sequence(:public_name) { |n| "user_#{n}" }
     home_network_id 79
-    email 'fake_email@fake_email.com'
+    sequence(:email) { |n| "user_#{n}@littlesis.org" }
     reason 'research'
   end
   

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
   end
 
   factory :sf_user, class: SfGuardUser do
-    # id 100
+    is_active true
     username { generate(:sf_user_name) }
   end
 

--- a/spec/features/users_admin_spec.rb
+++ b/spec/features/users_admin_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe "Users Admin Page", :type => :feature do
+  before(:all) { login_as(create_admin_user, :scope => :user) }
+  after(:all) { logout(:user) }
+
+  it 'displays the index page' do
+    visit '/users/admin'
+    expect(page).to have_selector("table.table")
+  end
+
+  # context 'user is restricted' do
+  #     before do
+  #       @user = build(:user, is_restricted: true)
+  #     end
+
+  #     it 'removes restriction from user' do
+  #       expect { post :restrict, action: 'PERMIT', id: 123 }.not_to change { @user.is_restricted }
+  #     end
+  #   end
+end

--- a/spec/features/users_admin_spec.rb
+++ b/spec/features/users_admin_spec.rb
@@ -45,4 +45,3 @@ describe "Users Admin Page", :type => :feature do
     expect(page).to have_selector 'div.alert', count: 1
   end
 end
-

--- a/spec/features/users_admin_spec.rb
+++ b/spec/features/users_admin_spec.rb
@@ -1,21 +1,48 @@
 require 'rails_helper'
 
 describe "Users Admin Page", :type => :feature do
-  before(:all) { login_as(create_admin_user, :scope => :user) }
-  after(:all) { logout(:user) }
-
-  it 'displays the index page' do
-    visit '/users/admin'
-    expect(page).to have_selector("table.table")
+  before(:all) do
+    @admin = create_admin_user
+    @restricted_user = create_user_with_sf(username: 'restricted', is_restricted: true)
+    @not_restricted_user = create_user_with_sf(username: 'not_restricted', is_restricted: false)
   end
 
-  # context 'user is restricted' do
-  #     before do
-  #       @user = build(:user, is_restricted: true)
-  #     end
+  before(:each) do
+    # see: https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara
+    login_as(@admin, :scope => :user)
+    visit '/users/admin'
+  end
 
-  #     it 'removes restriction from user' do
-  #       expect { post :restrict, action: 'PERMIT', id: 123 }.not_to change { @user.is_restricted }
-  #     end
-  #   end
+  after(:each) { logout(:user) }
+
+  it 'displays the index page' do
+    expect(page).to have_selector "table.table"
+    expect(page).to have_selector "table.table tbody tr", count: 3
+    expect(page).not_to have_selector 'div.alert'
+  end
+
+  it 'has one PERMIT form for restircted user' do
+    expect(page).to have_selector 'button', text: 'Remove restriction', count: 1
+  end
+
+  it 'has one RESTRICT form for the not_restircted user' do
+    expect(page).to have_selector 'button', text: 'Restrict this user', count: 1
+  end
+
+  it 'will allow restriction to be removed' do
+    expect(User.find(@restricted_user.id).restricted?).to be true
+    page.find("form#restrict_#{@restricted_user.id} button").click
+    expect(User.find(@restricted_user.id).restricted?).to be false
+    expect(page).to have_selector 'button', text: 'Restrict this user', count: 2
+    expect(page).to have_selector 'div.alert', count: 1
+  end
+
+  it 'will restriction to be added' do
+    expect(User.find(@not_restricted_user.id).restricted?).to be false
+    page.find("form#restrict_#{@not_restricted_user.id} button").click
+    expect(User.find(@not_restricted_user.id).restricted?).to be true
+    expect(page).to have_selector 'button', text: 'Remove restriction', count: 2
+    expect(page).to have_selector 'div.alert', count: 1
+  end
 end
+

--- a/spec/features/users_admin_spec.rb
+++ b/spec/features/users_admin_spec.rb
@@ -21,7 +21,7 @@ describe "Users Admin Page", :type => :feature do
     expect(page).not_to have_selector 'div.alert'
   end
 
-  it 'has one PERMIT form for restircted user' do
+  it 'has one PERMIT form for the restircted user' do
     expect(page).to have_selector 'button', text: 'Remove restriction', count: 1
   end
 
@@ -37,7 +37,7 @@ describe "Users Admin Page", :type => :feature do
     expect(page).to have_selector 'div.alert', count: 1
   end
 
-  it 'will restriction to be added' do
+  it 'will allow restriction to be added' do
     expect(User.find(@not_restricted_user.id).restricted?).to be false
     page.find("form#restrict_#{@not_restricted_user.id} button").click
     expect(User.find(@not_restricted_user.id).restricted?).to be true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -157,4 +157,14 @@ describe User do
       end
     end
   end
+
+  describe '#restricted?' do
+    it 'returns true for restircted user' do
+      expect(build(:user, is_restricted: true).restricted?).to be true
+    end
+
+    it 'returns false for unrestircted user' do
+      expect(build(:user, is_restricted: false).restricted?).to be false
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
+
 require 'devise'
 require 'paper_trail/frameworks/rspec'
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -36,7 +37,8 @@ RSpec.configure do |config|
   # devise helpers
   config.include Devise::Test::ControllerHelpers, :type => :controller
   config.include Devise::Test::ControllerHelpers, :type => :view
-  
+  config.include Warden::Test::Helpers
+
   config.extend ControllerMacros, :type => :controller
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,4 +99,6 @@ RSpec.configure do |config|
 
   config.include RSpecHtmlMatchers
 
+  Capybara.ignore_hidden_elements = false
+
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -38,4 +38,13 @@ module ControllerMacros
       sign_in user
     end
   end
+
+  def login_user_without_permissions
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      sf_user = FactoryGirl.create(:sf_guard_user)
+      user = FactoryGirl.create(:user, sf_guard_user_id: sf_user.id)
+      sign_in user
+    end
+  end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -39,6 +39,18 @@ module ControllerMacros
     end
   end
 
+
+  def login_restricted_user
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      sf_user = FactoryGirl.create(:sf_guard_user)
+      user = FactoryGirl.create(:user, sf_guard_user_id: sf_user.id, is_restricted: true)
+      SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+      SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+      sign_in user
+    end
+  end  
+
   def login_user_without_permissions
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -23,7 +23,7 @@ end
 
 
 def create_admin_user
-  sf_user = FactoryGirl.create(:sf_guard_user)
+  sf_user = FactoryGirl.create(:sf_guard_user, sf_guard_user_profile: build(:sf_guard_user_profile))
   user = FactoryGirl.create(:user, sf_guard_user_id: sf_user.id)
   SfGuardUserPermission.create!(permission_id: 1, user_id: sf_user.id)
   SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -56,6 +56,14 @@ def create_basic_user
   user
 end
 
+def create_restricted_user
+  sf_user = FactoryGirl.create(:sf_guard_user)
+  user = FactoryGirl.create(:user, sf_guard_user_id: sf_user.id, is_restricted: true)
+  SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+  user
+end
+
 def create_user_with_sf(attrs = {})
   sf_user = FactoryGirl.create(:sf_user)
   FactoryGirl.create(:sf_guard_user_profile, user_id: sf_user.id)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -55,3 +55,9 @@ def create_basic_user
   SfGuardUserPermission.create!(permission_id: 5, user_id: sf_user.id)
   user
 end
+
+def create_user_with_sf(attrs = {})
+  sf_user = FactoryGirl.create(:sf_user)
+  FactoryGirl.create(:sf_guard_user_profile, user_id: sf_user.id)
+  FactoryGirl.create(:user, attrs.merge(sf_guard_user: sf_user))
+end

--- a/spec/utility/ip_blocker_spec.rb
+++ b/spec/utility/ip_blocker_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe IpBlocker do
+
+  def reload_mod
+    # Removes the module from object-space:
+    Object.send(:remove_const, :IpBlocker) if Module.const_defined?(:IpBlocker)
+    # Reloads the module
+    load Rails.root.join('app', 'utility', 'ip_blocker.rb')
+  end
+  
+  context 'blacklist file is missing' do
+    before do
+      expect(File).to receive(:exist?)
+                        .with(Rails.root.join('config', 'blacklist.yml')).and_return(false)
+      reload_mod
+    end
+
+    it 'defines .blocked? and always returns false' do
+      expect(IpBlocker.blocked?('10.10.10.10')).to eq false
+    end
+  end
+
+  context 'blacklist file exists' do
+    before do
+      expect(File).to receive(:exist?)
+                        .with(Rails.root.join('config', 'blacklist.yml')).and_return(true)
+
+      expect(YAML).to receive(:load).and_return(['fake', '192.0.2.0/24'])
+
+      reload_mod
+    end
+    
+    it 'rejects invalid ip addresses from file' do
+      expect(IpBlocker::IPS.length).to eq 1
+      expect(IpBlocker::IPS[0]).to eq IPAddr.new('192.0.2.0/24')
+    end
+
+    it 'blocked? return true if ip address is in list' do
+      
+    end
+
+    it 'blocked? return false if ip address is not inlist' do
+      
+    end
+  end
+      
+
+  
+end

--- a/spec/utility/ip_blocker_spec.rb
+++ b/spec/utility/ip_blocker_spec.rb
@@ -19,30 +19,30 @@ describe IpBlocker do
     end
   end
 
-  context 'restricted_ips contains two ip ranges' do
+  context 'restricted_ips contain two ip ranges' do
     before do
       expect(APP_CONFIG).to receive(:[]).twice.with('restricted_ips')
                               .and_return(['192.0.2.0/24','192.0.3.0/24'])
       reload_mod
     end
-    
+
     it 'returns true if given ip is in restricted range' do
       expect(IpBlocker.restricted?('192.0.2.1')).to be true
     end
 
-    it 'returns fasle for non-restricted ips' do
+    it 'returns false for non-restricted ips' do
       expect(IpBlocker.restricted?('10.11.12.13')).to be false
     end
   end
 
-  context 'list of registristed ips contain invalid ip' do
+  context 'list of restricted ips contain invalid addresses' do
     before do
       expect(APP_CONFIG).to receive(:[]).twice.with('restricted_ips')
                               .and_return(['192.0.2.0/24','FAKE'])
       reload_mod
     end
 
-    it 'remove invalid ip addresses form list' do
+    it 'removes the invalid ip addresses from the list' do
       expect(IpBlocker::IPS.length).to eq 1
       expect(IpBlocker::IPS[0]).to eq IPAddr.new('192.0.2.0/24')
     end

--- a/spec/views/home/flag.html.erb_spec.rb
+++ b/spec/views/home/flag.html.erb_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 describe 'home/flag.html.erb', type: :view do
+  before(:all) { Capybara.ignore_hidden_elements = true }
+  after(:all) { Capybara.ignore_hidden_elements = false }
+  
   context 'when referrer is missing' do
     before do
       assign(:referrer, nil)


### PR DESCRIPTION
Allows users to be set to 'restricted' via the /users/admin page.

Being *restricted* allows you to access the site, but you cannot do anything that requires permissions. This is essentially the same as being a user without any permissions.

Adds a new configuration "restricted_ips" -- a list of ip addresses (or ranges), where if a user signs up from one of those addresses it automatically makes their account restricted. 

resolves #192 
