### PR TITLE
static tag overview page

### DIFF
--- a/app/assets/stylesheets/styles/tags.scss
+++ b/app/assets/stylesheets/styles/tags.scss
@@ -1,25 +1,40 @@
 /* TAGS */
 
+// SHARED
+
 $light-maroon: rgba(204,133,133,0.4);
 $maroon: rgba(204, 84, 84, 1);
+$tag_margin: 0.4em;
+
+.tag {
+    background-color: $light-maroon;
+    border-radius: .2em;
+    border: 1px solid $red;
+    display: inline-block;
+    list-style: none; 
+    margin-right: $tag_margin;
+    margin-top: $tag_margin;
+    padding: .3em;
+    color: $maroon;
+    &:hover { color: $maroon; }
+}
+
+.gray-description-text {
+    font-size: 1em;
+    font-style: italic;
+    color: gray;
+}
+
+// TAG SIDEBAR STYLES
 
 #tags-edit-list, #tags-list {
 
     @extend .list-unstyled;
     
     margin-top: 1em;
-    
-    $tag_margin: 0.4em;
 
     li.tag {
-	background-color: $light-maroon;
-	border-radius: .2em;
-	border: 1px solid $red;
-	display: inline-block;
-	list-style: none; 
-	margin-right: $tag_margin;
-        margin-top: $tag_margin;
-	padding: .3em;
+        @extend .tag;
     }
 
     li.tag-disabled{
@@ -78,11 +93,40 @@ $maroon: rgba(204, 84, 84, 1);
 
 input#tag_name {
     max-width: 250px;
-
 }
 
-#tag-show-container {
+// TAGS INDEX STYLES
 
+#tags-index-container {
+    #tags-index-list {
+        margin-top: 2em;
+        ul {
+            padding: 0;
+        }
+        .item {
+            display: flex;
+            flex-direction: row;
+            align-items: flex-end;
+            .tag-container {
+                padding-right: .5em;
+                margin-right: .5em;
+                border-right: 1px solid gray;
+                width: 10em;
+                text-align: right;
+                .tag {
+                    @extend .tag;
+                }
+            }
+            .description {
+                @extend .gray-description-text;
+            }
+        }
+    }
+}
+
+// TAG HOMEPAGE STYLES
+
+#tag-show-container {
     #tag-show-header {
         display: flex;
         flex-direction: row;
@@ -91,10 +135,8 @@ input#tag_name {
             font-size: 2em;
         }
         #tag-show-description {
-            font-size: 1em;
+            @extend .gray-description-text;
             margin: 0 0 .4em 1em; // TRBL
-            font-style: italic;
-            color: gray;
         }
     }
     .tagable-list{
@@ -144,5 +186,4 @@ input#tag_name {
             padding-left: 1em;
         }
     }
-
 }

--- a/app/assets/stylesheets/styles/tags.scss
+++ b/app/assets/stylesheets/styles/tags.scss
@@ -6,17 +6,29 @@ $light-maroon: rgba(204,133,133,0.4);
 $maroon: rgba(204, 84, 84, 1);
 $tag_margin: 0.4em;
 
-.tag {
-    background-color: $light-maroon;
-    border-radius: .2em;
+.tag-like {
     border: 1px solid $red;
-    display: inline-block;
-    list-style: none; 
+    background-color: $light-maroon;
+    color: $maroon;
+    &:hover { color: $maroon; }
+}
+
+.tag {
+    @extend .tag-like;
+    border-radius: .2em;
     margin-right: $tag_margin;
     margin-top: $tag_margin;
     padding: .3em;
-    color: $maroon;
-    &:hover { color: $maroon; }
+    display: inline-block;
+    list-style: none; 
+}
+
+.big-tag {
+    @extend .tag-like;
+    border-radius: .2em;
+    margin-right: $tag_margin;
+    margin-top: $tag_margin;
+    padding: .2em;
 }
 
 .gray-description-text {
@@ -127,16 +139,25 @@ input#tag_name {
 // TAG HOMEPAGE STYLES
 
 #tag-show-container {
-    #tag-show-header {
+    #tag-header {
         display: flex;
         flex-direction: row;
-        align-items: flex-end;
-        #tag-show-title {
-            font-size: 2em;
+        justify-content: space-between;
+        #tag-title {
+            display: flex;
+            flex-direction: row;
+            align-items: flex-end;
+            #tag-name {
+                font-size: 2em;
+            }
+            #tag-description {
+                @extend .gray-description-text;
+                margin: 0 0 .4em .4em; // TRBL
+            }
         }
