### PR TITLE
Deleting Things

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -70,6 +70,10 @@ class EntitiesController < ApplicationController
     end
   end
 
+  def destroy
+    
+  end
+
   def relationships
   end
 

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -157,8 +157,8 @@ class ListsController < ApplicationController
   def remove_entity
     check_permission 'admin'
     ListEntity.find(params[:list_entity_id]).destroy
-    @list.clear_cache(request.host)
-    redirect_to members_list_path(@list)        
+    @list.clear_cache
+    redirect_to members_list_path(@list)
   end
 
   def clear_cache

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,6 +1,7 @@
 class RelationshipsController < ApplicationController
-  before_action :set_relationship, only: [:show, :edit, :update, :reverse_direction]
+  before_action :set_relationship, only: [:show, :edit, :update, :destroy, :reverse_direction]
   before_action :authenticate_user!, except: [:show]
+  before_action -> { check_permission('deleter') }, only: [:destroy]
 
   def show
   end
@@ -50,6 +51,11 @@ class RelationshipsController < ApplicationController
       }
       render json: errors, status: :bad_request
     end
+  end
+
+  def destroy
+    @relationship.soft_delete
+    redirect_to home_dashboard_path, notice: 'Relationship successfully deleted'
   end
 
   # POST /relationships/:id/reverse_direction

--- a/app/models/concerns/soft_delete.rb
+++ b/app/models/concerns/soft_delete.rb
@@ -20,7 +20,7 @@ module SoftDelete
   end
 
   def soft_delete
-    self.class.transaction do  
+    self.class.transaction do
       update(is_deleted: true)
       after_soft_delete
     end

--- a/app/models/concerns/soft_delete.rb
+++ b/app/models/concerns/soft_delete.rb
@@ -2,7 +2,7 @@ require 'active_support/concern'
 
 module SoftDelete
   extend ActiveSupport::Concern
-
+  
   included do
     default_scope -> { where(is_deleted: false) }
     scope :active, -> { where(is_deleted: false) }
@@ -20,12 +20,22 @@ module SoftDelete
   end
 
   def soft_delete
-    self.class.transaction do
-      update(is_deleted: true)
-      after_soft_delete
+    set_paper_trail_event do
+      self.class.transaction do
+        update(is_deleted: true)
+        after_soft_delete
+      end
     end
   end
 
   def after_soft_delete
+  end
+
+  private
+
+  def set_paper_trail_event
+    self.paper_trail_event = 'soft_delete' if respond_to?(:paper_trail_event)
+    yield
+    self.paper_trail_event = nil if respond_to?(:paper_trail_event)
   end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -3,4 +3,6 @@ class Donation < ActiveRecord::Base
 
   belongs_to :relationship, inverse_of: :donation
   has_many :os_matches, inverse_of: :donation
+
+  has_paper_trail on: [:update, :destroy]
 end

--- a/app/models/education.rb
+++ b/app/models/education.rb
@@ -4,5 +4,8 @@ class Education < ActiveRecord::Base
   belongs_to :relationship, inverse_of: :education
   belongs_to :degree
 
+  has_paper_trail on: [:update, :destroy]
+
+
   SELECT_OPTIONS = ['Undergraduate', 'Graduate', 'High School'].freeze
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -742,7 +742,7 @@ class Entity < ActiveRecord::Base
     extension_models.each(&:destroy)
     extension_records.destroy_all
     images.each(&:soft_delete)
-    # ListEntity
+    list_entities.each(&:soft_delete)
     # ArticleEntity
   end
 

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -724,6 +724,7 @@ class Entity < ActiveRecord::Base
     aliases.destroy_all
     extension_models.each(&:destroy)
     primary_extension_model.destroy
+    images.each(&:soft_delete)
   end
 
   # A type checker for definition id and names

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -143,15 +143,19 @@ class Entity < ActiveRecord::Base
     extensions_with_attributes.values.reduce(:merge)
   end
 
+  # Returns an array of all extension models
+  def extension_models
+    (extension_names & Entity.all_extension_names_with_fields).map do |name|
+      name.constantize.find_by_entity_id(id)
+    end
+  end
+
   # Returns a hash where the key in each key/value pair is the extension name
   # and the value is a hash of the attributes for that extension
   def extensions_with_attributes
-    hash = {}
-    (extension_names & Entity.all_extension_names_with_fields).each do |name|
-      ext = name.constantize.find_by_entity_id(id)
-      hash[name] = ext.attributes.except('id', 'entity_id', :id, :entity_id)
+    extension_models.reduce({}) do |memo, model|
+      memo.merge(model.class.name => model.attributes.except('id', 'entity_id') )
     end
-    hash
   end
 
   def extension_ids
@@ -710,6 +714,10 @@ class Entity < ActiveRecord::Base
   end
 
   private
+
+  def after_soft_delete
+    
+  end
 
   # A type checker for definition id and names
   # input: String or Integer

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -133,6 +133,11 @@ class Entity < ActiveRecord::Base
     person? ? 'Org' : 'Person'
   end
 
+  def primary_extension_model
+    return person if person?
+    return org if org?
+  end
+
   def all_attributes
     attributes.merge!(extension_attributes).reject { |k,v| v.nil? }
   end
@@ -717,6 +722,8 @@ class Entity < ActiveRecord::Base
 
   def after_soft_delete
     aliases.destroy_all
+    extension_models.each(&:destroy)
+    primary_extension_model.destroy
   end
 
   # A type checker for definition id and names

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -716,7 +716,7 @@ class Entity < ActiveRecord::Base
   private
 
   def after_soft_delete
