### PR TITLE
Add tags to search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,52 +1,28 @@
 class SearchController < ApplicationController
   before_filter :authenticate_user!, except: [:basic]
+  before_action :set_page, only: [:basic]
 
   def basic
     @q = (params[:q] or "").gsub(/\b(and|the|of)\b/, "")
     @cant_find = params[:q].present? && @q.empty?
 
-    if @q.present?      
-      q = Riddle::Query.escape(@q)
-      page = (params[:page] or 1).to_i
-
-      @entities = Entity::Search.search(@q, page: page)
-
-      if page > 1
-        @groups = []
-        @lists = []
-        @maps = []
+    if @q.present?
+      if @page > 1
+        # only show entities
+        set_groups_lists_maps_to_be_empty
+        entities_search(@q)
       else
-        admin = current_user.present? and current_user.has_legacy_permission("admin")
-        list_is_admin = admin ? [0, 1] : 0
-        @groups = Group.search("@(name,tagline,description,slug) #{q}", per: 50, match_mode: :extended)
-        @lists = List.search("@(name,description) #{q}",
-                             per: 50,
-                             match_mode: :extended,
-                             with: { is_deleted: false, is_admin: list_is_admin, is_network: false },
-                             without: { access: Permissions::ACCESS_PRIVATE } )
-        @maps = NetworkMap.search("@(title,description,index_data) #{q}", per: 100, match_mode: :extended, with: { is_deleted: false, is_private: false })
+        perform_search(@q)
       end
     end
 
     respond_to do |format|
-      format.html {    
-        render "basic"
-      }
+      format.html { render "basic" }
 
-      format.json {
-        entities = @entities.map do |e|
-          {
-            id: e.id,
-            name: e.name,
-            description: e.blurb,
-            summary: e.summary,
-            primary_type: e.primary_ext,
-            url: e.legacy_url
-          }
-        end
-
+      format.json do
+        entities = @entities.map { |e| Entity::Search.entity_with_summary(e) }
         render json: { entities: entities }
-      }
+      end
     end
   end
 
@@ -64,5 +40,51 @@ class SearchController < ApplicationController
     else
       render json: search_results.map { |e| Entity::Search.entity_with_summary(e) }
     end
+  end
+
+  private
+
+  def set_groups_lists_maps_to_be_empty
+    @groups = []
+    @lists = []
+    @maps = []
+  end
+
+  def perform_search(query)
+    q = ThinkingSphinx::Query.escape(query)
+    entities_search(query)
+    groups_search(q)
+    lists_search(q)
+    maps_search(q)
+  end
+
+  # unlike groups, lists, and maps, Entity::Search takes
+  # the "raw" query before it has been escaped.
+  def entities_search(query)
+    @entities = Entity::Search.search(query, page: @page)
+  end
+
+  def groups_search(q)
+    @groups = Group.search("@(name,tagline,description,slug) #{q}", per: 50, match_mode: :extended)
+  end
+
+  def lists_search(q)
+    list_is_admin = current_user&.admin? ? [0, 1] : 0
+    @lists = List.search("@(name,description) #{q}",
+                         per: 50,
+                         match_mode: :extended,
+                         with: { is_deleted: false, is_admin: list_is_admin, is_network: false },
+                         without: { access: Permissions::ACCESS_PRIVATE })
+  end
+
+  def maps_search(q)
+    @maps = NetworkMap.search("@(title,description,index_data) #{q}",
+                              per: 100,
+                              match_mode: :extended,
+                              with: { is_deleted: false, is_private: false })
+  end
+
+  def set_page
+    @page = (params[:page] or 1).to_i
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,19 +3,13 @@ class SearchController < ApplicationController
 
   def basic
     @q = (params[:q] or "").gsub(/\b(and|the|of)\b/, "")
+    @cant_find = params[:q].present? && @q.empty?
 
     if @q.present?      
       q = Riddle::Query.escape(@q)
       page = (params[:page] or 1).to_i
 
