### PR TITLE
Scripted bulk tagging

### DIFF
--- a/lib/task-helpers/bulk_tagger.rb
+++ b/lib/task-helpers/bulk_tagger.rb
@@ -1,0 +1,25 @@
+require 'csv'
+
+class BulkTagger
+  def initialize(filename)
+    @csv_string = File.open(filename).read
+  end
+
+  def run
+    CSV.parse(@csv_string, headers: true) { |row| tag_entity(row) }
+  end
+
+  # input: CSV::Row
+  def tag_entity(row)
+    entity = Entity.find(entity_id_from(row.field('entity_url')))
+    row.field('tags').split(' ').each do |tag_name|
+      entity.tag(tag_name.downcase)
+    end
+  end
+
+  private
+
+  def entity_id_from(url)
+    %r{\/(org|person|entities)\/([0-9]+)[\/-]}.match(url)[2]
+  end
+end

--- a/lib/task-helpers/bulk_tagger.rb
+++ b/lib/task-helpers/bulk_tagger.rb
@@ -34,18 +34,17 @@ class BulkTagger
   # input: CSV::Row
   # fields: list_url, tags, tag_all_in_list
   def tag_list(row)
-    list = List.find(model_id_from(row.field('entity_url')))
+    list = List.find(model_id_from(row.field('list_url')))
     tags = row_tags(row)
 
     tags.each { |t| list.tag(t) }
-
-    if row.field('tag_all_in_list').present?
-      tag_all_in_list(list, tags)
-    end
-
+    tag_all_in_list(list, tags) if row.field('tag_all_in_list').present?
   end
 
   def tag_all_in_list(list, tags)
+    list.entities.each do |entity|
+      tags.each { |t| entity.tag(t) }
+    end
   end
 
   private

--- a/lib/task-helpers/bulk_tagger.rb
+++ b/lib/task-helpers/bulk_tagger.rb
@@ -1,12 +1,18 @@
 require 'csv'
 
 class BulkTagger
-  def initialize(filename)
+  def initialize(filename, mode)
+    raise ArgumentError, "Unknown mode: #{mode}" unless [:entity, :list].include?(mode)
+    @mode = mode
     @csv_string = File.open(filename).read
   end
 
   def run
-    CSV.parse(@csv_string, headers: true) { |row| tag_entity(row) }
+    CSV.parse(@csv_string, headers: true) do |row|
+      if @mode == :entity
+        tag_entity(row)
+      end
+    end                                             
   end
 
   # input: CSV::Row

--- a/lib/task-helpers/bulk_tagger.rb
+++ b/lib/task-helpers/bulk_tagger.rb
@@ -12,8 +12,22 @@ class BulkTagger
   # input: CSV::Row
   def tag_entity(row)
     entity = Entity.find(entity_id_from(row.field('entity_url')))
-    row.field('tags').split(' ').each do |tag_name|
-      entity.tag(tag_name.downcase)
+    tags = row.field('tags').downcase.split(' ')
+
+    tags.each do |tag_name|
+      entity.tag(tag_name)
+    end
+
+    if row.field('tag_all_related').present?
+      tag_related_entities(entity, tags)
+    end
+
+  end
+
+  def tag_related_entities(entity, tags)
+    entity.links.map(&:entity2_id).uniq.each do |id|
+      other_entity = Entity.find(id)
+      tags.each { |t| other_entity.tag(t) }
     end
   end
 

--- a/lib/task-helpers/bulk_tagging.rb
+++ b/lib/task-helpers/bulk_tagging.rb
@@ -1,6 +1,0 @@
-class BulkTagging
-  
-  def initialize(file)
-  end
-
-end

--- a/lib/tasks/tags.rake
+++ b/lib/tasks/tags.rake
@@ -5,4 +5,9 @@ namespace :tags do
   task :entity, [:file] => :environment do |t, args|
     BulkTagger.new(args[:file], :entity).run
   end
+
+  desc 'bulk tag a csv of lists'
+  task :list, [:file] => :environment do |t, args|
+    BulkTagger.new(args[:file], :list).run
+  end
 end

