### PR TITLE
Trim whitespace from name for entities and aliases

### DIFF
--- a/app/models/alias.rb
+++ b/app/models/alias.rb
@@ -6,6 +6,7 @@ class Alias < ActiveRecord::Base
   validates_presence_of :entity_id
   validates :name, length: { maximum: 200 }, presence: true
 
+  before_validation :trim_name_whitespace
   # Makes this alias the primary alias
   # -> boolean
   def make_primary
@@ -23,5 +24,10 @@ class Alias < ActiveRecord::Base
     person.name_regex(require_first)
   end
 
+  private
+
+  def trim_name_whitespace
+    self.name = self.name.strip unless self.name.nil?
+  end
 end
 

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -88,6 +88,7 @@ class Entity < ActiveRecord::Base
   validates :start_date, length: { maximum: 10 }, date: true
   validates :end_date, length: { maximum: 10 }, date: true
 
+  before_validation :trim_name_whitespace
   before_create :set_last_user_id
   after_create :create_primary_alias, :create_primary_ext, :add_to_default_network
 
@@ -804,5 +805,9 @@ class Entity < ActiveRecord::Base
 
   def extension_with_fields?(name)
     self.class.all_extension_names_with_fields.include?(name)
+  end
+
+  def trim_name_whitespace
+    self.name = self.name.strip unless self.name.nil?
   end
 end

--- a/spec/models/alias_spec.rb
+++ b/spec/models/alias_spec.rb
@@ -6,6 +6,12 @@ describe Alias, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:entity_id) }
 
+  it 'trim whitespace from name before validation' do
+    a = build(:alias, name: ' company name ', entity_id: rand(100))
+    expect(a.valid?).to be true
+    expect(a.name).to eq 'company name'
+  end
+
   describe '#make_primary' do
     it 'returns true if the element is already the primary alias' do
       expect(build(:alias, is_primary: true).make_primary).to be true

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -52,6 +52,14 @@ describe Entity, :tag_helper  do
         expect(build_entity(start_date: '').valid?).to be false
       end
     end
+
+    describe 'triming whitespace from name' do
+      it 'trims whitespace before vaidation' do
+        e = Entity.new(primary_ext: 'Person', name: ' jane smith  ')
+        expect(e.valid?).to be true
+        expect(e.name).to eql 'jane smith'
+      end
+    end
   end
 
   describe '#soft_delete' do


### PR DESCRIPTION
resolves #292 

Already existing entities can be fixed using this code:

``` rb
Entity.where("name REGEXP '^[ ].*'").each do |e|
  e.update_column(:name, e.name.strip)
end

Entity.where("name REGEXP '.*[ ]$'").each do |e|
  e.update_column(:name, e.name.strip)
end
```