-      @entities = Entity.search(
-        "@(name,aliases) #{q}", 
-        page: page, 
-        match_mode: :extended,
-        with: { is_deleted: false },
-        select: "*, weight() * (link_count + 1) AS link_weight",
-        order: "link_weight DESC"
-      )
+      @entities = Entity::Search.search(@q, page: page)
 
       if page > 1
         @groups = []

--- a/app/models/concerns/entity_search.rb
+++ b/app/models/concerns/entity_search.rb
@@ -2,15 +2,24 @@ module EntitySearch
   # A wrapper around the default
   # sphinx model search - Entity.search
   class Search
+    DEFAULT_SEARCH_OPTIONS = {
+      with: { is_deleted: false },
+      fields: 'name,aliases',
+      num: 15,
+      page: 1
+    }.freeze
+
     # String, Hash -> ThinkingShinx::Search
+    # NOTE: used by SearchController
     def self.search(query, opt = {})
       q = ThinkingSphinx::Query.escape(query)
-      options = { with: { is_deleted: false }, fields: 'name,aliases', num: 15 }.merge(opt)
+      options = DEFAULT_SEARCH_OPTIONS.merge(opt)
       Entity.search(
         "@(#{options[:fields]}) #{q}",
         match_mode: :extended,
         with: options[:with],
         per_page: options[:num],
+        page: options[:page],
         select: '*, weight() * (link_count + 1) AS link_weight',
         order: 'link_weight DESC'
       )

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -8,10 +8,6 @@ class Tag < ActiveRecord::Base
     restricted
   end
 
-  # def tag.permissions
-  #       fetch(:permissions)
-  #     end
-
   # (set, set) -> hash
   def self.parse_update_actions(client_ids, server_ids)
     {
@@ -20,5 +16,23 @@ class Tag < ActiveRecord::Base
       remove: server_ids - client_ids
     }
   end
-end
 
+  # String -> [Tag]
+  def self.search_by_names(phrase)
+    Tag.lookup.keys
+      .select { |tag_name| phrase.downcase.include?(tag_name) }
+      .map { |tag_name| lookup[tag_name] }
+  end
+
+  # String -> Tag | Nil
+  # Search through tags find tag by name
+  def self.search_by_name(query)
+    lookup[query.downcase]
+  end
+
+  def self.lookup
+    @lookup ||= Tag.all.reduce({}) do |acc, tag|
+      acc.tap { |h| h.store(tag.name.downcase.tr('-', ' '), tag) }
+    end
+  end
+end

--- a/app/views/search/basic.html.erb
+++ b/app/views/search/basic.html.erb
@@ -17,53 +17,65 @@
 
 <div class="search-results">
 
-<% if @q.present? %>
-  <% if @groups.count > 0 %>
-    <h3>Research Groups</h3>
-    <% @groups.each do |group| %>
-      <span class="search-result-link"><%= group_link(group) %></span> &nbsp;<em><%= highlight((strip_tags(group.tagline) or ""), params[:q]) %></em>
-      <br>
+    <% if @q.present? %>
+	
+	<% if @tags.count > 0 %>
+	    <h3>Tags</h3>
+	    <% @tags.each do |tag| %>
+		<span class="search-result-link">
+		    <%= link_to tag.name, tag_path(tag) %>
+		</span> &nbsp;<em><%= tag.description %></em>
+		<br>
+	    <% end %>
+	<% end %>
+
+	<% if @lists.count > 0 %>
+	    <h3>Lists</h3>
+	    <% @lists.each do |list| %>
+		<span class="search-result-link"><%= list_link(list) %></span> &nbsp;<em><%= highlight((truncate(list.description, length: 80) or ""), params[:q]) %></em>
+		<br>
+	    <% end %>
+	    <br>
+	<% end %>
+
+	<% if @entities.count > 0 %>
+	    <h3>Entities</h3>
+	    <%= paginate @entities %>
+	    <% @entities.each do |entity| %>
+		<div class="entity-search-result">
+		    <span class="search-result-link"><%= entity_link(entity) %></span> &nbsp;<em><%= highlight((entity.blurb or ""), params[:q]) %></em><br>
+		    <span class="entity-search-result-summary"><%= highlight(truncate((entity.summary or ""), length: 80), params[:q]) %></span>
+		</div>
+	    <% end %> 
+	    <br>
+	<% end %>
+
+	<% if @maps.count > 0 %>
+	    <h3>Network Maps</h3>
+	    <% @maps.each do |map| %>
+		<span class="search-result-link"><%= network_map_link(map) %></span>
+		<br>
+	    <% end %> 
+	    <br>
+	<% end %>
+
+	<% if @groups.count > 0 %>
+	    <h3>Research Groups</h3>
+	    <% @groups.each do |group| %>
+		<span class="search-result-link"><%= group_link(group) %></span> &nbsp;<em><%= highlight((strip_tags(group.tagline) or ""), params[:q]) %></em>
+		<br>
+	    <% end %>
+	    <br>
+	<% end %>
+
+
+	<% if @groups.count + @lists.count + @entities.count + @maps.count + @tags.count == 0 %>
+	    <strong>No results found.</strong>
+	<% end %>
     <% end %>
