### PR TITLE
Request a tag page

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,6 +1,6 @@
 class TagsController < ApplicationController
   before_action :authenticate_user!, except: [:show]
-  before_action -> { check_permission('admin') }, except: [:show]
+  before_action -> { check_permission('admin') }, except: [:show, :tag_request]
   before_action :set_tag, only: [:edit, :update, :destroy, :show]
   before_action :set_taggings_by_class, only: [:show]
 
@@ -30,6 +30,9 @@ class TagsController < ApplicationController
   def destroy
     @tag.destroy
     redirect_to admin_tags_path, notice: 'The tag has been removed'
+  end
+
+  def tag_request
   end
 
   private

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -33,6 +33,10 @@ class TagsController < ApplicationController
   end
 
   def tag_request
+    if request.post?
+      NotificationMailer.tag_request_email(current_user, params).deliver_later
+      return redirect_to home_dashboard_path, notice: "Your request for a new tag has been submitted. Thank you!"
+    end
   end
 
   private

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -37,4 +37,13 @@ class NotificationMailer < ApplicationMailer
     @params = params
     mail(to: DEFAULT_TO, subject: subject, method_options: SMTP_OPTIONS)
   end
+
+  def tag_request_email(user, params)
+    @user = user
+    @params = params
+    mail(to: DEFAULT_TO,
+         subject: "Tag Request: #{params['tag_name']}",
+         reply_to: user.email,
+         method_options: SMTP_OPTIONS)
+  end
 end

--- a/app/views/notification_mailer/tag_request_email.text.erb
+++ b/app/views/notification_mailer/tag_request_email.text.erb
@@ -1,0 +1,23 @@
+TAG REQUEST
+===========
+
+Requester: <%= @user.username %>
+Email: <%= @user.email %>
+
+
+Tag name: <%= @params['tag_name'] %>
+
+
+Description:
+
+<%= @params['tag_description'] %>
+
+
+<% unless @params['tag_additional'].empty? %>
+Additional information:
+
+<%= @params['tag_additional'] %>
+
+<% end %>
+
+    

--- a/app/views/tags/tag_request.html.erb
+++ b/app/views/tags/tag_request.html.erb
@@ -1,0 +1,44 @@
+<div class="row m-bottom-1em">
+    <h1>Request a new tag</h1>
+</div>
+
+<div class="row">
+    <%= form_tag("/tags/tag_request", method: "post", multipart: true, class: 'form-horizontal', id: 'request-tag-form') do %>
+
+	<div class="form-group">
+	    <label class="col-sm-2 control-label">Email</label>
+	    <div class="col-sm-8">
+		<p class="form-control-static">email@example.com</p>
+	    </div>
+	</div>
+
+	<div class="form-group">
+	    <label class="col-sm-2 control-label">Tag name:</label>
+	    <div class="col-sm-8">
+		<%= text_field_tag :tag_name, nil, class: 'form-control', required: true %>
+	    </div>
+	</div>
+	    
+	<div class="form-group">
+	    <label class="col-sm-2 control-label">Description:</label>
+	    <div class="col-sm-8">
+		<%= text_area_tag :tag_description, nil, class: 'form-control', required: true %>
+	    </div>
+	</div>
+
+	<div class="form-group">
+	    <label class="col-sm-2 control-label">Additional information:</label>
+	    <div class="col-sm-8">
+		<%= text_area_tag :tag_additional, nil, class: 'form-control' %>
+		<p><small>Anything else you like you say. Is there for a special research project you'd like us to know about?</small></p>
+	    </div>
+	</div>
+
+	<div class="form-group">
+	    <div class="col-sm-8 col-sm-offset-2">
+		<button type="submit" class="btn btn-primary">Submit</button>
+	    </div>
+	</div>
+
+    <% end %>
+</div>

--- a/app/views/tags/tag_request.html.erb
+++ b/app/views/tags/tag_request.html.erb
@@ -3,12 +3,12 @@
 </div>
 
 <div class="row">
-    <%= form_tag("/tags/tag_request", method: "post", multipart: true, class: 'form-horizontal', id: 'request-tag-form') do %>
+    <%= form_tag("/tags/request", method: "post", multipart: true, class: 'form-horizontal', id: 'request-tag-form') do %>
 
 	<div class="form-group">
-	    <label class="col-sm-2 control-label">Email</label>
+	    <label class="col-sm-2 control-label">Your Email:</label>
 	    <div class="col-sm-8">
-		<p class="form-control-static">email@example.com</p>
+		<p class="form-control-static"><%= current_user.email %></p>
 	    </div>
 	</div>
 