-    
+    aliases.destroy_all
   end
 
   # A type checker for definition id and names

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -720,12 +720,24 @@ class Entity < ActiveRecord::Base
 
   private
 
+  # Callbacks for Soft Delete
   def after_soft_delete
     aliases.destroy_all
     extension_models.each(&:destroy)
-    primary_extension_model.destroy
     images.each(&:soft_delete)
+    # ListEntity
   end
+
+  # When an entity is deleted we will store information
+  # from it's associated models that gets deleted
+  # in a 'meta' field with the PaperTrail version
+  # def set_entity_meta
+  #   @association_data = {
+  #     extension_ids: extension_ids,
+  #     aliases: aliases.where(is_primary: false).map(&:name),
+  #   }
+    # paper_trail.on_destroy
+  #end
 
   # A type checker for definition id and names
   # input: String or Integer

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1,5 +1,6 @@
 class Family < ActiveRecord::Base
   include SingularTable
 
+  has_paper_trail on: [:update, :destroy]
   belongs_to :relationship, inverse_of: :family
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -2,7 +2,6 @@ class List < ActiveRecord::Base
   self.table_name = "ls_list"
 
   include SoftDelete
-  include Cacheable
   include Referenceable
 
   has_paper_trail
@@ -111,6 +110,14 @@ class List < ActiveRecord::Base
     end
 
     query
+  end
+
+  # The host argument is there for compatibility reasons:
+  # the symfony/legacy caching system required it.
+  # In Rails, all we need to do to clear the cache
+  # is change the updated_at timestamp
+  def clear_cache(host = nil)
+    touch
   end
 
   def self.default_network

--- a/app/models/list_entity.rb
+++ b/app/models/list_entity.rb
@@ -10,4 +10,10 @@ class ListEntity < ActiveRecord::Base
     soft_delete
   end
 
+  private
+
+  def after_soft_delete
+    list.touch
+  end
+
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,5 +1,6 @@
 class Membership < ActiveRecord::Base
   include SingularTable
 
+  has_paper_trail on: [:update, :destroy]
   belongs_to :relationship, inverse_of: :membership
 end

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -2,4 +2,6 @@ class Ownership < ActiveRecord::Base
   include SingularTable
 
   belongs_to :relationship, inverse_of: :ownership
+
+  has_paper_trail on: [:update, :destroy]
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -1,5 +1,7 @@
 class Position < ActiveRecord::Base
   include SingularTable
   
+  has_paper_trail on: [:update, :destroy]
+  
   belongs_to :relationship, inverse_of: :position
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -67,6 +67,10 @@ class Relationship < ActiveRecord::Base
   # associated entities for the relationship
   after_save :update_entity_timestamps
   
+  ##############
+  # CATEGORIES #
+  ##############
+
   def create_category
     self.class.all_categories[category_id].constantize.create(relationship: self) if self.class.all_category_ids_with_fields.include?(category_id)
   end 
@@ -156,6 +160,20 @@ class Relationship < ActiveRecord::Base
     hash
   end
 
+  #####################
+
+  ## callbacks for soft_delete
+  def after_soft_delete
+    links.destroy_all
+    position&.destroy! if is_position?
+    education&.destroy! if is_education?
+    membership&.destroy! if is_member?
+    family&.destroy! if is_family?
+    donation&.destroy! if is_donation?
+    trans&.destroy! if is_transaction?
+    ownership&.destroy! if is_ownership?
+  end
+ 
   def legacy_url(action=nil)
     self.class.legacy_url(id, action)
   end
@@ -207,6 +225,7 @@ class Relationship < ActiveRecord::Base
   def source_links
     Reference.where(object_id: self.id, object_model: "Relationship")
   end
+
 
   #############
   #   LINKS   #

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,4 +2,6 @@ class Transaction < ActiveRecord::Base
   include SingularTable
 
   belongs_to :relationship, inverse_of: :trans
+
+  has_paper_trail on: [:update, :destroy]
 end

--- a/app/views/lists/companies.html.erb
+++ b/app/views/lists/companies.html.erb
@@ -5,6 +5,6 @@
 
 <%= render partial: "lists/interlocks_alert" %>
 
-<% cache(@list.cache_key('companies', nil, { page: @page }), expires_in: 1.day) do %>
+<% cache( [@list.cache_key, 'companies', @page ], expires_in: 1.day) do %>
   <%= render partial: "lists/companies", locals: { companies: @companies } %>
 <% end %>

--- a/app/views/lists/funding.html.erb
+++ b/app/views/lists/funding.html.erb
@@ -5,7 +5,7 @@
 
 <%= render partial: "lists/interlocks_alert" %>
 
-<% cache(@list.cache_key('funding', nil, { page: @page }), expires_in: 1.day) do %>
+<% cache( [ @list.cache_key, 'funding', @page ], expires_in: 1.day) do %>
 
   <% if @donors.count > 0 %>
   <h3>Common Donors</h3>

--- a/app/views/lists/giving.html.erb
+++ b/app/views/lists/giving.html.erb
@@ -5,7 +5,7 @@
 
 <%= render partial: "lists/interlocks_alert" %>
 
-<% cache(@list.cache_key('giving', nil, { page: @page }), expires_in: 1.day) do %>
+<% cache( [ @list.cache_key, 'giving', @page ], expires_in: 1.day) do %>
 
   <% if @recipients.count > 0 %>
   <h3>Common Recipients</h3>