--- a/lib/tasks/tags.rake
+++ b/lib/tasks/tags.rake
@@ -1,0 +1,8 @@
+require Rails.root.join('lib', 'task-helpers', 'bulk_tagger.rb')
+
+namespace :tags do
+  desc 'bulk tag a csv of entities'
+  task :entity, [:file] => :environment do |t, args|
+    BulkTagger.new(args[:file], :entity).run
+  end
+end

--- a/spec/lib/bulk_tagging_spec.rb
+++ b/spec/lib/bulk_tagging_spec.rb
@@ -18,7 +18,7 @@ describe 'BulkTagging' do
       allow(File).to receive(:open).and_return(double(:read => csv))
     end
 
-    let(:tagger) { BulkTagger.new('tags.csv') }
+    let(:tagger) { BulkTagger.new('tags.csv', :entity) }
 
     def tagable_mock(tags)
       double('tagable').tap do |double|
@@ -27,6 +27,7 @@ describe 'BulkTagging' do
     end
 
     it 'tags entities with the provided tags' do
+      expect(tagger).to receive(:tag_related_entities).twice
       expect(Entity).to receive(:find).with('123')
                           .and_return(tagable_mock(['nyc']))
       expect(Entity).to receive(:find).with('456')

--- a/spec/lib/bulk_tagging_spec.rb
+++ b/spec/lib/bulk_tagging_spec.rb
@@ -1,24 +1,41 @@
 require 'rails_helper'
-require Rails.root.join('lib', 'task-helpers', 'bulk_tagging.rb')
+require 'csv'
+require Rails.root.join('lib', 'task-helpers', 'bulk_tagger.rb')
 
 describe 'BulkTagging' do
-  # let(:entity1) { build(:org) }
-  # let(:entity2) { build(:person) }
+  context 'Tagging entites' do
+    let(:csv) do
+      CSV.generate do |csv|
+        csv << ['entity_url', 'tags', 'tag_all_related']
+        csv << ['https://littlesis.org/org/123/org_name', 'nyc', '']
+        csv << ['https://littlesis.org/org/456-org_name', 'oil', '']
+        csv << ['/person/789-person_name', 'nyc oil', '']
+        csv << ['http://littlesis.org/person/1000/person_name', 'georgia', '']
+      end
+    end
 
-  # let(:entities) do
-  #   Array.new(3) { build(:org) }
-  # end
-  # let(:csv) do
-  # end
-  # context 'Tagging entites' do
-  #   let(:csv) do
-  #     (['entity_url,tags,tag_all_related'] +
-  #       entities.map { |e| entity_url(e) + ',' + 'oil nyc,' }).join("\n")
-  #   end
-    
-  #   it 'It tags entity by tag' do
-  #     puts csv
-  #     expect(true).to be true
-  #   end
-  # end
+    before do
+      allow(File).to receive(:open).and_return(double(:read => csv))
+    end
+
+    let(:tagger) { BulkTagger.new('tags.csv') }
+
+    def tagable_mock(tags)
+      double('tagable').tap do |double|
+        tags.each { |t| expect(double).to receive(:tag).with(t) }
+      end
+    end
+
+    it 'It tags entity by tag' do
+      expect(Entity).to receive(:find).with('123')
+                          .and_return(tagable_mock(['nyc']))
+      expect(Entity).to receive(:find).with('456')
+                          .and_return(tagable_mock(['oil']))
+      expect(Entity).to receive(:find).with('789')
+                          .and_return(tagable_mock(['nyc', 'oil']))
+      expect(Entity).to receive(:find).with('1000')
+                          .and_return(tagable_mock(['georgia']))
+      tagger.run
+    end
+  end
 end

--- a/spec/lib/bulk_tagging_spec.rb
+++ b/spec/lib/bulk_tagging_spec.rb
@@ -3,6 +3,11 @@ require 'csv'
 require Rails.root.join('lib', 'task-helpers', 'bulk_tagger.rb')
 
 describe 'BulkTagging' do
+  let(:csv) { '' }
+  before(:each) do
+    allow(File).to receive(:open).and_return(double(:read => csv))
+  end
+
   context 'Tagging entites' do
     let(:csv) do
       CSV.generate do |csv|