-    <br>
-  <% end %>
-
-  <% if @lists.count > 0 %>
-    <h3>Lists</h3>
-    <% @lists.each do |list| %>
-      <span class="search-result-link"><%= list_link(list) %></span> &nbsp;<em><%= highlight((truncate(list.description, length: 80) or ""), params[:q]) %></em>
-      <br>
-    <% end %>
-    <br>
-  <% end %>
-
-  <% if @entities.count > 0 %>
-    <h3>Entities</h3>
-    <%= paginate @entities %>
-    <% @entities.each do |entity| %>
-      <div class="entity-search-result">
-        <span class="search-result-link"><%= entity_link(entity) %></span> &nbsp;<em><%= highlight((entity.blurb or ""), params[:q]) %></em><br>
-        <span class="entity-search-result-summary"><%= highlight(truncate((entity.summary or ""), length: 80), params[:q]) %></span>
-      </div>
-    <% end %> 
-    <br>
-  <% end %>
-
-  <% if @maps.count > 0 %>
-    <h3>Network Maps</h3>
-    <% @maps.each do |map| %>
-      <span class="search-result-link"><%= network_map_link(map) %></span>
-      <br>
-    <% end %> 
-    <br>
-  <% end %>
-
-  <% if @groups.count + @lists.count + @entities.count + @maps.count == 0 %>
-    <strong>No results found.</strong>
-  <% end %>
-<% end %>
 
 </div>
 
 <% if @cant_find %>
-  <%= render partial: "cantfind" %>
+    <%= render partial: "cantfind" %>
 <% end %>

--- a/app/views/search/basic.html.erb
+++ b/app/views/search/basic.html.erb
@@ -64,6 +64,6 @@
 
 </div>
 
-<% if params[:q].present? %>
+<% if @cant_find %>
   <%= render partial: "cantfind" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,7 +273,7 @@ Lilsis::Application.routes.draw do
 
   # Tags
 
-  resources :tags, only: [:edit, :create, :update, :destroy]
+  resources :tags, only: [:edit, :create, :update, :destroy, :show]
 
 
   #########

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :group do
+    sequence(:id)
+    name "Goldman Sachs Investigation"
+    tagline "This group is putting together a list detailing the key players at Goldman Sachs and their ties to Washington."
+    slug "goldmansachs"
+  end
+end

--- a/spec/factories/list.rb
+++ b/spec/factories/list.rb
@@ -39,11 +39,6 @@ FactoryGirl.define do
     is_deleted false
   end
 
