### PR TITLE
[#272] Add list access rules guidance to edit list page

### DIFF
--- a/app/assets/stylesheets/styles/lists.scss
+++ b/app/assets/stylesheets/styles/lists.scss
@@ -91,3 +91,9 @@ td.lists_table_name {
     margin-top: 1em;
     margin-bottom: 2em;
 }
+
+
+.list-access-level-help {
+    margin-top: 25px;
+    color: rgba(0,0,0,.8);
+}

--- a/app/views/lists/_settings.html.erb
+++ b/app/views/lists/_settings.html.erb
@@ -3,6 +3,9 @@
    $("#" + access + "-radio").trigger('click');
    $("#list-config-access-buttons button").removeClass('btn-primary');
    $("#" + access + "-button").addClass('btn-primary');
+
+   $('.list-access-level-help').hide();
+   $("#list-access-level-help-" + access).show();
  }
 
  $(function(){
@@ -23,7 +26,7 @@
 </script>
 
 <div class="row">
-  <div class="col-sm-10 col-md-8">
+  <div class="col-sm-4 col-md-3">
     <%= label_tag 'Access level' %> <br/>
 
     <div id="list-config-access-buttons" class="btn-group m-bottom-1em" role="group" aria-label="...">
@@ -31,11 +34,23 @@
       <button type="button" id="closed-button" class="btn btn-default" onclick="handleRadioClick('closed')">Closed</button>
       <button type="button" id="private-button" class="btn btn-default" onclick="handleRadioClick('private')">Private</button>
     </div>
+  
+    
+    <%= f.radio_button :access, 0, class: 'btn btn-default', id: 'open-radio', style: "display: none" %>
+    <%= f.radio_button :access, 1, class: 'btn btn-default', id: 'closed-radio', style: "display: none"  %>
+    <%= f.radio_button :access, 2, class: 'btn btn-default', id: 'private-radio', style: "display: none"  %>
   </div>
-
-  <%= f.radio_button :access, 0, class: 'btn btn-default', id: 'open-radio', style: "display: none" %>
-  <%= f.radio_button :access, 1, class: 'btn btn-default', id: 'closed-radio', style: "display: none"  %>
-  <%= f.radio_button :access, 2, class: 'btn btn-default', id: 'private-radio', style: "display: none"  %>
+  <div class="col-sm-4 col-md-4">
+      <div class="list-access-level-help" id="list-access-level-help-open" style="display: none;">
+	  An <b>open list</b> is visible by everyone and can be edited by any LittleSis user who is allowed to modify lists.
+      </div>
+      <div class="list-access-level-help" id="list-access-level-help-closed" style="display: none;">
+	  A <b>closed list</b> is visible by everyone, but it can only be edited you.
+      </div>
+      <div class="list-access-level-help" id="list-access-level-help-private" style="display: none;">
+	  A <b>private list</b> can only be seen and edited by you.
+      </div>
+  </div>
 </div>
 
 <div class="row form-group">


### PR DESCRIPTION
This is _exactly_ a popover but I think it gets the point across:

![list_access_help](https://user-images.githubusercontent.com/8505044/30133587-6909c074-9322-11e7-9cb0-86e5a6822594.gif)


resolves #272 