### PR TITLE
Restoring deleted entities and relationships

### DIFF
--- a/app/models/concerns/tagable.rb
+++ b/app/models/concerns/tagable.rb
@@ -34,6 +34,13 @@ module Tagable
                               tagable_id:     self.id)
   end
 
+  def tag_without_callbacks(name_or_id)
+    Tagging.skip_callback(:save, :after, :update_tagable_timestamp)
+    tag(name_or_id)
+  ensure
+    Tagging.set_callback(:save, :after, :update_tagable_timestamp)
+  end
+
   def remove_tag(name_or_id)
     taggings
       .find_by_tag_id(parse_tag_id!(name_or_id))

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -729,7 +729,8 @@ class Entity < ActiveRecord::Base
     {
       'extension_ids' => extension_ids,
       'relationship_ids' => relationship_ids,
-      'aliases' => aliases.where(is_primary: false).map(&:name)
+      'aliases' => aliases.where(is_primary: false).map(&:name),
+      'tags' => tags.map(&:name)
     }
   end
 
@@ -747,6 +748,7 @@ class Entity < ActiveRecord::Base
     images.each(&:soft_delete)
     list_entities.each(&:soft_delete)
     relationships.each(&:soft_delete)
+    taggings.destroy_all
     # ArticleEntity
   end
 

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -736,7 +736,7 @@ class Entity < ActiveRecord::Base
 
   # Restores (un-deletes) an entity
   def restore!
-    raise "Cannot restore an entity unles the entity has been deleted" unless is_deleted
+    raise Exceptions::CannotRestoreError unless is_deleted
     association_data = retrive_deleted_association_data
 
     # TODO: when associaiton_data is nil

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -734,6 +734,15 @@ class Entity < ActiveRecord::Base
     }
   end
 
+  def restore!
+    raise "Cannot restore an entity unles the entity has been deleted" unless is_deleted
+    association_data = YAML.load(versions.last.association_data)
+    create_primary_ext
+    add_extensions_by_def_ids(association_data['extension_ids'])
+
+    update_attribute(:is_deleted, false)
+  end
+
   def description
     blurb
   end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -737,7 +737,7 @@ class Entity < ActiveRecord::Base
   # un-deletes an entity
   # Essentially this just reverts
   # what happens in #after_soft_delete
-  def restore!
+  def restore!(restore_relationships = false)
     raise Exceptions::CannotRestoreError unless is_deleted
     association_data = retrieve_deleted_association_data
     raise Exceptions::MissingEntityAssociationDataError if association_data.nil?
@@ -754,8 +754,10 @@ class Entity < ActiveRecord::Base
 
     update(is_deleted: false)
 
-    association_data['relationship_ids'].each do |rel_id|
-      Relationship.unscoped.find(rel_id).restore!
+    if restore_relationships
+      association_data['relationship_ids'].each do |rel_id|
+        Relationship.unscoped.find(rel_id).restore!
+      end
     end
   end
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -505,6 +505,16 @@ class Relationship < ActiveRecord::Base
     "#{entity.name} #{description_sentence[0]} #{related.name} #{description_sentence[1]}"
   end
 
+  def restore!(skip_entity_check = nil)
+    raise Exceptions::CannotRestoreError unless is_deleted
+
+    # return nil if (entity1_id !== skip_entity_check) && entity.nil?
+    # return nil if (entity2_id !== skip_entity_check) && related.empty?
+    
+    # run_callbacks :create
+    # update_entity_links
+  end
+
   private
 
   def last_user_id_for_entity_update(sf_user_id = nil)

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -505,14 +505,11 @@ class Relationship < ActiveRecord::Base
     "#{entity.name} #{description_sentence[0]} #{related.name} #{description_sentence[1]}"
   end
 
-  def restore!(skip_entity_check = nil)
+  def restore!
     raise Exceptions::CannotRestoreError unless is_deleted