-  factory :group, class: Group do
-    name 'a team'
-    slug '/'
-  end
-
   factory :note, class: Note do
     user_id 1
     body 'why is EVERYTHING connected?'

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -1,0 +1,29 @@
+FactoryGirl.define do
+
+  factory :tag, class: Tag  do
+    sequence(:id)
+    sequence(:name) { |n| "tag-name#{n}"}
+    sequence(:description) { |n| "description of tag-name#{n}"}
+  end
+
+  factory :oil_tag, class: Tag do
+    name 'oil'
+    description "the reason for our planet's demise"
+  end
+
+  factory :nyc_tag, class: Tag do
+    name 'nyc'
+    description "anything related to New York City"
+    restricted true
+  end
+
+  factory :finance_tag, class: Tag do
+    name 'finance'
+    description 'banks and such'
+  end
+
+  factory :real_estate_tag, class: Tag do
+    name 'real-estate'
+    description 'The real estate industry'
+  end
+end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -670,22 +670,30 @@ describe Entity, :tag_helper  do
 
   describe 'EntitySearch' do
     describe 'Entity::Search.search' do
-      let(:defaults) {{ match_mode: :extended,
-                        with: {is_deleted: false},
-                        per_page: 15,
-                        select: '*, weight() * (link_count + 1) AS link_weight',
-                        order: 'link_weight DESC' }}
+      let(:defaults) do
+        { match_mode: :extended,
+          with: { is_deleted: false },
+          per_page: 15,
+          page: 1,
+          select: '*, weight() * (link_count + 1) AS link_weight',
+          order: 'link_weight DESC' }
+      end
+
+      let(:arg1) { '@(name,aliases) someone' }
 
       it 'calls Entity.search with defaults' do
-        expect(Entity).to receive(:search)
-                           .with('@(name,aliases) someone', defaults)
+        expect(Entity).to receive(:search).with(arg1, defaults)
         Entity::Search.search 'someone'
       end
 
       it 'accept hash as second arg to overrides defaults' do
-        expect(Entity).to receive(:search)
-                           .with('@(name,aliases) someone', defaults.merge(per_page: 5))
+        expect(Entity).to receive(:search).with(arg1, defaults.merge(per_page: 5))
         Entity::Search.search 'someone', num: 5
+      end
+
+      it 'will allow the page option to be modified' do
+        expect(Entity).to receive(:search).with(arg1, defaults.merge(page: 2))
+        Entity::Search.search 'someone', page: 2
       end
     end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,33 +1,105 @@
 require 'rails_helper'
 
 describe Tag, :tag_helper do
-  seed_tags
 
   it { should have_db_column(:restricted) }
   it { should have_db_column(:name) }
   it { should have_db_column(:description) }
   it { should have_many(:taggings) }
 
-  describe 'validations' do
-    subject { Tag.new(name: 'fake tag name', description: 'all about fake tags') }
+  context 'with seed tags' do
+    seed_tags
 
-    it { should validate_uniqueness_of(:name) }
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:description) }
+    describe 'validations' do
+      subject { Tag.new(name: 'fake tag name', description: 'all about fake tags') }
+
+      it { should validate_uniqueness_of(:name) }
+      it { should validate_presence_of(:name) }
+      it { should validate_presence_of(:description) }
+    end
+
+    it 'can determine if a tag is restricted' do
+      expect(Tag.find_by_name('oil').restricted?).to be false
+      expect(Tag.find_by_name('nyc').restricted?).to be true
+    end
+
+    it 'partitions tag ids from client into hash of update actions to be taken' do
+      client_ids = [1, 2, 3].to_set
+      server_ids = [2, 3, 4].to_set
+      expect(Tag.parse_update_actions(client_ids, server_ids)).to eql(
+                                                                    add: [1].to_set,
+                                                                    remove: [4].to_set,
+                                                                    ignore: [2, 3].to_set
+                                                                  )
+    end
   end
 
-  it 'can determine if a tag is restricted' do
-    expect(Tag.find_by_name('oil').restricted?).to be false
-    expect(Tag.find_by_name('nyc').restricted?).to be true
-  end
+  describe 'Class Methods' do
+    before(:each) do
+      @oil = build(:oil_tag)
+      @nyc = build(:nyc_tag)
+      @finance = build(:finance_tag)
+      @real_estate = build(:real_estate_tag)
+      Tag.instance_variable_set(:@lookup, nil)
+      allow(Tag).to receive(:all).and_return([@oil, @nyc, @finance, @real_estate])
+    end
 