-        #tag-show-description {
-            @extend .gray-description-text;
-            margin: 0 0 .4em 1em; // TRBL
+        #tag-overview-link {
+            margin: 0 .4em .4em 0; // TRBL
+            align-self: flex-end;
         }
     }
     .tagable-list{

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,7 +1,8 @@
 class TagsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action -> { check_permission('admin') }, except: [:show, :tag_request]
+  before_action -> { check_permission('admin') }, except: [:index, :show, :tag_request]
   before_action :set_tag, only: [:edit, :update, :destroy, :show]
+  before_action :set_tags, only: [:index]
   before_action :set_taggings_by_class, only: [:show]
 
   def index; end
@@ -50,6 +51,10 @@ class TagsController < ApplicationController
 
   def set_tag
     @tag = Tag.find(params[:id])
+  end
+
+  def set_tags
+    @tags = Tag.all.order(:name)
   end
 
   def set_taggings_by_class

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,11 +1,14 @@
 class TagsController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action -> { check_permission('admin') }, except: [:show, :tag_request]
   before_action :set_tag, only: [:edit, :update, :destroy, :show]
   before_action :set_taggings_by_class, only: [:show]
 
-  def edit
-  end
+  def index; end
+
+  def show; end
+
+  def edit; end
 
   def create
     tag = Tag.new(tag_params)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -3,7 +3,9 @@ module TagsHelper
     content_tag(:div, id: 'tags-container') do
       content_tag(:ul, id: 'tags-list') do
         tags.reduce(''.html_safe) do |html, tag|
-          html + content_tag(:li, tag[:name], class: 'tag')
+          html + content_tag(:li) do
+            link_to(tag.name, tag, class: 'tag')
+          end
         end
       end
     end

--- a/app/views/entities/_sidebar.html.erb
+++ b/app/views/entities/_sidebar.html.erb
@@ -37,7 +37,9 @@
 	  <div id="tags-container">
             <ul id="tags-list">
               <% @entity.tags.each do |t| %>
-                <li class="tag"><%= t[:name] %></li>
+                <li>
+                  <%= link_to(t.name, t, class: 'tag') %>
+                </li>
               <% end %>
             </ul>
 	  </div>

--- a/app/views/lists/_tags.html.erb
+++ b/app/views/lists/_tags.html.erb
@@ -5,7 +5,9 @@
     <% end %>
     <ul id="tags-list">
 	<% tags.each do |t| %>
-	    <li class="tag"><%= t[:name] %></li>
+	  <li>
+            <%= link_to(t.name, t, class: 'tag') %>
+          </li>
 	<% end %>
     </ul>
 </div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,0 +1,24 @@
+<div id="tags-index-container">
+
+  <h1 id="tags-index-title">Tags</h1>
+
+  <hr/>
+
+  <div id="tags-index-description">
+    Tags allow contributors to thematically group people, organizations, lists, and relationships on LittleSis. Below is a list of all the tags on the site. Don't see a tag you want to use? Use <%=link_to "this form", tags_request_path %> to request it!
+  </div>
+
+  <div id="tags-index-list">
+    <ul>
+      <% @tags.each do |tag| %>
+        <div class="item">
+          <div class="tag-container">
+            <%= link_to(tag.name, tag, class: "tag") %>  
+          </div>          
+          <%= content_tag :div, tag.description, class: "description"%>
+        </div>
+      <% end %> 
+    </ul>
+  </div>
+
+</div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,15 +1,20 @@
 <div id="tag-show-container">
 
-  <div id="tag-show-header">
+  <div id="tag-header">
 
-    <div id="tag-show-title">
-      Tag: <%= @tag.name.titlecase %>
+    <div id="tag-title">
+      <div id="tag-name">
+        Tag: <%= content_tag :span, @tag.name, class: "big-tag" %>
+      </div>
+
+      <div id="tag-description">
+        <%= @tag.description %>
+      </div>
     </div>
 
-    <div id="tag-show-description">
-      <%= @tag.description %>
+    <div id="tag-overview-link">
+      <%= link_to "see all tags", tags_path  %>
     </div>
-
   </div>
 
   <% @taggings_by_class.each do |tagable_class, taggings|  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,7 @@ Lilsis::Application.routes.draw do
 
   get '/tags/request' => 'tags#tag_request'
   post '/tags/request' => 'tags#tag_request'
-  resources :tags, only: [:edit, :create, :update, :destroy, :show]
+  resources :tags, only: [:edit, :create, :update, :destroy, :show, :index]
 
   #########
   # edits #

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe TagsController, type: :controller do
+  it { should route(:get, '/tags/456').to(action: :show, id: 456) }
+  it { should route(:get, '/tags').to(action: :index) }
   it { should route(:get, '/tags/456/edit').to(action: :edit, id: 456) }
   it { should route(:post, '/tags').to(action: :create) }
   it { should route(:put, '/tags/456').to(action: :update, id: 456) }

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -2,21 +2,17 @@ require 'rails_helper'
 
 describe 'Tags', type: :feature do
 
-  let(:tag) { create(:tag) }
-
   before(:all) do
     # we use instance variables here as a performance optimization to trim seconds off of this suite
+    @tags = Array.new(2) { create(:tag) }
+    @tag = @tags.first
     @entities = Array.new(11) { create(:org) }
     @lists = Array.new(11) { create(:list) }
     @relationships = Array.new(11) do
       create(:generic_relationship, entity: @entities.first, related: @entities.second)
     end
     @tagables = [@entities, @lists, @relationships]
-    # avoid inadvertantly re-setting entity `updated_at` field when we set relationship `updated_at` field
-    #Relationship.skip_callback(:save, :after, :update_entity_timestamps)
   end
-
-  after(:all) { Relationship.set_callback(:save, :after, :update_entity_timestamps) }
 
   # setup helpers
   def update_time(tagable, i)
@@ -35,13 +31,57 @@ describe 'Tags', type: :feature do
     page.all("#tagable-list-#{name_of(tagable_class)} .tagable-list-item")
   end
 
+  describe "tag index" do
+    before { visit "tags/" }
+
+    it "has a title" do
+      expect(page).to have_selector "#tags-index-title"
+    end
+
+    it "has a description" do
+      expect(page).to have_selector "#tags-index-description"
+    end
+
+    it "links to the tag request form" do
+      expect(page.find("#tags-index-description"))
+        .to have_link("this form", href: tags_request_path)
+    end
+
+    it "shows a list of all tags" do
+      @tags.each_with_index do |tag, i|
+        expect(page.find("#tags-index-list"))
+          .to have_selector ".item", count: @tags.size
+      end
+    end
+
+    it "shows a link to each tag's homepage" do
+      @tags.each_with_index do |tag, i|
+        expect(page.all("#tags-index-list .item")[i])
+          .to have_link(tag.name, href: tag_path(tag))
+      end
+    end
+
+    it "shows a description of each tag" do
+      @tags.each_with_index do |tag, i|
+        expect(page.all("#tags-index-list .item .description")[i])
+          .to have_text(tag.description)
+      end
+    end
+
+    it "sorts tags in alphabetical order" do
+      create(:tag, name: "aa")
+      refresh_page
+      expect(page.all("#tags-index-list .item")[0]).to have_text("aa")
+    end
+  end
+  
   describe "tag homepage" do
     context "with no taggings" do
-      before { visit "/tags/#{tag.id}" }
+      before { visit "/tags/#{@tag.id}" }
 
       it "shows the tag title and description" do
-        expect(page).to have_text tag.name
-        expect(page).to have_text tag.description
+        expect(page).to have_text @tag.name
+        expect(page).to have_text @tag.description
       end
 
       it "shows empty lists for all tagable types" do
@@ -63,10 +103,10 @@ describe 'Tags', type: :feature do
           # so that we will expect view to sort them in reverse
           offset = 4 / ((i % 2) + 1)
           tagable
-            .tag(tag.id)
+            .tag(@tag.id)
             .update_columns(updated_at: Time.now - offset.days)
         end
-        visit "/tags/#{tag.id}"
+        visit "/tags/#{@tag.id}"
       end
       
       it "shows a list of tagables for each tagable type" do
@@ -132,7 +172,7 @@ describe 'Tags', type: :feature do
 
       it "truncates descriptions longer than 90 charcaters" do
         @lists[1].update(description: "a" * 91) # second b/c sorting reverses order
-        visit "/tags/#{tag.id}"
+        visit "/tags/#{@tag.id}"
 
         expect(page.all("#tagable-list-lists .tagable-list-item-description").first.text)
           .to eq "a" * 87 + "..."
@@ -141,8 +181,8 @@ describe 'Tags', type: :feature do
 
     context "with more than 10 taggings" do
       before do
-        n_tagables(11).map { |t| t.tag(tag.id) }
-        visit "/tags/#{tag.id}"
+        n_tagables(11).map { |t| t.tag(@tag.id) }
+        visit "/tags/#{@tag.id}"
       end
 
       it "only shows 10 tagables for each tagable type" do

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -13,23 +13,6 @@ describe 'Tags', type: :feature do
   end
   let(:tagables) { [entities, lists, relationships] }
   
-  
-  # before(:all) do
-  #   # we use instance variables here as a performance optimization to trim seconds off of this suite
-  #   tags = Array.new(2) { create(:tag) }
-  #   tag = tags.first
-  #   entities = Array.new(11) { create(:org) }
-  #   lists = Array.new(11) { create(:list) }
-  #   relationships = Array.new(11) do
-  #     create(:generic_relationship, entity: entities.first, related: entities.second)
-  #   end
-  #   tagables = [entities, lists, relationships]
-  #   #avoid inadvertantly re-setting entity `updated_at` field when we set relationship `updated_at` field
-  #   Relationship.skip_callback(:save, :after, :update_entity_timestamps)
-  # end
-
-  # after(:all) { Relationship.set_callback(:save, :after, :update_entity_timestamps) }
-
   # setup helpers
   def update_time(tagable, i)
     tagable.update_columns(updated_at: Time.now - (4 / (i + 1)).days)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,10 +41,11 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, :type => :view
   config.include Warden::Test::Helpers
   config.include FactoryGirl::Syntax::Methods
+  config.include FeatureExampleMacros, :type => :feature
 
   # these run inside example groups (ie: describe blocks)
   config.extend ControllerMacros, :type => :controller
-  config.extend FeatureMacros, :type => :feature
+  config.extend FeatureGroupMacros, :type => :feature
   config.extend ListHelpersForExampleGroups, :list_helper
   config.extend TaggingHelpers, :tagging_helper
   config.extend TagSpecHelper, :tag_helper

--- a/spec/support/feature_macros.rb
+++ b/spec/support/feature_macros.rb
@@ -1,8 +1,23 @@
-module FeatureMacros
+module FeatureSharedMacros
+  # h/t: https://makandracards.com/makandra/760-reload-the-page-in-your-cucumber-features
+  def refresh_page
+    visit [current_path, page.driver.request.env['QUERY_STRING']].reject(&:blank?).join('?')
+  end
+end
+
+# for use in example groups
+module FeatureGroupMacros
+  include FeatureSharedMacros
+
   def denies_access
     it 'denies access' do
       expect(page.status_code).to eq 403
       expect(page).to have_content 'Bad Credentials'
     end
   end
+end
+
+# for use in examples
+module FeatureExampleMacros
+  include FeatureSharedMacros
 end


### PR DESCRIPTION
resolves #232 

## Notes

* for consistency, opted to add clickable links to all view-mode tags throughout site (as this PR introduced them on overview page)
* reverted to slower feature spec setup to avoid non-determinstic state collisions with other part of suite
_____

## screenshoots (peek still broken for me):

**NOTE:** my screenshot program does not show the hand pointer. these links have hand pointers (not arrow pointers) when being hovered over.

clickable links on the overview page:

![tags-link-overview-page](https://user-images.githubusercontent.com/6032844/30351930-a0410d72-97eb-11e7-9245-b48a3972d6a1.png)

link to overview page from tag homepage (plus more stylish "red tag" look in header):

![tags-homepage-redo](https://user-images.githubusercontent.com/6032844/30353087-e4016cfe-97f1-11e7-949a-2147a8acba3e.png)


clickable links on the entity page:

![tags-link-entities-page](https://user-images.githubusercontent.com/6032844/30351935-a4d952ae-97eb-11e7-83db-113ea406c90f.png)

clickable links on the list page:

![tag-link-lists-page](https://user-images.githubusercontent.com/6032844/30352008-f2c2bb68-97eb-11e7-8bf5-9bafbc57e9e8.png)

clickable links on the relationship page:

![tag-link-relationship-page](https://user-images.githubusercontent.com/6032844/30352014-f75a3b42-97eb-11e7-95f5-1ff3face1198.png)