@@ -30,7 +30,7 @@
 	    <label class="col-sm-2 control-label">Additional information:</label>
 	    <div class="col-sm-8">
 		<%= text_area_tag :tag_additional, nil, class: 'form-control' %>
-		<p><small>Anything else you like you say. Is there for a special research project you'd like us to know about?</small></p>
+		<p><small>Anything else you'd like you say. Is this for a special research project you'd like us to know about?</small></p>
 	    </div>
 	</div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,7 @@ Lilsis::Application.routes.draw do
   ########
 
   get '/tags/request' => 'tags#tag_request'
+  post '/tags/request' => 'tags#tag_request'
   resources :tags, only: [:edit, :create, :update, :destroy, :show]
 
   #########

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,6 +274,7 @@ Lilsis::Application.routes.draw do
   # Tags #
   ########
 
+  get '/tags/request' => 'tags#tag_request'
   resources :tags, only: [:edit, :create, :update, :destroy, :show]
 
   #########

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -5,4 +5,5 @@ describe TagsController, type: :controller do
   it { should route(:post, '/tags').to(action: :create) }
   it { should route(:put, '/tags/456').to(action: :update, id: 456) }
   it { should route(:delete, '/tags/456').to(action: :destroy, id: 456) }
+  it { should route(:get, '/tags/request').to(action: :tag_request) }
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -6,4 +6,5 @@ describe TagsController, type: :controller do
   it { should route(:put, '/tags/456').to(action: :update, id: 456) }
   it { should route(:delete, '/tags/456').to(action: :destroy, id: 456) }
   it { should route(:get, '/tags/request').to(action: :tag_request) }
+  it { should route(:post, '/tags/request').to(action: :tag_request) }
 end

--- a/spec/features/request_a_tag_spec.rb
+++ b/spec/features/request_a_tag_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 feature 'Requesting a new tag', type: :feature do
-
   let(:user) { create_really_basic_user }
 
   before(:each) do
@@ -13,6 +12,7 @@ feature 'Requesting a new tag', type: :feature do
 
   scenario 'Contains a form where the user can request a tag' do
     expect(page.status_code).to eq 200
+    expect(page).to have_selector 'p', text: user.email
     expect(page).to have_selector '#request-tag-form'
     expect(page).to have_selector 'input#tag_name'
     expect(page).to have_selector 'textarea#tag_description'
@@ -20,8 +20,29 @@ feature 'Requesting a new tag', type: :feature do
     expect(page).to have_selector "button[type='submit']"
   end
 
-  scenario 'After user submits a form, it sends an email to the staff' do
-    
-  end
+  feature 'Email notifiation' do
+    let(:params) do
+      {
+        'tag_name' => 'dogs',
+        'tag_description' => 'dogs and their evil ways',
+        'tag_additional' => ''
+      }
+    end
 
+    scenario 'After user submits a form, it sends an email to the staff' do
+      mailer = double("mailer")
+      expect(mailer).to receive(:deliver_later).once
+
+      expect(NotificationMailer).to receive(:tag_request_email)
+                                      .with(user, hash_including(params))
+                                      .and_return(mailer)
+
+      expect(page).to have_current_path '/tags/request'
+      fill_in 'tag_name', with: 'dogs'
+      fill_in 'tag_description', with: 'dogs and their evil ways'
+      click_button 'Submit'
+
+      expect(page).to have_current_path home_dashboard_path
+    end
+  end
 end

--- a/spec/features/request_a_tag_spec.rb
+++ b/spec/features/request_a_tag_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+feature 'Requesting a new tag', type: :feature do
+
+  let(:user) { create_really_basic_user }
+
+  before(:each) do
+    login_as(user, scope: :user)
+    visit "/tags/request"
+  end
+
+  after(:each) { logout(:user) }
+
+  scenario 'Contains a form where the user can request a tag' do
+    expect(page.status_code).to eq 200
+    expect(page).to have_selector '#request-tag-form'
+    expect(page).to have_selector 'input#tag_name'
+    expect(page).to have_selector 'textarea#tag_description'
+    expect(page).to have_selector 'textarea#tag_additional'
+    expect(page).to have_selector "button[type='submit']"
+  end
+
+  scenario 'After user submits a form, it sends an email to the staff' do
+    
+  end
+
+end


### PR DESCRIPTION
This creates a new page where users can request new tags:

![request_tag_page](https://user-images.githubusercontent.com/8505044/30298008-cc1f7b92-9717-11e7-94e5-a8b629e12684.png)

after submitting the request it sends the user to their dashboard:

![dashboard_after_tag_request](https://user-images.githubusercontent.com/8505044/30298033-e1710678-9717-11e7-8c3f-97810720dcea.png)


The requests arrive via email just like the contact us and flag requests.

resolves #299 