-
-    # return nil if (entity1_id !== skip_entity_check) && entity.nil?
-    # return nil if (entity2_id !== skip_entity_check) && related.empty?
-    
-    # run_callbacks :create
-    # update_entity_links
+    return nil if entity.nil? || related.nil? || entity.is_deleted || related.is_deleted
+    run_callbacks :create
+    update(is_deleted: false)
   end
 
   private

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -3,4 +3,9 @@ module Exceptions
   class NotFoundError < StandardError; end
   class MissingApiTokenError < StandardError; end
   class RestrictedUserError < StandardError; end
+  class CannotRestoreError < StandardError
+    def message
+      "Cannot restore a model that has not yet been deleted"
+    end
+  end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -8,4 +8,10 @@ module Exceptions
       "Cannot restore a model that has not yet been deleted"
     end
   end
+
+  class MissingEntityAssociationDataError < StandardError
+    def message
+      "Missing association data for this Entity"
+    end
+  end
 end

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -32,7 +32,10 @@ describe EntitiesController, type: :controller do
     let(:entity) { create(:entity_org, updated_at: Time.now) }
 
     describe "/entity/id" do
-      before { get(:show, id: entity.id) }
+      before do
+        expect(Entity).to receive(:search)
+        get(:show, id: entity.id)
+      end
       it { should render_template(:show) }
     end
 

--- a/spec/models/entity_deleting_spec.rb
+++ b/spec/models/entity_deleting_spec.rb
@@ -104,8 +104,19 @@ describe 'Deleting an Entity', type: :model do
         expect { business_academic.soft_delete }
           .to change { Relationship.unscoped.find(rel.id).is_deleted }.to(true)
 
-        expect { business_academic.restore! }
+        expect { business_academic.restore!(true) }
           .to change { Relationship.unscoped.find(rel.id).is_deleted }.to(false)
+      end
+
+      it "does not restore the entity's relationships" do
+        business_academic
+        rel = Relationship.create!(entity: entity, related: business_academic, category_id: Relationship::GENERIC_CATEGORY)
+
+        expect { business_academic.soft_delete }
+          .to change { Relationship.unscoped.find(rel.id).is_deleted }.to(true)
+
+        expect { business_academic.restore! }
+          .not_to change { Relationship.unscoped.find(rel.id).is_deleted }
       end
 
       it "raises error if missing association data" do

--- a/spec/models/entity_deleting_spec.rb
+++ b/spec/models/entity_deleting_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'Deleting an Entity', type: :model do
+  describe 'Deleting an entity with tags' do
+    let(:tags) do
+      { oil: create(:oil_tag), nyc: create(:nyc_tag) }
+    end
+    let(:entity) do
+      entity = create(:entity_org)
+      entity.tag('oil')
+      entity.tag('nyc')
+      entity
+    end
+
+    with_versioning do
+      before { tags }
+
+      it 'saves tags on paper trail version' do
+        entity.soft_delete
+        version = Entity.unscoped.find(entity.id).versions.last
+        expect(YAML.load(version.association_data)['tags']).to eql %w(oil nyc)
+      end
+
+      it 'deletes the taggings' do
+        entity
+        expect { entity.soft_delete }.to change { Tagging.count }.by(-2)
+      end
+    end
+
+  end
+end

--- a/spec/models/entity_deleting_spec.rb
+++ b/spec/models/entity_deleting_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 describe 'Deleting an Entity', type: :model do
+  let(:tags) { { oil: create(:oil_tag), nyc: create(:nyc_tag) } }
+
   describe 'Deleting an entity with tags' do
-    let(:tags) do
-      { oil: create(:oil_tag), nyc: create(:nyc_tag) }
-    end
     let(:entity) do
       entity = create(:entity_org)
       entity.tag('oil')
@@ -32,9 +31,21 @@ describe 'Deleting an Entity', type: :model do
     with_versioning do
       let(:entity) { create(:entity_org) }
 
