### PR TITLE
[#235] Show tags on list page

### DIFF
--- a/app/assets/stylesheets/styles/lists.scss
+++ b/app/assets/stylesheets/styles/lists.scss
@@ -22,10 +22,20 @@ td.lists_table_name {
 	box-decoration-break: clone;
 	-webkit-box-decoration-break: clone;
     }
-    
+
     a:hover {
 	text-decoration: none;
     }
+
+    .list-tags-container {
+	display: inline;
+	position: relative;
+	bottom: 0.4em;
+	ul {
+	    display: inline;
+	}
+    }
+
 }
 
 #list-description {

--- a/app/assets/stylesheets/styles/lists.scss
+++ b/app/assets/stylesheets/styles/lists.scss
@@ -11,13 +11,21 @@ td.lists_table_name {
 }
 
 #list-name {
-  font-size: 42px; 
-  line-height: 60px;
-  font-weight: 500;
-
-  a:hover {
-    text-decoration: none;
-  }
+    .multiline-text { }
+    .multiline-text a {
+	font-size: 42px;
+     	line-height: 1.2;
+    	font-weight: 500;
+    	display: inline;
+	padding: 0.45rem;
+	/* Needs prefixing */
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+    }
+    
+    a:hover {
+	text-decoration: none;
+    }
 }
 
 #list-description {

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -4,6 +4,17 @@ module ListsHelper
     link_to(name, members_list_path(list))
   end
 
+  def tags_on_right?(tags)
+    tags.count > 2
+  end
+
+  # For lists with less than 2 tags
+  # they will appear appended to the list name.
+  # Otherwise, they go in their own column on the right.
+  def list_name_class(tags)
+    tags_on_right?(tags) ? "col-sm-8 col-md-9" : "col-sm-12"
+  end
+
   def network_link(list)
     link_to(list.name, list.legacy_network_url)
   end

--- a/app/views/lists/_header.html.erb
+++ b/app/views/lists/_header.html.erb
@@ -1,7 +1,22 @@
 <div id="list-header">
-  <div id="list-name"><%= list_link(list) %></div>
-  <div id="list-description"><%= list.short_description %></div>
-  <div id="list-long-description"><%= list.description %></div>
+    <div id="list-name" class="row">
+	<div class="<%= list_name_class(list.tags) %>">
+	    <span class="multiline-text">
+		<%= list_link(list) %>
+	    </span>
+	    <% if list.tags.present? && !tags_on_right?(list.tags) %>
+		<%= render partial: 'lists/tags', locals: { tags: list.tags } %>
+	    <% end %>
+	</div>
+	<% if tags_on_right?(list.tags) %>
+	    <div class="col-sm-4 col-md-3">
+		<%= render partial: 'lists/tags', locals: { tags: list.tags, include_title: true } %>
+	    </div>
+	<% end %>
+    </div>
+    
+    <div id="list-description"><%= list.short_description %></div>
+    <div id="list-long-description"><%= list.description %></div>
 </div>
 
 <% if list.default_topic.present? %>

--- a/app/views/lists/_header.html.erb
+++ b/app/views/lists/_header.html.erb
@@ -4,19 +4,23 @@
 	    <span class="multiline-text">
 		<%= list_link(list) %>
 	    </span>
+
 	    <% if list.tags.present? && !tags_on_right?(list.tags) %>
 		<%= render partial: 'lists/tags', locals: { tags: list.tags } %>
 	    <% end %>
+
+	    <div id="list-description"><%= list.short_description %></div>
+	    <div id="list-long-description"><%= list.description %></div>
+
 	</div>
+
 	<% if tags_on_right?(list.tags) %>
 	    <div class="col-sm-4 col-md-3">
 		<%= render partial: 'lists/tags', locals: { tags: list.tags, include_title: true } %>
 	    </div>
 	<% end %>
+
     </div>
-    
-    <div id="list-description"><%= list.short_description %></div>
-    <div id="list-long-description"><%= list.description %></div>
 </div>
 
 <% if list.default_topic.present? %>

--- a/app/views/lists/_tags.html.erb
+++ b/app/views/lists/_tags.html.erb
@@ -1,0 +1,11 @@
+<% include_title = false if local_assigns[:include_title].nil? %>
+<div id="list-tags-container" class="list-tags-container">
+    <% if include_title %>
+	<h4 class="thin-grey-bottom-border">Tags</h4>
+    <% end %>
+    <ul id="tags-list">
+	<% tags.each do |t| %>
+	    <li class="tag"><%= t[:name] %></li>
+	<% end %>
+    </ul>
+</div>

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,7 +17,15 @@ describe Tag do
     }
   end
 
-  let(:tags) { [oil, nyc] }
+  let(:finance) do
+    {
+      'name' => 'finance',
+      'description' => 'banks and such',
+      'id' => 3
+    }
+  end
+
+  let(:tags) { [oil, nyc, finance] }
   let(:invalid_tags) { tags.dup.tap { |t| t[1]['id'] = 1 } }
 
   it "returns all tags" do
@@ -48,7 +56,9 @@ describe Tag do
                1 => oil,
                'oil' => oil,
                2 => nyc,
-               'nyc' => nyc
+               'nyc' => nyc,
+               3 => finance,
+               'finance' => finance
              })
   end
 

--- a/spec/testdata/tags.yml
+++ b/spec/testdata/tags.yml
@@ -7,3 +7,7 @@
   name: nyc
   description: "anything related to New York City"
   id: 2
+-
+  name: finance
+  description: "banks and such"
+  id: 3

--- a/spec/views/lists/_header.html.erb_spec.rb
+++ b/spec/views/lists/_header.html.erb_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'partial: lists/header', type: :view do
+  let(:tags) { [] }
+  let(:list) do
+    list = build(:list)
+    allow(list).to receive(:tags).and_return(tags)
+    list
+  end
+
+  before(:each) do
+    render partial: 'lists/header.html.erb', locals: { list: list }
+  end
+
+  context 'list has no tags' do
+    it 'does not show the tags component' do
+      expect(view).not_to render_template(:partial => "lists/_tags")
+    end
+
+    it 'does not have the tags column wrapper' do
+      not_css 'div.col-sm-4'
+    end
+  end
+
+  context 'list has 1 tag' do
+    let(:tags) { Tag.all.take(1) }
+
+    it 'renders tag partial without the title ' do
+      expect(view).to render_template(:partial => "lists/_tags", :locals => { tags: tags })
+      not_css 'h4'
+    end
+
+    it 'shows tags on same row with title' do
+      css '#list-name div.col-sm-12'
+      not_css '#list-name div.col-sm-8'
+    end
+  end
+
+  context 'list has 3 tag' do
+    let(:tags) { Tag.all.take(3) }
+
+    it 'renders template lists/tags with the title' do
+      expect(view).to render_template(:partial => "lists/_tags",
+                                      :locals => { tags: tags, include_title: true })
+      css 'h4', text: 'Tags'
+    end
+
+    it 'shows tags on same row with title' do
+      not_css '#list-name div.col-sm-12'
+      css '#list-name div.col-sm-8'
+    end
+  end
+end


### PR DESCRIPTION
There are two different layouts depending on the number of tags. For lists
with 2 or fewer tags, they will appear in line with the list
title. For lists with more than 2 tags, they will appear in their own
column to the right of tags.

resolves #235 