### PR TITLE
[#278] remove /press from navbar

### DIFF
--- a/app/views/shared/_bootstrap_nav_menu.html.erb
+++ b/app/views/shared/_bootstrap_nav_menu.html.erb
@@ -73,7 +73,6 @@ items['About'] = {
     Features: "/features",
     'Our Team' => "/team",
     Blog: "https://news.littlesis.org",
-    Press: "/press",
     'Data API' => "/api",
     'Source Code' => "https://github.com/public-accountability/littlesis-rails",
     Disclaimer: "/disclaimer",


### PR DESCRIPTION
fixes #278 