+      let(:business_academic) do
+        tags
+        person = create(:entity_person) #, last_user_id: APP_CONFIG['system_user_id'])
+        person.aliases.create!(name: Faker::TwinPeaks.character)
+        person.add_extension('BusinessPerson')
+        person.add_extension('Academic')
+        person.tag('oil')
+        person.tag('nyc')
+        person.images.create!(filename: Faker::File.file_name(nil, nil,'png'), title: 'image')
+        person
+      end
+
       it 'raises error if entity is not deleted' do
         expect { build(:entity_org, is_deleted: false).restore! }.to raise_error(StandardError)
-        #expect { create(:entity_org, is_deleted: true).restore! }.not_to raise_error
+        # expect { create(:entity_org, is_deleted: true).restore! }.not_to raise_error
       end
 
       it 'reverts is_deleted state' do
@@ -44,13 +55,6 @@ describe 'Deleting an Entity', type: :model do
       end
 
       context 'extensions' do
-        let(:business_academic) do
-          person = create(:entity_person)
-          person.add_extension('BusinessPerson')
-          person.add_extension('Academic')
-          person
-        end
-
         before do
           business_academic.soft_delete
           business_academic.reload
@@ -70,17 +74,29 @@ describe 'Deleting an Entity', type: :model do
           [1, 29, 31].each do |definition_id|
             expect(business_academic.extension_records.map(&:definition_id)).to include definition_id
           end
-          
         end
-
       end
 
-      it 'restores it\'s images' do
+      it "restores it's images" do
+        business_academic
+        expect { business_academic.soft_delete }.to change { Image.count }.by(-1)
+        expect { business_academic.restore! }.to change { Image.count }.by(1)
       end
 
-      it 're-creates aliases'
+      it 're-creates aliases' do
+        business_academic
+        alias_name = business_academic.aliases.where(is_primary: false).first.name
+        expect { business_academic.soft_delete }.to change { Alias.count }.by(-2)
+        expect { business_academic.restore! }.to change { Alias.count }.by(2)
+        expect(business_academic.reload.primary_alias.name).to eql business_academic.name
+        expect(business_academic.aliases.where(is_primary: false).first.name).to eql alias_name
+      end
 
-      it "re-creates the entity's taggings"
+      it "re-creates the entity's taggings" do
+        business_academic
+        expect { business_academic.soft_delete }.to change { Tagging.count }.by(-2)
+        expect { business_academic.restore! }.to change  { Tagging.count }.by(2)
+      end
 
       context 'entity relationships' do
         it 'un-deletes relationships if the other entity in the relationship has not been deleted'

--- a/spec/models/entity_deleting_spec.rb
+++ b/spec/models/entity_deleting_spec.rb
@@ -44,7 +44,7 @@ describe 'Deleting an Entity', type: :model do
       end
 
       it 'raises error if entity is not deleted' do
-        expect { build(:entity_org, is_deleted: false).restore! }.to raise_error(StandardError)
+        expect { build(:entity_org, is_deleted: false).restore! }.to raise_error(Exceptions::CannotRestoreError)
         # expect { create(:entity_org, is_deleted: true).restore! }.not_to raise_error
       end
 

--- a/spec/models/entity_deleting_spec.rb
+++ b/spec/models/entity_deleting_spec.rb
@@ -26,6 +26,66 @@ describe 'Deleting an Entity', type: :model do
         expect { entity.soft_delete }.to change { Tagging.count }.by(-2)
       end
     end
+  end
 