--- a/app/views/lists/government.html.erb
+++ b/app/views/lists/government.html.erb
@@ -5,6 +5,6 @@
 
 <%= render partial: "lists/interlocks_alert" %>
 
-<% cache(@list.cache_key('government', nil, { page: @page }), expires_in: 1.day) do %>
+<% cache([@list.cache_key, 'government', @page], expires_in: 1.day) do %>
   <%= render partial: "lists/government", locals: { govt_bodies: @govt_bodies } %>
 <% end %>

--- a/app/views/lists/interlocks.html.erb
+++ b/app/views/lists/interlocks.html.erb
@@ -5,7 +5,7 @@
 
 <%= render partial: "lists/interlocks_alert" %>
 
-<% cache(@list.cache_key('interlocks'), expires_in: 1.day) do %>
+<% cache( [@list.cache_key, 'interlocks' ], expires_in: 1.day) do %>
   <%= render partial: "lists/companies", locals: { companies: @companies, preview: true } %>
   <%= render partial: "lists/government", locals: { govt_bodies: @govt_bodies, preview: true } %>
   <%= render partial: "lists/other_orgs", locals: { others: @others, preview: true } %>

--- a/app/views/lists/members.html.erb
+++ b/app/views/lists/members.html.erb
@@ -14,8 +14,8 @@
 
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :members } %>
 
-<% cache(@list.cache_key('members', nil, { editable: @editable, admin: @admin }), expires_in: 1.day) do %>
-  <%= render partial: 'datatable', locals: { table: @table, editable: @editable, admin: @admin } %>
+<% cache( [@list.cache_key, 'members'], expires_in: 1.day) do %>
+    <%= render partial: 'datatable', locals: { table: @table, editable: @editable, admin: @admin } %>
 <% end %>
 
 <%= render partial: 'shared/add_entity_js', locals: { input_id: 'add-entity-input', post_path: add_entity_list_path(@list, entity_id: "XXX"), query_path: raw(name_search_entities_url + "?q=%QUERY&exclude_list=#{@list.id}") } %>

--- a/app/views/lists/other_orgs.html.erb
+++ b/app/views/lists/other_orgs.html.erb
@@ -5,6 +5,6 @@
 
 <%= render partial: "lists/interlocks_alert" %>
 
-<% cache(@list.cache_key('other_orgs', nil, { page: @page }), expires_in: 1.day) do %>
+<% cache( [ @list.cache_key, 'other_orgs', @page] , expires_in: 1.day) do %>
   <%= render partial: "lists/other_orgs", locals: { others: @others } %>
 <% end %>

--- a/app/views/relationships/_actions.html.erb
+++ b/app/views/relationships/_actions.html.erb
@@ -5,18 +5,20 @@
 	<% end %>
 	<%= link_to "flag", "/home/contact?type=flag" %>
 	<% if signed_in and @current_user.has_legacy_permission 'deleter' %>
-            <%=  link_to "remove", @relationship.legacy_url('remove'), id: 'remove-relationship' %>
+	    
+	    <%= form_tag relationship_path(@relationship), method: :delete, id: 'remove-relationship-form', style: "display: none;" do %>
+	    <% end %>
+            
+	    <%= link_to "remove", "#", id: 'remove-relationship' %>
             <%= javascript_tag do %>
              $('#remove-relationship').click(function(e){
                e.preventDefault();
-               if (confirm('Are you sure you want to remove this relationship?')) { 
-                 var f = document.createElement('form'); 
-                 document.body.appendChild(f);
-                 f.method = 'POST';
-                 f.action = this.href;
-                 f.submit();
-               }
-             });
+	
+               if (confirm('Are you sure you want to remove this relationship?')) {
+		 document.getElementById('remove-relationship-form').submit();
+	       }
+	       
+	     });
             <% end %>
 	<% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,7 +232,7 @@ Lilsis::Application.routes.draw do
   post '/relationships/bulk_add' => 'relationships#bulk_add'
   get '/relationships/find_similar' => 'relationships#find_similar'
 
-  resources :relationships, only: [:show, :create, :update, :edit] do
+  resources :relationships, except: [:index, :new] do
     member do
       post 'reverse_direction'
     end

--- a/db/migrate/20170719172615_add_association_data_to_versions.rb
+++ b/db/migrate/20170719172615_add_association_data_to_versions.rb
@@ -1,0 +1,7 @@
+class AddAssociationDataToVersions < ActiveRecord::Migration
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :association_data, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706142752) do
+ActiveRecord::Schema.define(version: 20170719172615) do
 
   create_table "address", force: :cascade do |t|
     t.integer  "entity_id",    limit: 8,                   null: false
@@ -1771,15 +1771,16 @@ ActiveRecord::Schema.define(version: 20170706142752) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",      limit: 255,        null: false
-    t.integer  "item_id",        limit: 4,          null: false
-    t.string   "event",          limit: 255,        null: false
-    t.string   "whodunnit",      limit: 255
-    t.text     "object",         limit: 65535
+    t.string   "item_type",        limit: 255,        null: false
+    t.integer  "item_id",          limit: 4,          null: false
+    t.string   "event",            limit: 255,        null: false
+    t.string   "whodunnit",        limit: 255
+    t.text     "object",           limit: 65535
     t.datetime "created_at"
