### PR TITLE
Direct users to page with instructions after they join

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -120,7 +120,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    home_dashboard_path
+    join_success_path
   end
 
   def after_update_path_for(resource)
@@ -142,10 +142,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   private
-  
+
   def reset_signup_session
     clean_up_passwords resource
     set_minimum_password_length
   end
-  
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit_permissions, :add_permission, :delete_permission, :destroy, :restrict]
-  before_action :authenticate_user!
-  before_filter :admins_only, except: [:show, :restrict]
+  before_action :authenticate_user!, except: [:success]
+  before_filter :admins_only, except: [:show, :restrict, :success]
 
   # get /users
   def index

--- a/app/views/users/success.html.erb
+++ b/app/views/users/success.html.erb
@@ -1,7 +1,9 @@
 <div class="row">
-    <div class="col-sm-8">
+    <div class="col-sm-12 col-md-10">
         <h2>Welcome to LittleSis!</h2>
         <p>Before you can starting editing you must confirm your email address.</p>
-        <p>You should have recieved an email with a confirmation link. If the email never arrives or if you are having any problems with the registration process please contact us at: <%=  mail_to "admin@littlesis.org" %></p>
+	<p>You recieve shortly an email with a confirmation link. If the email never arrives or if you are having any problems with the registration process please contact us at: <%=  mail_to "admin@littlesis.org" %></p>
+	<p> After confirming your email address, you'll be able to login using your email and password here: <%= link_to 'littlesis.org/login', new_user_session_path %></p>
+	
     </div>
 </div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -130,4 +130,10 @@ describe UsersController, type: :controller do
 
     end
   end
+
+  describe '#success' do
+    before { get :success }
+    it { should respond_with(200) }
+    it { should render_template('success') }
+  end
 end


### PR DESCRIPTION
resolves #250 

**Current Page:**

![join_success_page](https://user-images.githubusercontent.com/8505044/30445803-376b7222-9955-11e7-8418-127dcdc6cba1.png)


Perhaps later we can expand that page with more instructions or details?