-  it 'partitions tag ids from client into hash of update actions to be taken' do
-    client_ids = [1, 2, 3].to_set
-    server_ids = [2, 3, 4].to_set
-    expect(Tag.parse_update_actions(client_ids, server_ids)).to eql(
-      add: [1].to_set,
-      remove: [4].to_set,
-      ignore: [2, 3].to_set
-    )
+    describe '#search_by_name' do
+      it 'finds tag by if search includes exact name' do
+        expect(Tag.search_by_name('oil')).to eql @oil
+        expect(Tag.search_by_name('nyc')).to eql @nyc
+      end
+
+      it 'finds tag regardless of capitalization' do
+        expect(Tag.search_by_name('OIL')).to eql @oil
+        expect(Tag.search_by_name('nYc')).to eql @nyc
+      end
+
+      it 'return nil if there is no tag' do
+        expect(Tag.search_by_name('NOTATAG')).to be nil
+      end
+    end
+
+    describe '#search_by_names' do
+      let(:phrase) { '' }
+      subject { Tag.search_by_names(phrase) }
+
+      it { is_expected.to be_a Array }
+
+      context 'phrase contains one tag' do
+        let(:phrase) { "oil barons" }
+        it { should eql [@oil] }
+      end
+
+      context 'phrase contains two tag' do
+        let(:phrase) { "oil barons who like finance" }
+        it { should eql [@oil, @finance] }
+      end
+
+      context 'phrase contains a repeated tag name' do
+        let(:phrase) { "nyc nyc" }
+        it { should eql [@nyc] }
+      end
+
+      context 'phrase contains real estate' do
+        let(:phrase) { "my rent is too high. DAMN REAL ESTATE INDUSTRY" }
+        it { should eql [@real_estate] }
+      end
+
+      context 'phrase is unrelated to tags' do
+        let(:phrase) { "nothing to see here" }
+        it { should eql [] }
+      end
+    end
+
+    describe 'lookup' do
+      it 'returns a look up table of all hash by name' do
+        expect(Tag.lookup).to eq('oil' => @oil,
+                                 'nyc' => @nyc,
+                                 'finance' => @finance,
+                                 'real estate' => @real_estate)
+      end
+
+    end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -93,7 +93,7 @@ describe Tag, :tag_helper do
     end
 
     describe 'lookup' do
