### PR TITLE
[#293] Replace math problem with recaptcha on /join

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,3 +105,6 @@ gem 'mongo'
 
 # used by Pages and Toolkit for Markdown->Html
 gem 'redcarpet', '>= 3.4.0'
+
+# google's recaptcha
+gem "recaptcha", require: "recaptcha/rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,8 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
+    recaptcha (4.4.0)
+      json
     redcarpet (3.4.0)
     redis (3.3.1)
     redis-actionpack (5.0.0)
@@ -456,6 +458,7 @@ DEPENDENCIES
   pry-rails
   rack-mini-profiler
   rails (= 4.2.8)
+  recaptcha
   redcarpet (>= 3.4.0)
   redis-rails
   rmagick
@@ -484,4 +487,4 @@ DEPENDENCIES
   whenever (~> 0.9.7)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,7 +1,3 @@
-<%  simple_math_1 = rand(20) %>
-<%  simple_math_2 = rand(20) %>
-<%  simple_math_total = (simple_math_1 + simple_math_2) %>
-
 <script>
  $(function(){
    var aboutYouInput = document.getElementById('about-you-input');
@@ -18,25 +14,19 @@
 	   });
  });
  
-
  function validateForm(){
    if (!document.getElementById('terms_of_use').checked) {
      alert("Unfortunately, you have to accept the terms first");
      return false;
    }
-
    var password = document.getElementsByName("user[password]")[0].value;
    var confirmation = document.getElementsByName("user[password_confirmation]")[0].value;
-   var solution = Number(<%= simple_math_total %>);
-   var answerProvided = Number(document.getElementById('simple_math').value);
+   
    if (password.length < 8) {
      alert('Please ensure that your password is 8 or more characters long!');
      return false;
    } else if (password !== confirmation) {
      alert('Your password and password confirmation do not match :(');
-     return false;
-   } else if (solution  !==  answerProvided) {
-     alert('Please double check your math :( ');
      return false;
    } else {
      return true;
@@ -165,15 +155,7 @@
                             </div>
 			</div>
 
-			<div class="form-group">
-                            <%=  label_tag 'spam_test', "Spam Test", :class => label_class %>
-                            <div class="col-sm-2">
-				<samp class="text-center"><%= simple_math_1 %> + <%= simple_math_2 %> = </samp>
-                            </div>
-                            <div class="col-sm-2">
-				<%= text_field_tag :spam_test, "", maxlength: 2, id: 'simple_math', class: 'form-control' %>
-                            </div>
-			</div>
+			
 
 
 			<div class="form-group">
@@ -198,6 +180,14 @@
                             </div>
 			</div>
 			
+			<div class="form-group">
+			    <%=  label_tag 'spam_test', "", :class => label_class %>
+                            <div class="col-sm-10">
+				<%= flash[:recaptcha_error] %>
+				<%= recaptcha_tags %>
+			    </div>
+			</div>
+
 			<div class="actions form-group">
                             <div class="col-sm-2"></div>
                             <div class="col-sm-2">

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,4 @@
+Recaptcha.configure do |config|
+  config.site_key  = APP_CONFIG.fetch('recaptcha').fetch('site_key')
+  config.secret_key = APP_CONFIG.fetch('recaptcha').fetch('secret_key')
+end

--- a/config/lilsis.yml.sample
+++ b/config/lilsis.yml.sample
@@ -52,10 +52,10 @@ defaults: &defaults
     api_url: "rocketchat:3000"
     admin_username: 
     admin_password:
-    
+  recaptcha:
+    site_key: 'your-recaptcha-site-key-here'
+    secret_key: 'your-recaptcha-secret-key-here'
   
-  
-
 
 test:
   <<: *defaults


### PR DESCRIPTION
This replaces the custom math problem with google's recaptcha:

![not_a_robot](https://user-images.githubusercontent.com/8505044/30137505-a76cd7f2-9331-11e7-8aaa-a90e9d0e81c2.png)


I *kind of* cheated and pushed this to the server via git branch switching to totally make sure that it works live and it does:

![confirmation_captcha](https://user-images.githubusercontent.com/8505044/30137526-bfdba4d0-9331-11e7-8f56-03c9181dcdcc.png)

![testing_the_join_page](https://user-images.githubusercontent.com/8505044/30137584-ff2e7aea-9331-11e7-9d2d-ca55768fe900.png)