+  describe 'restore!' do
+    with_versioning do
+      let(:entity) { create(:entity_org) }
+
+      it 'raises error if entity is not deleted' do
+        expect { build(:entity_org, is_deleted: false).restore! }.to raise_error(StandardError)
+        #expect { create(:entity_org, is_deleted: true).restore! }.not_to raise_error
+      end
+
+      it 'reverts is_deleted state' do
+        entity
+        expect { entity.soft_delete }.to change { entity.is_deleted }.to(true)
+        expect { entity.restore! }.to change { entity.is_deleted }.to(false)
+      end
+
+      context 'extensions' do
+        let(:business_academic) do
+          person = create(:entity_person)
+          person.add_extension('BusinessPerson')
+          person.add_extension('Academic')
+          person
+        end
+
+        before do
+          business_academic.soft_delete
+          business_academic.reload
+        end
+
+        it 're-creates extension_models' do
+          expect(business_academic.business_person).to be nil
+          business_academic.restore!
+          expect(business_academic.business_person).to be_a BusinessPerson
+        end
+
+        it 're-creates extension_records' do
+          expect(business_academic.extension_records.length).to be_zero
+          business_academic.restore!
+          expect(business_academic.reload.extension_records.length).to eql 3
+
+          [1, 29, 31].each do |definition_id|
+            expect(business_academic.extension_records.map(&:definition_id)).to include definition_id
+          end
+          
+        end
+
+      end
+
+      it 'restores it\'s images' do
+      end
+
+      it 're-creates aliases'
+
+      it "re-creates the entity's taggings"
+
+      context 'entity relationships' do
+        it 'un-deletes relationships if the other entity in the relationship has not been deleted'
+        it 'restores relationship links'
+      end
+    end
   end
 end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -151,7 +151,17 @@ describe Entity, :tag_helper  do
   end
 
   describe 'get_association_data' do
-    let(:association_data) { public_company.get_association_data }
+    let(:company) do
+      org = create(:entity_org)
+      org.tag('oil')
+      org.tag('nyc')
+      org.aliases.create!(name: 'another name')
+      Relationship.create!(entity: org, related: create(:entity_person), category_id: 12)
+      org.add_extension('PublicCompany')
+      org
+    end
+
+    let(:association_data) { company.get_association_data }
 
     it 'has extension ids' do
       expect(association_data['extension_ids']).to eql [2, 13]
@@ -163,6 +173,10 @@ describe Entity, :tag_helper  do
 
     it 'has aliases' do
       expect(association_data['aliases']).to eql ['another name']
+    end
+
+    it 'has tags' do
+      expect(association_data['tags']).to eq ['oil', 'nyc']
     end
   end
 

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -587,15 +587,22 @@ describe Relationship, type: :model do
     end
   end
 
-  context 'Using paper_trail for versioning' do
+  describe 'restore!' do
     with_versioning do
-      before do
-        @human = create(:person)
-        @corp = create(:corp)
+      it 'raises error if called on a model that is not deleted' do
+        expect { build(:relationship, is_deleted: false).restore! }.to raise_error(Exceptions::CannotRestoreError)
       end
+    end
+  end
 
+
+  context 'Using paper_trail for versioning' do
+    let(:human) { create(:entity_person) }
+    let(:corp) { create(:entity_org) }
+
+    with_versioning do
       it 'records created, modified, and deleted versions' do
-        rel = Relationship.create!(entity1_id: @human.id, entity2_id: @corp.id, category_id: 12)
+        rel = Relationship.create!(entity1_id: human.id, entity2_id: corp.id, category_id: 12)
         expect(rel.versions.size).to eq(1)
         rel.description1 = "important connection"
         rel.save
@@ -607,10 +614,10 @@ describe Relationship, type: :model do
       end
 
       it 'saves entity1 and entity2 metadata' do
-        rel = Relationship.create!(entity1_id: @human.id, entity2_id: @corp.id, category_id: 12)
+        rel = Relationship.create!(entity1_id: human.id, entity2_id: corp.id, category_id: 12)
         rel.update(description1: 'x')
-        expect(rel.versions.last.entity1_id).to eq @human.id
-        expect(rel.versions.last.entity2_id).to eq @corp.id
+        expect(rel.versions.last.entity1_id).to eq human.id
+        expect(rel.versions.last.entity2_id).to eq corp.id
       end
     end
   end


### PR DESCRIPTION
This adds a methods``` restore! ``` to both _Entity_ and _Relationship_.

If called on deleted models, it will un-delete them, including re-creating or restoring links, tags, and any other associations that existed. 

By default it won't restore an entities relationships, but if you can optionally  restore the relatioships:
 ``` entity#restore!(true) ```

#241 concerns just tags, although this pull requests concerns restoring all entity associations incuding tags