-      it 'returns a look up table of all hash by name' do
+      it 'returns a hash lookup table of all tags by name' do
         expect(Tag.lookup).to eq('oil' => @oil,
                                  'nyc' => @nyc,
                                  'finance' => @finance,

--- a/spec/support/tag_spec_helper.rb
+++ b/spec/support/tag_spec_helper.rb
@@ -22,6 +22,4 @@ module TagSpecHelper
       Tag.destroy_all
     end
   end
-
-  
 end

--- a/spec/views/search/basic.html.erb_spec.rb
+++ b/spec/views/search/basic.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe "search/basic", type: :view do
   let(:groups) { [] }
   let(:lists) { [] }
   let(:maps) { [] }
+  let(:tags) { [] }
   let(:q) { '' }
 
   before(:each) do
@@ -14,6 +15,7 @@ describe "search/basic", type: :view do
     assign(:groups, groups)
     assign(:lists, lists)
     assign(:maps, maps)
+    assign(:tags, tags)
     assign(:q, q)
     render
   end
@@ -82,6 +84,15 @@ describe "search/basic", type: :view do
         css 'span.search-result-link', count: 1
       end
     end
-  end 
+
+    context 'found a tag' do
+      let(:tags) { [build(:oil_tag, id: 123)] }
+
+      it 'shows a link to the tag' do
+        css 'h3', text: 'Tags'
+        css 'span.search-result-link', count: 1
+      end
+    end
+  end
   
 end

--- a/spec/views/search/basic.html.erb_spec.rb
+++ b/spec/views/search/basic.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe "search/basic", type: :view do
+  let(:cant_find) { false }
+
+  before(:each) do
+    assign(:cant_find, cant_find)
+    render
+  end
+
+  describe 'layout' do
+    it 'contains search form and results div' do
+      css 'form'
+      css 'div.search-results'
+    end
+  end
+
+  context 'results found' do
+    it { is_expected.not_to render_template(partial: '_cantfind') }
+  end
+
+  context 'no results found' do
+    let(:cant_find) { true }
+    it { is_expected.to render_template(partial: '_cantfind') }
+  end
+  
+end

--- a/spec/views/search/basic.html.erb_spec.rb
+++ b/spec/views/search/basic.html.erb_spec.rb
@@ -2,26 +2,86 @@ require 'rails_helper'
 
 describe "search/basic", type: :view do
   let(:cant_find) { false }
+  let(:entities) { [] }
+  let(:groups) { [] }
+  let(:lists) { [] }
+  let(:maps) { [] }
+  let(:q) { '' }
 
   before(:each) do
     assign(:cant_find, cant_find)
+    assign(:entities, entities)
+    assign(:groups, groups)
+    assign(:lists, lists)
+    assign(:maps, maps)
+    assign(:q, q)
     render
   end
 
   describe 'layout' do
     it 'contains search form and results div' do
+      css 'h1', text: 'Search'
       css 'form'
       css 'div.search-results'
     end
+
+    context 'results found' do
+      it { is_expected.not_to render_template(partial: '_cantfind') }
+    end
+
+    context 'no results found' do
+      let(:cant_find) { true }
+      it { is_expected.to render_template(partial: '_cantfind') }
+    end
   end
 
-  context 'results found' do
-    it { is_expected.not_to render_template(partial: '_cantfind') }
-  end
+  context 'Searching for bufffalo' do
+    let(:q) { 'buffalo' }
 
-  context 'no results found' do
-    let(:cant_find) { true }
-    it { is_expected.to render_template(partial: '_cantfind') }
-  end
+    context 'nothing found' do
+      it 'displays no results found message' do
+        css 'strong', text: 'No results found.'
+      end
+    end
+
+    context 'found a group' do
+      let(:groups) { [build(:group)] }
+
+      it 'shows research groups' do
+        css 'h3', text: 'Research Groups'
+        css 'span.search-result-link'
+      end
+    end
+
+    context 'found 2 lists (and no groups)' do
+      let(:lists) { [build(:list), build(:open_list)] }
+
+      it 'shows list of list links' do
+        not_css 'h3', text: 'Research Groups'
+        css 'h3', text: 'Lists'
+        css 'span.search-result-link', count: 2
+      end
+    end
+
+    context 'found a map' do
+      let(:maps) { [build(:network_map)] }
+
+      it 'shows link to the map' do
+        not_css 'h3', text: 'Research Groups'
+        not_css 'h3', text: 'List'
+        css 'h3', text: 'Maps'
+        css 'span.search-result-link', count: 1
+      end
+    end
+
+    context 'found a entity' do
+      let(:entities) { Kaminari.paginate_array([build(:org)]).page(1) }
+
+      it 'shows link to the entity' do
+        css 'h3', text: 'Entities'
+        css 'span.search-result-link', count: 1
+      end
+    end
+  end 
   
 end


### PR DESCRIPTION
resolves #297 

Adds tags section to search results:

![tags_on_general_search](https://user-images.githubusercontent.com/8505044/30187648-89343b64-93f8-11e7-94a8-29be4627c7eb.png)


dev notes:

- Did some testing and refactoring of SearchController, but there's still more to be done.
-  it looks for the presence of a tag name in the search string. for instance if you search for "real estate companies" it will find the real estate tag. however, it does not do any fancy fuzzy matching or search within the tag description field -- perhaps that's something to add later on?