-    t.text     "object_changes", limit: 4294967295
-    t.integer  "entity1_id",     limit: 4
-    t.integer  "entity2_id",     limit: 4
+    t.text     "object_changes",   limit: 4294967295
+    t.integer  "entity1_id",       limit: 4
+    t.integer  "entity2_id",       limit: 4
+    t.text     "association_data", limit: 4294967295
   end
 
   add_index "versions", ["entity1_id"], name: "index_versions_on_entity1_id", using: :btree

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,7 @@ CREATE TABLE `alias` (
   KEY `name_idx` (`name`),
   CONSTRAINT `alias_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `alias_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=351 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -166,7 +166,7 @@ CREATE TABLE `api_tokens` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_api_tokens_on_token` (`token`),
   UNIQUE KEY `index_api_tokens_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -346,7 +346,7 @@ CREATE TABLE `business` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `business_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -382,7 +382,7 @@ CREATE TABLE `business_person` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `business_person_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -529,7 +529,7 @@ CREATE TABLE `delayed_jobs` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -563,7 +563,7 @@ CREATE TABLE `donation` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `donation_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `donation_ibfk_2` FOREIGN KEY (`bundler_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -584,7 +584,7 @@ CREATE TABLE `education` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `education_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `education_ibfk_2` FOREIGN KEY (`degree_id`) REFERENCES `degree` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -606,7 +606,7 @@ CREATE TABLE `elected_representative` (
   KEY `entity_id_idx` (`entity_id`),
   KEY `crp_id_idx` (`crp_id`),
   CONSTRAINT `elected_representative_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -670,7 +670,7 @@ CREATE TABLE `entity` (
   KEY `index_entity_on_delta` (`delta`),
   CONSTRAINT `entity_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `entity_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=20016 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=106 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -732,7 +732,7 @@ CREATE TABLE `extension_record` (
   CONSTRAINT `extension_record_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `extension_record_ibfk_2` FOREIGN KEY (`definition_id`) REFERENCES `extension_definition` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `extension_record_ibfk_3` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=206 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -884,7 +884,7 @@ CREATE TABLE `government_body` (
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `government_body_ibfk_1` FOREIGN KEY (`state_id`) REFERENCES `address_state` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `government_body_ibfk_2` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -902,7 +902,7 @@ CREATE TABLE `group_lists` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_group_lists_on_group_id_and_list_id` (`group_id`,`list_id`),
   KEY `index_group_lists_on_list_id` (`list_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -954,7 +954,7 @@ CREATE TABLE `groups` (
   UNIQUE KEY `index_groups_on_slug` (`slug`),
   KEY `index_groups_on_delta` (`delta`),
   KEY `index_groups_on_campaign_id` (`campaign_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1067,7 +1067,7 @@ CREATE TABLE `link` (
   CONSTRAINT `link_ibfk_2` FOREIGN KEY (`entity2_id`) REFERENCES `entity` (`id`),
   CONSTRAINT `link_ibfk_3` FOREIGN KEY (`entity1_id`) REFERENCES `entity` (`id`),
   CONSTRAINT `link_ibfk_4` FOREIGN KEY (`category_id`) REFERENCES `relationship_category` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=195 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1229,7 +1229,7 @@ CREATE TABLE `ls_list` (
   KEY `index_ls_list_on_name` (`name`),
   CONSTRAINT `ls_list_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `ls_list_ibfk_2` FOREIGN KEY (`featured_list_id`) REFERENCES `ls_list` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=139 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=84 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1259,7 +1259,7 @@ CREATE TABLE `ls_list_entity` (
   CONSTRAINT `ls_list_entity_ibfk_1` FOREIGN KEY (`list_id`) REFERENCES `ls_list` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `ls_list_entity_ibfk_2` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `ls_list_entity_ibfk_3` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=384 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1297,7 +1297,7 @@ CREATE TABLE `membership` (
   PRIMARY KEY (`id`),
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `membership_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1385,7 +1385,7 @@ CREATE TABLE `network_map` (
   PRIMARY KEY (`id`),
   KEY `user_id_idx` (`user_id`),
   KEY `index_network_map_on_delta` (`delta`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1581,7 +1581,7 @@ CREATE TABLE `ny_disclosures` (
   KEY `index_ny_disclosures_on_original_date` (`original_date`),
   KEY `index_ny_disclosures_on_delta` (`delta`),
   KEY `index_filer_report_trans_date_e_year` (`filer_id`,`report_id`,`transaction_id`,`schedule_transaction_date`,`e_year`)
-) ENGINE=InnoDB AUTO_INCREMENT=29 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1626,7 +1626,7 @@ CREATE TABLE `ny_disclosures_staging` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1653,7 +1653,7 @@ CREATE TABLE `ny_filer_entities` (
   KEY `index_ny_filer_entities_on_is_committee` (`is_committee`),
   KEY `index_ny_filer_entities_on_cmte_entity_id` (`cmte_entity_id`),
   KEY `index_ny_filer_entities_on_filer_id` (`filer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1683,7 +1683,7 @@ CREATE TABLE `ny_filers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_ny_filers_on_filer_id` (`filer_id`),
   KEY `index_ny_filers_on_filer_type` (`filer_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1707,7 +1707,7 @@ CREATE TABLE `ny_matches` (
   KEY `index_ny_matches_on_donor_id` (`donor_id`),
   KEY `index_ny_matches_on_recip_id` (`recip_id`),
   KEY `index_ny_matches_on_relationship_id` (`relationship_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1754,7 +1754,7 @@ CREATE TABLE `org` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `org_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=123 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1836,7 +1836,7 @@ CREATE TABLE `os_committees` (
   KEY `index_os_committees_on_cmte_id` (`cmte_id`),
   KEY `index_os_committees_on_recipid` (`recipid`),
   KEY `index_os_committees_on_cmte_id_and_cycle` (`cmte_id`,`cycle`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1895,7 +1895,7 @@ CREATE TABLE `os_donations` (
   KEY `index_os_donations_on_recipid` (`recipid`),
   KEY `index_os_donations_on_recipid_and_amount` (`recipid`,`amount`),
   KEY `index_os_donations_on_zip` (`zip`)
-) ENGINE=InnoDB AUTO_INCREMENT=80 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2021,7 +2021,7 @@ CREATE TABLE `os_matches` (
   KEY `index_os_matches_on_cmte_id` (`cmte_id`),
   KEY `index_os_matches_on_relationship_id` (`relationship_id`),
   KEY `index_os_matches_on_reference_id` (`reference_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=32 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2059,7 +2059,7 @@ CREATE TABLE `pages` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_pages_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2092,7 +2092,7 @@ CREATE TABLE `person` (
   CONSTRAINT `person_ibfk_1` FOREIGN KEY (`party_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `person_ibfk_2` FOREIGN KEY (`gender_id`) REFERENCES `gender` (`id`),
   CONSTRAINT `person_ibfk_3` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=40 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2143,7 +2143,7 @@ CREATE TABLE `political_candidate` (
   KEY `house_fec_id_idx` (`house_fec_id`),
   KEY `crp_id_idx` (`crp_id`),
   CONSTRAINT `political_candidate_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2186,7 +2186,7 @@ CREATE TABLE `political_fundraising` (
   CONSTRAINT `political_fundraising_ibfk_1` FOREIGN KEY (`type_id`) REFERENCES `political_fundraising_type` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `political_fundraising_ibfk_2` FOREIGN KEY (`state_id`) REFERENCES `address_state` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `political_fundraising_ibfk_3` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2223,7 +2223,7 @@ CREATE TABLE `position` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `position_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `position_ibfk_2` FOREIGN KEY (`boss_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2257,7 +2257,7 @@ CREATE TABLE `public_company` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `public_company_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2308,7 +2308,7 @@ CREATE TABLE `reference` (
   KEY `object_idx` (`object_model`,`object_id`,`updated_at`),
   KEY `index_reference_on_object_model_and_object_id_and_ref_type` (`object_model`,`object_id`,`ref_type`),
   CONSTRAINT `reference_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=81 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2330,7 +2330,7 @@ CREATE TABLE `reference_excerpt` (
   KEY `last_user_id_idx` (`last_user_id`),
   CONSTRAINT `reference_excerpt_ibfk_1` FOREIGN KEY (`reference_id`) REFERENCES `reference` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `reference_excerpt_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2372,7 +2372,7 @@ CREATE TABLE `relationship` (
   CONSTRAINT `relationship_ibfk_2` FOREIGN KEY (`entity1_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `relationship_ibfk_3` FOREIGN KEY (`category_id`) REFERENCES `relationship_category` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `relationship_ibfk_4` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=101 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2490,7 +2490,7 @@ CREATE TABLE `school` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `school_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2529,7 +2529,7 @@ CREATE TABLE `sessions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sessions_on_session_id` (`session_id`),
   KEY `index_sessions_on_updated_at` (`updated_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2654,7 +2654,7 @@ CREATE TABLE `sf_guard_user` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   KEY `is_active_idx_idx` (`is_active`)
-) ENGINE=InnoDB AUTO_INCREMENT=346 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2740,7 +2740,7 @@ CREATE TABLE `sf_guard_user_profile` (
   UNIQUE KEY `unique_public_name_idx` (`public_name`),
   KEY `user_id_public_name_idx` (`user_id`,`public_name`),
   CONSTRAINT `sf_guard_user_profile_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `sf_guard_user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2847,7 +2847,7 @@ CREATE TABLE `toolkit_pages` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_toolkit_pages_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2983,7 +2983,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_username` (`username`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
   UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=300 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3004,11 +3004,12 @@ CREATE TABLE `versions` (
   `object_changes` longtext,
   `entity1_id` int(11) DEFAULT NULL,
   `entity2_id` int(11) DEFAULT NULL,
+  `association_data` longtext,
   PRIMARY KEY (`id`),
   KEY `index_versions_on_item_type_and_item_id` (`item_type`,`item_id`),
   KEY `index_versions_on_entity1_id` (`entity1_id`),
   KEY `index_versions_on_entity2_id` (`entity2_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=42 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -3020,7 +3021,7 @@ CREATE TABLE `versions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-07-06 20:10:03
+-- Dump completed on 2017-07-19 17:32:48
 INSERT INTO schema_migrations (version) VALUES ('20131031182415');
 
 INSERT INTO schema_migrations (version) VALUES ('20131031182500');
@@ -3228,4 +3229,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170612172624');
 INSERT INTO schema_migrations (version) VALUES ('20170626212039');
 
 INSERT INTO schema_migrations (version) VALUES ('20170706142752');
+
+INSERT INTO schema_migrations (version) VALUES ('20170719172615');
 

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -16,6 +16,7 @@ describe EntitiesController, type: :controller do
     it { should route(:post, '/entities').to(action: :create) }
     it { should route(:get, '/entities/1/edit').to(action: :edit, id: 1) }
     it { should route(:patch, '/entities/1').to(action: :update, id: 1) }
+    it { should route(:delete, '/entities/1').to(action: :destroy, id: 1) }
     it { should route(:get, '/entities/1/political').to(action: :political, id: 1) }
     it { should route(:get, '/entities/1/references').to(action: :references, id: 1) }
     it { should route(:get, '/entities/1/match_donations').to(action: :match_donations, id: 1) }
@@ -141,7 +142,7 @@ describe EntitiesController, type: :controller do
         end
       end
 
-      context 'from the /entiites/id/add_relationship page' do
+      context 'from the /entities/id/add_relationship page' do
         context 'without errors' do
           it 'should create a new entity' do
             expect { post :create, params_add_relationship_page }.to change { Entity.count }.by(1)

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -182,7 +182,7 @@ describe ListsController, type: :controller do
       @list = create(:list)
       @list.update_column(:updated_at, 1.day.ago)
       @person = create(:person)
-      @list_entity = create(:list_entity, list_id: @list.id, entity_id: @person.id)
+      @list_entity = ListEntity.create!(list_id: @list.id, entity_id: @person.id)
     end
 
     before do

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -180,6 +180,7 @@ describe ListsController, type: :controller do
     login_admin
     before(:all) do
       @list = create(:list)
+      @list.update_column(:updated_at, 1.day.ago)
       @person = create(:person)
       @list_entity = create(:list_entity, list_id: @list.id, entity_id: @person.id)
     end
@@ -196,6 +197,12 @@ describe ListsController, type: :controller do
       expect(List).to receive(:find).with(@list.id.to_s).and_return(@list)
       expect(@list).to receive(:clear_cache)
       @post_remove_entity.call
+    end
+
+    it 'updates the updated_at of the list' do
+      expect(&@post_remove_entity).to change {
+        List.find(@list.id).updated_at
+      }
     end
 
     it 'redirects to the members page' do

--- a/spec/controllers/relationships_controller_spec.rb
+++ b/spec/controllers/relationships_controller_spec.rb
@@ -20,6 +20,7 @@ describe RelationshipsController, type: :controller do
   it { should route(:get, '/relationships/1/edit').to(action: :edit, id: 1) }
   it { should route(:post, '/relationships/1/reverse_direction').to(action: :reverse_direction, id: 1) }
   it { should route(:patch, '/relationships/1').to(action: :update, id: 1) }
+  it { should route(:delete, '/relationships/1').to(action: :destroy, id: 1) }
   it { should route(:post, '/relationships/bulk_add').to(action: :bulk_add) }
   it { should route(:get, '/relationships/find_similar').to(action: :find_similar) }
 
@@ -184,6 +185,20 @@ describe RelationshipsController, type: :controller do
       end
     end
   end # end describe POST #create
+
+  describe 'DELETE /relationship/id' do
+    login_user
+    
+    it 'destroys relationship and redirects to dashboard' do
+      @rel = build :relationship
+      expect(Relationship).to receive(:find).with('1').and_return(@rel)
+      expect(@rel).to receive(:soft_delete).once
+      delete :destroy, { id: '1' }
+      expect(response).to have_http_status 302
+      expect(response.location).to include '/home/dashboard'
+    end
+    
+  end
 
   describe 'GET /relationships/id/edit' do
     login_user

--- a/spec/factories/entities.rb
+++ b/spec/factories/entities.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   sequence :entity_id do |n|
-    n
+    n + 100
   end
 
   factory :org, class: Entity do

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
   factory :image, class: Image do
     sequence(:id)
     is_featured false
+    is_deleted false
     entity_id { generate(:image_entity_id) }
     filename { generate(:filename) }
     title "title"

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  sequence :image_entity_id do |n|
+    n
+  end
+
+  sequence :filename do |n|
+    "image#{n}.png"
+  end
+
+  factory :image, class: Image do
+    sequence(:id)
+    is_featured false
+    entity_id { generate(:image_entity_id) }
+    filename { generate(:filename) }
+    title "title"
+  end
+end

--- a/spec/factories/list.rb
+++ b/spec/factories/list.rb
@@ -19,16 +19,11 @@ FactoryGirl.define do
     is_network false
   end
 
-  factory :image, class: Image do
-    filename 'image.jpg'
-    title '#corporateSelfie'
-  end
-
   factory :group, class: Group do
     name 'a team'
     slug '/'
   end
-  
+
   factory :note, class: Note do
     user_id 1
     body 'why is EVERYTHING connected?'

--- a/spec/factories/list.rb
+++ b/spec/factories/list.rb
@@ -1,15 +1,4 @@
 FactoryGirl.define do
-  factory :sf_user_two, class: SfGuardUser do
-    id 2
-    username 'sfusertwo'
-  end
-
-  factory :user_two, class: User do
-    id 2
-    username 'usertwo'
-    sf_guard_user_id 2
-  end
-
   factory :list, class: List do
     name "Fortune 1000 Companies"
     description "Fortune Magazine's list..."
@@ -17,6 +6,13 @@ FactoryGirl.define do
     is_admin false
     is_featured false
     is_network false
+  end
+
+  factory :list_entity, class: ListEntity do
+    sequence(:id)
+    sequence(:list_id)
+    sequence(:entity_id)
+    is_deleted false
   end
 
   factory :group, class: Group do

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   sequence :relationship_id do |n|
-    n
+    n + 100
   end
 
   factory :relationship_with_house, class: Relationship do

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -50,16 +50,19 @@ describe Entity do
   end
 
   describe '#soft_delete' do
-    
+
     it 'sets is_deleted to be true' do
       org = create(:org)
       expect(org.is_deleted).to be false
       org.soft_delete
       expect(org.is_deleted).to be true
     end
-    
+
     it 'deletes aliases' do
-      
+      org = create(:org)
+      a = org.aliases.create!(name: 'my other org name')
+      expect { org.soft_delete }.to change { Alias.count }.by(-1)
+      expect(Alias.find_by_id(a.id)).to be nil
     end
 
   end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -50,7 +50,6 @@ describe Entity do
   end
 
   describe '#soft_delete' do
-
     it 'sets is_deleted to be true' do
       org = create(:org)
       expect(org.is_deleted).to be false
@@ -61,10 +60,9 @@ describe Entity do
     it 'deletes aliases' do
       org = create(:org)
       a = org.aliases.create!(name: 'my other org name')
-      expect { org.soft_delete }.to change { Alias.count }.by(-1)
+      expect { org.soft_delete }.to change { Alias.count }.by(-2)
       expect(Alias.find_by_id(a.id)).to be nil
     end
-
   end
 
   describe 'summary_excerpt' do

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -141,9 +141,6 @@ describe Entity do
     end
   end
 
-  describe 'store meta information after entity soft_delete' do
-  end
-
   describe 'summary_excerpt' do
     it 'returns nil if there is no summary' do
       mega_corp = build(:mega_corp_inc, summary: nil)

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -49,6 +49,21 @@ describe Entity do
     end
   end
 
+  describe '#soft_delete' do
+    
+    it 'sets is_deleted to be true' do
+      org = create(:org)
+      expect(org.is_deleted).to be false
+      org.soft_delete
+      expect(org.is_deleted).to be true
+    end
+    
+    it 'deletes aliases' do
+      
+    end
+
+  end
+
   describe 'summary_excerpt' do
     it 'returns nil if there is no summary' do
       mega_corp = build(:mega_corp_inc, summary: nil)
@@ -216,6 +231,24 @@ describe Entity do
         expect(school.extensions_with_attributes.key?('Org')).to be true
         expect(school.extensions_with_attributes.length).to eql 2
       end
+    end
+
+    describe '#extension_models' do
+      before(:all) do
+        @person = create(:person)
+        @person.add_extension('Lawyer')
+        @person.add_extension('PoliticalCandidate')
+      end
+ 
+     it 'returns array' do
+       expect(@person.extension_models).to be_a Array
+       expect(@person.extension_models.length).to eq 2
+     end
+
+     it 'has Org and PoliticalCandidate models' do
+       expect(@person.extension_models[0]).to be_a Person
+       expect(@person.extension_models[1]).to be_a PoliticalCandidate
+     end
     end
 
     describe '#extension_names' do

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -94,6 +94,14 @@ describe Entity do
       expect { org.soft_delete }.to change { ExtensionRecord.count }.by(-1)
     end
 
+    it 'soft deletes list entities (including removing from network)' do
+      org = create(:org)
+      list = create(:list)
+      list_entity = ListEntity.create!(list_id: list.id, entity_id: org.id)
+      expect { org.soft_delete }.to change { ListEntity.count }.by(-2)
+      expect(ListEntity.find_by_id(list_entity.id)).to be nil
+    end
+
     describe 'soft delete versioning' do
       with_versioning do
         before { @org = create(:org) }

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -68,7 +68,12 @@ describe Entity do
       person.add_extension('BusinessPerson', sec_cik: 987)
       expect { person.soft_delete }.to change { BusinessPerson.count }.by(-1)
     end
-    
+
+    it 'soft deletes associated images' do
+      org = create(:org)
+      image = create(:image, entity: org)
+      expect { org.soft_delete }.to change { Image.unscoped.find(image.id).is_deleted }.to(true)
+    end
   end
 
   describe 'summary_excerpt' do

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Image, type: :model do
+
+  describe 'validations' do
+    it { should validate_presence_of(:entity_id) }
+    it { should validate_presence_of(:filename) }
+    it { should validate_presence_of(:title) }
+  end
+
+  describe 'soft_delete' do
+    it 'changes is_deleted' do
+      image = create(:image, entity: create(:org))
+      expect { image.soft_delete }.to change { image.is_deleted }.to(true)
+    end
+  end
+end

--- a/spec/models/list_entity_spec.rb
+++ b/spec/models/list_entity_spec.rb
@@ -2,39 +2,14 @@ require 'rails_helper'
 
 describe ListEntity do  
 
-
-  describe ('creating list entries') do 
-
-    it 'retrieves all List Entities for a list_id' do 
-      
+  describe 'soft delete' do
+    it 'changes the list\'s updated at field after being deleted' do
       list = create(:list)
-      inc = create(:mega_corp_inc)
-      llc = create(:mega_corp_llc)
-      inc_entity = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
-      ListEntity.find_or_create_by(list_id: list.id, entity_id: llc.id)
-      inc_entity.destroy
-      expect(ListEntity.where(list_id: list.id).count).to eq (1)
-      expect(ListEntity.unscoped.where(list_id: list.id).count).to eq(2)
-    end
-    
-    context 'after destroying a list entity' do 
-      it  're-adding the same one creates a new entry' do
-        list_entity_count = ListEntity.count
-        list = create(:list)
-        inc = create(:mega_corp_inc)
-        
-        le = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
-        expect(ListEntity.count).to eql (list_entity_count + 2)
-        expect(ListEntity.unscoped.count).to eql (list_entity_count + 2)
-        le.destroy
-        expect(ListEntity.count).to eql(list_entity_count + 1)
-        expect(ListEntity.unscoped.count).to eql (list_entity_count + 2)
-        expect(ListEntity.unscoped.deleted.last).to eql(le)
-        le2 = ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
-        expect(ListEntity.count).to eql (list_entity_count + 2)
-        expect(ListEntity.unscoped.count).to eql (list_entity_count + 3)
-        expect(le.id).not_to eq(le2.id)
-      end
+      corp = create(:mega_corp_inc)
+      le = ListEntity.create!(list_id: list.id, entity_id: corp.id)
+      list.update_column(:updated_at, 1.day.ago)
+      expect { le.soft_delete }.to change { list.reload.updated_at }
     end
   end
+
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -131,17 +131,16 @@ describe List do
 
   context 'Using paper_trail for versioning' do
     with_versioning do
-      it 'records created, modified, and deleted versions' do 
+      it 'records created, modified, and deleted versions' do
         l = create(:list)
-        expect(l.versions.size).to eq(1)
+        expect(l.versions.size).to eq 1
         l.name = "change the name name!"
         l.save
-        expect(l.versions.size).to eq(2)
-        expect(l.versions.last.event).to eq('update')
+        expect(l.versions.size).to eq 2
+        expect(l.versions.last.event).to eq 'update'
         l.destroy
-        expect(l.versions.size).to eq(3)
-        # this is 'update' and not destroy because the implementation of soft delete
-        expect(l.versions.last.event).to eq('update')
+        expect(l.versions.size).to eq 3
+        expect(l.versions.last.event).to eq 'soft_delete'
       end
     end
   end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -36,8 +36,7 @@ describe List do
       inc = create(:mega_corp_inc)
       create(:image, entity_id: inc.id)
       ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
-      expect(list.images.count).to eq (1)
-      expect(list.images.first.filename).to eql ('image.jpg')
+      expect(list.images.count).to eq 1
     end
 
     it 'has groups' do 

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -496,6 +496,69 @@ describe Relationship, type: :model do
     end
   end
 
+  describe 'Deleting' do
+    let(:rel) { create(:generic_relationship, entity1_id: create(:person).id, entity2_id: create(:person).id) }
+
+    it 'soft_delete set is_deleted to be true' do
+      @rel = rel
+      expect(@rel.is_deleted).to be false
+      @rel.soft_delete
+      expect(@rel.is_deleted).to be true
+    end
+    
+    it 'soft_delete removes links' do
+      @rel = rel
+      expect { @rel.soft_delete }.to change { Link.count }.by(-2)
+    end
+
+    context 'removing associated category models' do
+      before(:all) do
+        @person = create(:person)
+        @org = create(:org)
+      end
+      
+      it 'removes position model' do
+        rel = create(:position_relationship, entity1_id: @person.id, entity2_id: @org.id)
+        expect { rel.soft_delete }.to change { Position.count }.by(-1)
+      end
+      
+      it 'removes education model' do
+        rel = Relationship.create!(category_id: 2, entity1_id: @person.id, entity2_id: create(:org).id)
+        expect { rel.soft_delete }.to change { Education.count }.by(-1)
+      end
+
+      it 'removes membership model' do
+        rel = Relationship.create!(category_id: 3, entity1_id: @person.id, entity2_id: @org.id)
+        expect { rel.soft_delete }.to change { Membership.count }.by(-1)
+      end
+
+      it 'removes family model' do
+        rel = Relationship.create!(category_id: 4, entity1_id: @person.id, entity2_id: create(:person).id)
+        expect { rel.soft_delete }.to change { Family.count }.by(-1)
+      end
+
+      it 'removes donation model' do
+        rel = Relationship.create!(category_id: 5, entity1_id: @person.id, entity2_id: @org.id)
+        expect { rel.soft_delete }.to change { Donation.count }.by(-1)
+      end
+
+      it 'removes transation model' do
+        rel = Relationship.create!(category_id: 6, entity1_id: @person.id, entity2_id: @org.id)
+        expect { rel.soft_delete }.to change { Transaction.count }.by(-1)
+      end
+
+      it 'removes ownership model' do
+        rel = Relationship.create!(category_id: 10, entity1_id: @person.id, entity2_id: @org.id)
+        expect { rel.soft_delete }.to change { Ownership.count }.by(-1)
+      end
+
+      it 'does nothing if deleting a generic relationship' do
+        rel = Relationship.create!(category_id: 12, entity1_id: @person.id, entity2_id: @org.id)
+        expect { rel.soft_delete }.not_to change { Position.count }
+      end
+    end
+  end
+
   context 'Using paper_trail for versioning' do
     with_versioning do
       before do

--- a/spec/views/relationships/show.html.erb_spec.rb
+++ b/spec/views/relationships/show.html.erb_spec.rb
@@ -54,7 +54,7 @@ describe 'relationships/show.html.erb', type: :view do
 
     it 'has modal and form' do
       css '#add-reference-modal'
-      css 'form', :count => 1
+      css 'form#reference-form', :count => 1
     end
 
     it 'has hidden inputs' do


### PR DESCRIPTION
- Tracks changes to relationship types with PaperTrail
- fix relationship links bug: delete relationship types and links after soft delete
- move the remove relationship post request to rails
- delete or soft delete associated models after an entity is soft deleted
- add new meta data field to Versions -- association_data -- which stores yaml version of selected entity association data (eventually this will be used to allow an entity to be easily restored)
- add custom paper trail event -- soft_delete
- remove legacy caching from lists