### PR TITLE
Tag homepage grouped by tags

### DIFF
--- a/app/assets/stylesheets/styles/tags.scss
+++ b/app/assets/stylesheets/styles/tags.scss
@@ -160,7 +160,10 @@ input#tag_name {
             align-self: flex-end;
         }
     }
-    .tagable-list{
+    #tag-nav {
+        margin-top: 1em;
+    }
+    #tagable-list{
         margin: 1em 0 1em 0; // TRBL
         .tagable-list-header {
             background-color: $maroon;

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -3,7 +3,9 @@ class TagsController < ApplicationController
   before_action -> { check_permission('admin') }, except: [:index, :show, :tag_request]
   before_action :set_tag, only: [:edit, :update, :destroy, :show]
   before_action :set_tags, only: [:index]
-  before_action :set_taggings_by_class, only: [:show]
+  before_action :set_tagables, only: [:show]
+
+  TAGABLE_PAGINATION_LIMIT = 20
 
   def index; end
 
@@ -36,6 +38,13 @@ class TagsController < ApplicationController
     redirect_to admin_tags_path, notice: 'The tag has been removed'
   end
 
+  def entities
+    set_tag
+    render 'show'
+  end
+
+  # COMPLEX ACTIONS
+
   def tag_request
     if request.post?
       NotificationMailer.tag_request_email(current_user, params).deliver_later
@@ -49,15 +58,24 @@ class TagsController < ApplicationController
     params.require(:tag).permit(:name, :description, :restricted)
   end
 
+  def set_tagables
+    # TODO(ag|Thu 14 Sep 2017):
+    # consider using dynamic methods to create actions for each tagable class
+    # (corresponding to `tagable_category` string)
+    # instead of pulling `tagable_category` from params as here
+    @tagable_category = params[:tagable_category] || 'entities'
+    @tagables = @tag
+                .send(@tagable_category.to_sym)
+                .order(updated_at: :desc)
+                .page(params[:page])
+                .per(TAGABLE_PAGINATION_LIMIT)
+  end
+
   def set_tag
     @tag = Tag.find(params[:id])
   end
 
   def set_tags
     @tags = Tag.all.order(:name)
-  end
-
-  def set_taggings_by_class
-    @taggings_by_class = @tag.taggings_grouped_by_class(params)
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -38,11 +38,6 @@ class TagsController < ApplicationController
     redirect_to admin_tags_path, notice: 'The tag has been removed'
   end
 
-  def entities
-    set_tag
-    render 'show'
-  end
-
   # COMPLEX ACTIONS
 
   def tag_request

--- a/app/models/concerns/tagable.rb
+++ b/app/models/concerns/tagable.rb
@@ -6,16 +6,25 @@ module Tagable
     has_many :tags, through: :taggings
   end
 
+  class_methods do
+    def category_str
+      name.downcase.pluralize
+    end
+
+    def category_sym
+      category_str.to_sym
+    end
+  end
+
+  # str|sym -> ClassConstant
+  def self.class_of(category)
+    category.to_s.singularize.classify.constantize
+  end
+
+  # NOTE(@aguestuser): this constant *cannot* go before `included` and `class_methods` blocks
   TAGABLE_CLASSES = [Entity, List, Relationship]
 
-  # sorts a list of tagables in descending order of relationships to tagables w/ same tag
-  def self.sort_by_related_tagables(tagables)
-    tagables
-  end
-
-  def self.page_param_of(klass_name)
-    (klass_name.to_s.downcase + "_page").to_sym
-  end
+  # CRUD METHODS
 
   # [String|Int] -> Tagable
   def update_tags(ids)
@@ -32,6 +41,7 @@ module Tagable
     Tagging.find_or_create_by(tag_id:         parse_tag_id!(name_or_id),
                               tagable_class:  self.class.name,
                               tagable_id:     self.id)
+    self
   end
 
   def tag_without_callbacks(name_or_id)

--- a/app/models/concerns/tagable.rb
+++ b/app/models/concerns/tagable.rb
@@ -1,20 +1,7 @@
 module Tagable
   extend ActiveSupport::Concern
 
-  included do
-    has_many :taggings, as: :tagable, foreign_type: :tagable_class
-    has_many :tags, through: :taggings
-  end
-
-  class_methods do
-    def category_str
-      name.downcase.pluralize
-    end
-
-    def category_sym
-      category_str.to_sym
-    end
-  end
+  # Class methods on Tagable
 
   # () -> Array[ClassConstant]
   def self.classes
@@ -31,8 +18,24 @@ module Tagable
     category.to_s.singularize.classify.constantize
   end
 
-  # NOTE(@aguestuser): this constant *cannot* go before `included` and `class_methods` blocks
-  TAGABLE_CLASSES = [Entity, List, Relationship]
+  # Instance methods on Tagable instances
+
+  included do
+    has_many :taggings, as: :tagable, foreign_type: :tagable_class
+    has_many :tags, through: :taggings
+  end
+
+  # Class methods on Tagable instances
+
+  class_methods do
+    def category_str
+      name.downcase.pluralize
+    end
+
+    def category_sym
+      category_str.to_sym
+    end
+  end
 
   # CRUD METHODS
 

--- a/app/models/concerns/tagable.rb
+++ b/app/models/concerns/tagable.rb
@@ -16,6 +16,16 @@ module Tagable
     end
   end
 
+  # () -> Array[ClassConstant]
+  def self.classes
+    @classes ||= [Entity, List, Relationship].freeze
+  end
+
+  # () -> Array[Symbol]
+  def self.categories
+    @categories ||= classes.map(&:category_sym).freeze
+  end
+
   # str|sym -> ClassConstant
   def self.class_of(category)
     category.to_s.singularize.classify.constantize

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,8 +1,8 @@
 class Tag < ActiveRecord::Base
   has_many :taggings
-  has_many :tagables, through: :taggings, source: :tagable, source_type: Tagable
 
-  # creates polymorphic joins for all tagable classes
+  # create associations for all tagable classes
+  # ie: tag#entities, tag#lists, tag#relationships, etc...
   Tagable.classes.each do |klass|
     has_many klass.category_sym, through: :taggings, source: :tagable, source_type: klass
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,7 @@ class Tag < ActiveRecord::Base
   has_many :tagables, through: :taggings, source: :tagable, source_type: Tagable
 
   # creates polymorphic joins for all tagable classes
-  Tagable::TAGABLE_CLASSES.each do |klass|
+  Tagable.classes.each do |klass|
     has_many klass.category_sym, through: :taggings, source: :tagable, source_type: klass
   end
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -19,7 +19,7 @@
 
   <div id="tag-nav">
     <ul class="nav nav-tabs">
-      <% Tagable::TAGABLE_CLASSES.each do |tc|  %>
+      <% Tagable.classes.each do |tc|  %>
         <li role="presentation"
             id="tag-nav-tab-<%= tc.category_str%>"
             class=<%= tc == Tagable.class_of(@tagable_category) ? "active" : "inactive" %>
@@ -61,7 +61,7 @@
         </div>
 
       <% end #if !tagables.empty %>
-    </div> 
+    </div>
 
   <%# end # tagables_grouped_by_class.map%>
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -17,29 +17,37 @@
     </div>
   </div>
 
-  <% @taggings_by_class.each do |tagable_class, taggings|  %>
+  <div id="tag-nav">
+    <ul class="nav nav-tabs">
+      <% Tagable::TAGABLE_CLASSES.each do |tc|  %>
+        <li role="presentation"
+            id="tag-nav-tab-<%= tc.category_str%>"
+            class=<%= tc == Tagable.class_of(@tagable_category) ? "active" : "inactive" %>
+        >
+          <%=  link_to tc.category_str.capitalize,"/tags/#{@tag.id}/#{tc.category_str}" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 
-    <div class="tagable-list" id="tagable-list-<%= tagable_class.downcase.pluralize %>">
+  <%# @taggings_by_class.each do |tagable_class, taggings|  %>
+  
+    <div id="tagable-list">
 
-      <div class="tagable-list-header">
-        <%= "#{tagable_class.pluralize}" %>
-      </div>
-
-      <% if taggings.empty? %>
+      <% if @tagables.empty? %>
 
         <div class="tagable-list-empty-message">
-          <%= "There are no #{tagable_class.downcase.pluralize} tagged \"#{@tag.name}\"" %>
+          <%= "There are no #{@tagable_category} tagged \"#{@tag.name}\"" %>
         </div>
 
       <% else %>
 
         <ul class="tagable-list-items">
-          <% taggings.each_with_index do |tagging, i| %>
+          <% @tagables.each_with_index do |tagable, i| %>
             <div class="tagable-list-item">
-              <% tagable = tagging.tagable %>
-              <%= link_to tagable.name.titlecase, tagable, class: "tagable-list-item-name"%>
+              <%= link_to tagable.name, tagable, class: "tagable-list-item-name"%>
               <%= content_tag :div,
-                              "tagged #{time_ago_in_words(tagging.updated_at)} ago",
+                              "edited #{time_ago_in_words(tagable.updated_at)} ago",
                               class: "tagable-list-item-date"%>
               <%= content_tag :div,
                               truncate(tagable.description, length: 90),
@@ -49,12 +57,12 @@
         </ul>
 
         <div class="tagable-list-pagination">
-          <%= paginate taggings, param_name: Tagable.page_param_of(tagable_class) %>
+          <%= paginate @tagables %>
         </div>
 
       <% end #if !tagables.empty %>
     </div> 
 
-  <% end # tagables_grouped_by_class.map%>
+  <%# end # tagables_grouped_by_class.map%>
 
   <div class=".tag-show-container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,7 +278,10 @@ Lilsis::Application.routes.draw do
   post '/tags/request' => 'tags#tag_request'
   resources :tags, only: [:edit, :create, :update, :destroy, :show, :index] do
     member do
-      get '/:tagable_category' => 'tags#show', constraints: { tagable_category: /entities|lists|relationships/ }
+      get '/:tagable_category' => 'tags#show',
+          constraints: {
+            tagable_category: /#{Tagable.categories.join('|')}/
+          }
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,11 @@ Lilsis::Application.routes.draw do
 
   get '/tags/request' => 'tags#tag_request'
   post '/tags/request' => 'tags#tag_request'
-  resources :tags, only: [:edit, :create, :update, :destroy, :show, :index]
+  resources :tags, only: [:edit, :create, :update, :destroy, :show, :index] do
+    member do
+      get '/:tagable_category' => 'tags#show', constraints: { tagable_category: /entities|lists|relationships/ }
+    end
+  end
 
   #########
   # edits #

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -7,6 +7,7 @@ describe TagsController, type: :controller do
   it { should route(:post, '/tags').to(action: :create) }
   it { should route(:put, '/tags/456').to(action: :update, id: 456) }
   it { should route(:delete, '/tags/456').to(action: :destroy, id: 456) }
+  it { should route(:get, '/tags/456/entities').to(action: :show, id: 456, tagable_category: 'entities') }
   it { should route(:get, '/tags/request').to(action: :tag_request) }
   it { should route(:post, '/tags/request').to(action: :tag_request) }
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -7,7 +7,16 @@ describe TagsController, type: :controller do
   it { should route(:post, '/tags').to(action: :create) }
   it { should route(:put, '/tags/456').to(action: :update, id: 456) }
   it { should route(:delete, '/tags/456').to(action: :destroy, id: 456) }
-  it { should route(:get, '/tags/456/entities').to(action: :show, id: 456, tagable_category: 'entities') }
   it { should route(:get, '/tags/request').to(action: :tag_request) }
   it { should route(:post, '/tags/request').to(action: :tag_request) }
+  Tagable.categories.each do |tagable_category|
+    it do
+      should(route(:get, "/tags/456/#{tagable_category}")
+              .to(action: :show, id: 456, tagable_category: tagable_category))
+    end
+  end
+  it do
+    should(route(:get, "tags/456/not_a_tagable_category")
+            .to(controller: :errors, action: :not_found, path: "tags/456/not_a_tagable_category"))
+  end
 end

--- a/spec/factories/tagging.rb
+++ b/spec/factories/tagging.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     sequence(:tag_id)
     sequence(:tagable_id)
     sequence(:tagable_class) do |n|
-      Tagable::TAGABLE_CLASSES[n % Tagable::TAGABLE_CLASSES.size]
+      Tagable.classes[n % Tagable.classes.size]
     end
   end
   factory :open_tagging, class: Tagging  do

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -97,7 +97,7 @@ describe 'Tags', type: :feature do
       end
     end
 
-    Tagable::TAGABLE_CLASSES.map(&:category_str).each do |tagable_category|
+    Tagable.classes.map(&:category_str).each do |tagable_category|
 
       context "on #{tagable_category} tab" do
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -4,30 +4,27 @@ describe 'Tags', type: :feature do
 
   let(:tags) { Array.new(2) { create(:tag) } }
   let(:tag) { tags.first }
-  let(:entities) { Array.new(11) { create(:org) } }
-  let(:lists) { Array.new(11) { create(:list) } }
-  let(:relationships) do
-    Array.new(11) do
-      create(:generic_relationship, entity: entities.first, related: entities.second)
-    end
-  end
-  let(:tagables) { [entities, lists, relationships] }
-  
+
   # setup helpers
-  def update_time(tagable, i)
-    tagable.update_columns(updated_at: Time.now - (4 / (i + 1)).days)
+
+  def n_entities (n)
+    Array.new(n) { create(:org) }
   end
 
-  def n_tagables(n)
-    tagables.map { |ts| ts.take(n) }.flatten
+  def n_lists (n)
+    Array.new(n) { create(:list) }
   end
 
-  def name_of(tagable_class)
-    tagable_class.to_s.downcase.pluralize
+  def relate(x,y)
+    create(:generic_relationship, entity: x, related: y)
   end
 
-  def list_items_for(tagable_class)
-    page.all("#tagable-list-#{name_of(tagable_class)} .tagable-list-item")
+  def n_relationships(n)
+    Array.new(n) { relate(create(:entity_org), create(:entity_org)) }
+  end
+
+  def n_tagables(n, tagable_category)
+    self.send("n_#{tagable_category}".to_sym, n)
   end
 
   describe "tag index" do
@@ -72,124 +69,116 @@ describe 'Tags', type: :feature do
   end
   
   describe "tag homepage" do
-    context "with no taggings" do
+
+    context "with no tab specified" do
       before { visit "/tags/#{tag.id}" }
+
+      it "defaults to the entities tab" do
+        expect(page).to have_selector("#tag-nav-tab-entities.active")
+      end
 
       it "shows the tag title and description" do
         expect(page).to have_text tag.name
         expect(page).to have_text tag.description
       end
 
-      it "shows empty lists for all tagable types" do
-        Tagable::TAGABLE_CLASSES.each { |tc| should_be_empty_for(tc) }
-      end
-
-      def should_be_empty_for(tagable_class)
-        list = page.find("#tagable-list-#{name_of(tagable_class)}")
-        expect(list).to have_text "no #{name_of(tagable_class)} tagged"
-        expect(list).not_to have_selector '.tagable-list-item'
-      end
-    end
-
-    context "with less than 10 taggings" do
-
-      before do
-        n_tagables(2).each_with_index do |tagable, i|
-          # set dates for each collection in chronological order
-          # so that we will expect view to sort them in reverse
-          offset = 4 / ((i % 2) + 1)
-          tagable
-            .tag(tag.id)
-            .update_columns(updated_at: Time.now - offset.days)
-        end
-        visit "/tags/#{tag.id}"
-      end
-      
-      it "shows a list of tagables for each tagable type" do
-        Tagable::TAGABLE_CLASSES.each { |tc| should_show_tagable_list_for(tc) }
-      end
-
-      def should_show_tagable_list_for(tagable_class)
-        expect(page.find("#tagable-list-#{name_of(tagable_class)}"))
-          .to have_selector '.tagable-list-item', count: 2
-      end
-
-      it "renders the name of each tagable as a link" do
-        Tagable::TAGABLE_CLASSES.each_with_index do |tc, i|
-          should_show_name_as_link_for(tc, tagables[i])
-        end
-      end
-
-      def should_show_name_as_link_for(tagable_class, tagable_collection)
-        list_items_for(tagable_class).each_with_index do |item, i|
-          link = item.find('a.tagable-list-item-name')
-          tagable = tagable_collection.take(2).reverse[i] # b/c sorting by update reversed order
-          expect(link).to have_text(tagable.name.titlecase)
-          expect(link[:href]).to include(tagable.id.to_s)
-        end
-      end
-
-      it "shows a description of each tagable" do
-        Tagable::TAGABLE_CLASSES.each_with_index do |tc, i|
-          should_show_description_for(tc, tagables[i])
-        end
-      end
-
-      def should_show_description_for(tagable_class, tagable_collection)
-        list_items_for(tagable_class).each_with_index do |item, i|
-          tagable = tagable_collection.take(2).reverse[i] # b/c sorting by update reversed order
-          expect(item.find(".tagable-list-item-description")).to have_text(tagable.description)
-        end
-      end
-
-      it "displays last updated date for each tagable" do
-        Tagable::TAGABLE_CLASSES.each do |tc|
-          should_show_date_for(tc)
-        end
-      end
-
-      def should_show_date_for(tagable_class)
-        list_items_for(tagable_class).each do |item|
-          expect(item.find(".tagable-list-item-date")).to have_text("ago")
-        end
-      end
-
-      it "sorts each tagble list in reverse chronological order of last update" do
-        Tagable::TAGABLE_CLASSES.each do |tc|
-          should_be_sorted_by_update_date(tc)
-        end
-      end
-
-      def should_be_sorted_by_update_date(tagable_class)
-        dates = list_items_for(tagable_class).map { |x| x.find(".tagable-list-item-date") }
-        expect(dates.first).to have_text "2 days ago"
-        expect(dates.second).to have_text "4 days ago"
-      end
-
-      it "truncates descriptions longer than 90 charcaters" do
-        lists[1].update(description: "a" * 91) # second b/c sorting reverses order
-        visit "/tags/#{tag.id}"
-
-        expect(page.all("#tagable-list-lists .tagable-list-item-description").first.text)
-          .to eq "a" * 87 + "..."
+      # NOTE(ag|Thu 14 Sep 2017): this test would make more sense below
+      # *but* because we can't programatically set the description for
+      # every tagable in the same way, we do it here for convenience
+      it "truncates descriptions longer than 90 characters" do
+        n_tagables(1, Entity.category_str)
+          .first
+          .tag(tag.id)
+          .update(blurb: ("a" * 91))
+        refresh_page
+        expect(
+          page.all("#tagable-list .tagable-list-item-description").first.text
+        ).to eq("a" * 87 + "...")
       end
     end
 
-    context "with more than 10 taggings" do
-      before do
-        n_tagables(11).map { |t| t.tag(tag.id) }
-        visit "/tags/#{tag.id}"
-      end
+    Tagable::TAGABLE_CLASSES.map(&:category_str).each do |tagable_category|
 
-      it "only shows 10 tagables for each tagable type" do
-        Tagable::TAGABLE_CLASSES.each { |tc| should_paginate_for(tc) }
-      end
+      context "on #{tagable_category} tab" do
 
-      def should_paginate_for(tagable_class)
-        expect(page.find("#tagable-list-#{name_of(tagable_class)}"))
-          .to have_selector '.tagable-list-item', count: 10
+        context "no tagged #{tagable_category}" do
+          before { visit "/tags/#{tag.id}/#{tagable_category}"}
+
+          it "shows an empty list message" do
+            expect(page).not_to have_selector '.tagable-list-item'
+            expect(page.find("#tagable-list")).to have_text "no #{tagable_category} tagged"
+          end
+        end
+
+        context "less than 20 tagged #{tagable_category}" do
+          let(:tagables){ n_tagables(2, tagable_category) }
+
+          before do
+            tagables.each_with_index do |tagable, i|
+              # set dates for each collection in chronological order
+              # so that we will expect view to sort them in reverse
+              offset = (4 / (i + 1)).days
+              tagable
+                .tag(tag.id)
+                .update_columns(updated_at: Time.now - offset)
+            end
+            visit "/tags/#{tag.id}/#{tagable_category}"
+          end
+
+          it "shows the tag title and description" do
+            expect(page).to have_text tag.name
+            expect(page).to have_text tag.description
+          end
+
+          it "shows a list of tagged entities" do
+            expect(page.find("#tagable-list"))
+              .to have_selector '.tagable-list-item', count: 2
+          end
+
+          it "renders the name of each entity as a link" do
+            page.all("#tagable-list .tagable-list-item").each_with_index do |item, i|
+              tagable = tagables.reverse[i] # b/c sorting by update reversed order
+              link = item.find('a.tagable-list-item-name')
+
+              expect(link).to have_text(tagable.name)
+              expect(link[:href]).to include(tagable.id.to_s)
+            end
+          end
+
+          it "shows a description of each entity" do
+            page.all("#tagable-list .tagable-list-item").each_with_index do |item, i|
+              tagable = tagables.reverse[i] # b/c sorting by update reversed order
+              expect(item.find(".tagable-list-item-description")).to have_text(tagable.description)
+            end
+          end
+
+          it "displays last updated date for each entity" do
+            page.all("#tagable-list .tagable-list-item").each do |item|
+              expect(item.find(".tagable-list-item-date")).to have_text("ago")
+            end
+          end
+
+          it "sorts the entity list in reverse chronological order of last update" do
+            list_items = page.all("#tagable-list .tagable-list-item")
+            dates = list_items.map{ |x| x.find(".tagable-list-item-date") }
+            expect(dates.first).to have_text "2 days ago"
+            expect(dates.second).to have_text "4 days ago"
+          end
+        end
+
+        context "more than 20 tagged #{tagable_category}" do
+          let(:tagables) { n_tagables(21, tagable_category) }
+          before do
+            tagables.map { |t| t.tag(tag.id) }
+            visit "/tags/#{tag.id}/#{tagable_category}"
+          end
+
+          it "only shows 10 entities with pagination bar" do
+            expect(page.find("#tagable-list"))
+              .to have_selector '.tagable-list-item', count: 20
+          end
+        end
       end
     end
   end
 end
-;

--- a/spec/models/concerns/tagable_spec.rb
+++ b/spec/models/concerns/tagable_spec.rb
@@ -43,7 +43,7 @@ describe Tagable, type: :model do
     before { entity.tag(tag_id) }
 
     it "responds to interface methods" do
-      Tagable::TAGABLE_CLASSES.each do |tagable_class|
+      Tagable.classes.each do |tagable_class|
         tagable = tagable_class.new
         expect(tagable).to respond_to(:tag)
         expect(tagable).to respond_to(:tags)
@@ -65,22 +65,40 @@ describe Tagable, type: :model do
 
   describe "class methods" do
 
-    it "provides pluralized symbol for tagable category" do
-      expect(Entity.category_sym).to eq(:entities)
-      expect(List.category_sym).to eq(:lists)
-      expect(Relationship.category_sym).to eq(:relationships)
+    describe"on Tagable module itself" do
+
+      it "enumerates all Tagable classes" do
+        expect(Tagable.classes).to eq([Entity, List, Relationship])
+      end
+
+      it "enumerates all Tagable categories" do
+        expect(Tagable.categories).to eq(%i[entities lists relationships])
+      end
+
+      it "generates a class name from a category symbol" do
+        Tagable.categories.zip(Tagable.classes).each do |category, klass|
+          expect(Tagable.class_of(category)).to eq klass
+        end
+      end
     end
 
-    it "provides pluralized string for tagable category" do
-      expect(Entity.category_str).to eq('entities')
-      expect(List.category_str).to eq('lists')
-      expect(Relationship.category_str).to eq('relationships')
-    end
+    describe "on tagable instances" do
 
-    it "generates a class name from a category symbol" do
-      expect(Tagable.class_of(:entities)).to eq Entity
-      expect(Tagable.class_of(:lists)).to eq List
-      expect(Tagable.class_of(:relationships)).to eq Relationship
+      it "does not expose Tagable class methods" do
+        expect(Entity).not_to respond_to(:classes)
+      end
+
+      it "provides pluralized symbol for tagable category" do
+        expect(Entity.category_sym).to eq(:entities)
+        expect(List.category_sym).to eq(:lists)
+        expect(Relationship.category_sym).to eq(:relationships)
+      end
+
+      it "provides pluralized string for tagable category" do
+        expect(Entity.category_str).to eq('entities')
+        expect(List.category_str).to eq('lists')
+        expect(Relationship.category_str).to eq('relationships')
+      end
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -22,31 +22,15 @@ describe Tag do
       it { should validate_presence_of(:description) }
     end
 
+    describe "associations" do
+      Tagable::TAGABLE_CLASSES.each do |klass|
+        it { should have_many(klass.category_sym) }
+      end
+    end
+
     it 'can determine if a tag is restricted' do
       expect(tag.restricted?).to be false
       expect(restricted_tag.restricted?).to be true
-    end
-  end
-
-  describe "custom queries" do
-
-    let(:tag) { create(:tag) }
-    let(:entities) { Array.new(2) { create(:org) } }
-    let(:lists) { Array.new(2) { create(:list) } }
-    let(:relationships) do
-      Array.new(2) do
-        create(:generic_relationship, entity: entities.first, related: entities.second)
-      end
-    end
-    let(:tagables) { entities + lists + relationships }
-
-    before { tagables.map { |t| t.tag(tag.id) } }
-
-    it "queries tagables grouped by resource type" do
-      taggings = tag.taggings_grouped_by_class
-      expect(taggings['List'].map(&:tagable)).to eq lists
-      expect(taggings['Entity'].map(&:tagable)).to eq entities
-      expect(taggings['Relationship'].map(&:tagable)).to eq relationships
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -23,7 +23,7 @@ describe Tag do
     end
 
     describe "associations" do
-      Tagable::TAGABLE_CLASSES.each do |klass|
+      Tagable.classes.each do |klass|
         it { should have_many(klass.category_sym) }
       end
     end


### PR DESCRIPTION
resolves #306

______

# Screenshots:

**entities tab**

![tag-homepage-entities](https://user-images.githubusercontent.com/6032844/30447143-2373bcc6-9959-11e7-9d39-bc385732767e.png)


**empty state**

![tags-homepage-empty](https://user-images.githubusercontent.com/6032844/30447201-4eb86648-9959-11e7-825d-dea7905a5d5a.png)


**lists tab**

![tag-homepage-lists](https://user-images.githubusercontent.com/6032844/30447160-2f717eaa-9959-11e7-9d68-25c315bfd079.png)


**relationships tab**

![tag-homepage-relationships](https://user-images.githubusercontent.com/6032844/30447165-342b097a-9959-11e7-8b4b-1e37fa215820.png)


______

# Implementation notes:

* use `tags/:id/:tag_category` route to infer tag list from params
* introduce `has_many through` associations between `Tag` and any `Tagable` instance
* use these associations to hand `Tagable` instances to homepage view instead of  `Tagging` instances, eliminate `#group_taggings_by_class`
* introduce convention of `tag_category` (always pluralized, downcased version of tagable's class name)
* replace `Tagable#TAGABLE_CLASSES` with `Tagable.classes` (only accessible on `Tagable` module itself, *not* classes that include it)
* add `Tagable.categories` method that enumerates a tagable category (lowercase plural string) for each tagable class
* use `Tagable.categories` to safely/extensibly place constraints on values of `tagable_category` that may be passed to `tags#show` route
* add helper class methods for conversion btw/ class names &  categories
* `Tagable#tag` now returns the `Tagable` that called the method instead of the `Tagging` it created
* refactor tag homepage specs:
  * use `n_tagables` factory method in each group to create tagables only as needed (perf optimization)
  * dry up code by recyclying context/it blocks for each tagable category relationships, lists