@@ -12,10 +17,6 @@ describe 'BulkTagging' do
         csv << ['/person/789-person_name', 'nyc oil', 'TRUE']
         csv << ['http://littlesis.org/person/1000/person_name', 'georgia', '']
       end
-    end
-
-    before do
-      allow(File).to receive(:open).and_return(double(:read => csv))
     end
 
     let(:tagger) { BulkTagger.new('tags.csv', :entity) }
@@ -60,6 +61,20 @@ describe 'BulkTagging' do
       expect(Entity).to receive(:find).with('1000').and_return(spy)
       tagger.run
     end
-    
+  end
+
+  context 'Tagging lists' do
+    let(:tagger) { BulkTagger.new('tags.csv', :list) }
+    let(:csv) do
+      CSV.generate do |csv|
+        csv << ['list_url', 'tags', 'tag_all_in_list']
+        csv << ["https://littlesis.org/lists/1232-donor-crossover-list-1234/members", 'nyc', '']
+        csv << ["https://littlesis.org/lists/152-austerity-puppetmasters", 'oil', '']
+        csv << ["/lists/1327-cofina-plaintiffs-likely-parent-companies/members", 'georgia oil', 'YES']
+      end
+    end
+
+    it 'tags lists' do
+    end
   end
 end

--- a/spec/lib/bulk_tagging_spec.rb
+++ b/spec/lib/bulk_tagging_spec.rb
@@ -8,8 +8,8 @@ describe 'BulkTagging' do
       CSV.generate do |csv|
         csv << ['entity_url', 'tags', 'tag_all_related']
         csv << ['https://littlesis.org/org/123/org_name', 'nyc', '']
-        csv << ['https://littlesis.org/org/456-org_name', 'oil', '']
-        csv << ['/person/789-person_name', 'nyc oil', '']
+        csv << ['https://littlesis.org/org/456-org_name', 'oil', 'Y']
+        csv << ['/person/789-person_name', 'nyc oil', 'TRUE']
         csv << ['http://littlesis.org/person/1000/person_name', 'georgia', '']
       end
     end
@@ -26,7 +26,7 @@ describe 'BulkTagging' do
       end
     end
 
-    it 'It tags entity by tag' do
+    it 'tags entities with the provided tags' do
       expect(Entity).to receive(:find).with('123')
                           .and_return(tagable_mock(['nyc']))
       expect(Entity).to receive(:find).with('456')
@@ -37,5 +37,28 @@ describe 'BulkTagging' do
                           .and_return(tagable_mock(['georgia']))
       tagger.run
     end
+
+    def entity_whose_related_entities_will_be_tagged(tags)
+      entity = tagable_mock(tags)
+      mock_links = [ build(:link), build(:link) ]
+      expect(entity).to receive(:links).and_return(mock_links)
+      mock_links.each do |link|
+        other_entity = build(:org)
+        expect(Entity).to receive(:find).with(link.entity2_id).and_return(other_entity)
+        tags.each { |t| expect(other_entity).to receive(:tag).with(t) }
+      end
+      entity
+    end
+
+    it 'tags all related entities' do
+      expect(Entity).to receive(:find).with('123').and_return(tagable_mock(['nyc']))
+      expect(Entity).to receive(:find).with('456')
+                          .and_return(entity_whose_related_entities_will_be_tagged(['oil']))
+      expect(Entity).to receive(:find).with('789')
+                          .and_return(entity_whose_related_entities_will_be_tagged(['nyc', 'oil']))
+      expect(Entity).to receive(:find).with('1000').and_return(spy)
+      tagger.run
+    end
+    
   end
 end


### PR DESCRIPTION
Adds two new rake tasks:

> tags:entity[file]
> tags:list[file]

If you provide a path to a csv file it will process the file and tag the entities or lists.

**csv headers for entity:**

```
| entity_url | tags | tag_all_related |
```

**csv headers for list:**

```
| list_url | tags | tag_all_in_list |
```

tags can be any number of tags separated by a space. i.e.: ``` georgia fracking finance ```. Capitalization doesn't matter, but the tags must already exist in the system. 

if _tag_all_related_ is selected, it will tag all entities that the entity is related to. if _tag_all_in_list_ is picked, it will tag all entities in that list. 

Resolves #296 