### PR TITLE
Entity tab on tag homepage grouped by type

### DIFF
--- a/app/assets/stylesheets/styles/tags.scss
+++ b/app/assets/stylesheets/styles/tags.scss
@@ -163,46 +163,48 @@ input#tag_name {
     #tag-nav {
         margin-top: 1em;
     }
-    #tagable-list{
-        margin: 1em 0 1em 0; // TRBL
-        .tagable-list-header {
-            background-color: $maroon;
-            color: white;
-            padding: .2em 0 .2em .4em; // TRBL
-            border-radius: 0.2em;
-            font-size: 1.5em;
-        }
-        .tagable-list-empty-message {
-            margin: 1em;
-            font-style: italic;
-        }
-        .tagable-list-items {
-            display: flex;
-            flex-direction: column;
-            margin: 1em 0 1em -2em; // TRBL
-            .tagable-list-item {
+    #tagable-lists{
+        .tagable-list {
+            margin: 1em 0 1em 0; // TRBL
+            .tagable-list-subheader {
+                background-color: $maroon;
+                color: white;
+                padding: .2em 0 .2em .4em; // TRBL
+                border-radius: 0.2em;
+                font-size: 1.5em;
+            }
+            .tagable-list-empty-message {
+                margin: 1em;
+                font-style: italic;
+            }
+            .tagable-list-items {
                 display: flex;
-                flex-direction: row;
-                align-items: flex-end;
-                align-content: flex-start;
-                lign-height: 1.5em;
-                .tagable-list-item-name {
-                    white-space: nowrap;
-                }
-                .tagable-list-item-description {
-                    text-align: left;
-                    margin-left: .5em;
-                    font-size: .8em;
-                    color: gray;
-                    font-style: italic;
-                }
-                .tagable-list-item-sort-info {
-                    margin-left: 1em;
-                    padding: .1em .5em .1em .5em;
-                    font-size: .6em;
-                    background-color: lightgray;
-                    border-radius: .2em;
-                    color: white;
+                flex-direction: column;
+                margin: 1em 0 1em -2em; // TRBL
+                .tagable-list-item {
+                    display: flex;
+                    flex-direction: row;
+                    align-items: flex-end;
+                    align-content: flex-start;
+                    lign-height: 1.5em;
+                    .tagable-list-item-name {
+                        white-space: nowrap;
+                    }
+                    .tagable-list-item-description {
+                        text-align: left;
+                        margin-left: .5em;
+                        font-size: .8em;
+                        color: gray;
+                        font-style: italic;
+                    }
+                    .tagable-list-item-sort-info {
+                        margin-left: 1em;
+                        padding: .1em .5em .1em .5em;
+                        font-size: .6em;
+                        background-color: lightgray;
+                        border-radius: .2em;
+                        color: white;
+                    }
                 }
             }
         }

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -53,7 +53,8 @@ class TagsController < ApplicationController
   end
 
   def set_tagables
-    @tagable_category = params[:tagable_category] || 'entities'
+    @tagable_category = params[:tagable_category] || Entity.category_str
+    @tagable_subtypes = @tagable_category == Entity.category_str ? %w[Person Org] : [nil]
     page = params[:page] || 1
     @tagables = @tag.tagables_for_homepage(@tagable_category, page)
   end

--- a/app/views/tags/_tagable_list.html.erb
+++ b/app/views/tags/_tagable_list.html.erb
@@ -1,0 +1,17 @@
+<ul class="tagable-list-items">
+    <% tagables.each_with_index do |tagable, i| %>
+        <div class="tagable-list-item">
+            <%= link_to tagable.name, tagable, class: "tagable-list-item-name"%>
+            <%= content_tag :div,
+            tagable_list_sort_info(tagable, tag),
+            class: "tagable-list-item-sort-info" %>
+            <%= content_tag :div,
+            truncate(tagable.description, length: 90),
+            class: "tagable-list-item-description"%>
+        </div>
+    <% end #tagables.each %>
+</ul>
+
+<div class="tagable-list-pagination">
+    <%= paginate tagables %>
+</div>

--- a/app/views/tags/_tagable_list.html.erb
+++ b/app/views/tags/_tagable_list.html.erb
@@ -1,17 +1,33 @@
-<ul class="tagable-list-items">
+<%# locals: tagables, tag, sub_header, tagable_descriptor %>
+
+<div class="tagable-list">
+
+  <% if subheader %>
+    <%= content_tag :div, subheader, class: "tagable-list-subheader"%>  
+  <% end %>
+
+  <% if tagables.empty? %>
+    <%= content_tag :div,
+                    "There are no #{item_descriptor} tagged \"#{@tag.name}\"",
+                    class: "tagable-list-empty-message " %>  
+  <% end %>
+
+  <ul class="tagable-list-items">
     <% tagables.each_with_index do |tagable, i| %>
-        <div class="tagable-list-item">
-            <%= link_to tagable.name, tagable, class: "tagable-list-item-name"%>
-            <%= content_tag :div,
-            tagable_list_sort_info(tagable, tag),
-            class: "tagable-list-item-sort-info" %>
-            <%= content_tag :div,
-            truncate(tagable.description, length: 90),
-            class: "tagable-list-item-description"%>
-        </div>
+      <div class="tagable-list-item">
+        <%= link_to tagable.name, tagable, class: "tagable-list-item-name"%>
+        <%= content_tag :div,
+                        tagable_list_sort_info(tagable, tag),
+                        class: "tagable-list-item-sort-info" %>
+        <%= content_tag :div,
+                        truncate(tagable.description, length: 90),
+                        class: "tagable-list-item-description"%>
+      </div>
     <% end #tagables.each %>
-</ul>
+  </ul>
+
+</div>
 
 <div class="tagable-list-pagination">
-    <%= paginate tagables %>
+  <%= paginate tagables %>
 </div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -34,29 +34,19 @@
 
     <% if @tagables.empty? %>
 
-      <div class="tagable-list-empty-message">
-        <%= "There are no #{@tagable_category} tagged \"#{@tag.name}\"" %>
-      </div>
+	<div class="tagable-list-empty-message">
+            <%= "There are no #{@tagable_category} tagged \"#{@tag.name}\"" %>
+	</div>
 
     <% else %>
-
-      <ul class="tagable-list-items">
-        <% @tagables.each_with_index do |tagable, i| %>
-          <div class="tagable-list-item">
-            <%= link_to tagable.name, tagable, class: "tagable-list-item-name"%>
-            <%= content_tag :div,
-                tagable_list_sort_info(tagable, @tag),
-                class: "tagable-list-item-sort-info" %>
-            <%= content_tag :div,
-            truncate(tagable.description, length: 90),
-            class: "tagable-list-item-description"%>
-          </div>
-        <% end #tagables.each %>
-      </ul>
-
-      <div class="tagable-list-pagination">
-        <%= paginate @tagables %>
-      </div>
+	
+	<% if @tagable_types  %>
+	    <%= @tagable_types.each do |tagable_type|  %>
+		<%= render partial: 'tagable_list', locals: { tagables: @tagables[tagable_type], tag: @tag } %>
+	    <% end  %>
+	<% else %>
+	    <%= render partial: 'tagable_list', locals: { tagables: @tagables, tag: @tag } %>
+	<% end  %>
 
     <% end #if !tagables.empty %>
   </div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -30,25 +30,17 @@
     </ul>
   </div>
   
-  <div id="tagable-list">
+  <div id="tagable-lists">
 
-    <% if @tagables.empty? %>
+    <% # if no subtypes exist, @tagable_subtypes will be `[nil]` %>
+    <% @tagable_subtypes.each do |subtype|  %>
+      <%= render partial: 'tagable_list',
+                 locals: { tagables: subtype ? @tagables[subtype] : @tagables,
+                           tag: @tag,
+                           subheader: subtype&.pluralize,
+                           item_descriptor: subtype&.pluralize&.downcase || @tagable_category } %>
+    <% end %>
 
-	<div class="tagable-list-empty-message">
-            <%= "There are no #{@tagable_category} tagged \"#{@tag.name}\"" %>
-	</div>
-
-    <% else %>
-	
-	<% if @tagable_types  %>
-	    <%= @tagable_types.each do |tagable_type|  %>
-		<%= render partial: 'tagable_list', locals: { tagables: @tagables[tagable_type], tag: @tag } %>
-	    <% end  %>
-	<% else %>
-	    <%= render partial: 'tagable_list', locals: { tagables: @tagables, tag: @tag } %>
-	<% end  %>
-
-    <% end #if !tagables.empty %>
   </div>
 
   <div class=".tag-show-container">

--- a/lib/scripts/load_tags.rb
+++ b/lib/scripts/load_tags.rb
@@ -1,8 +1,14 @@
+# usage:
+# $ load Rails.root.join('lib', 'scripts', 'load_tags.rb')
+# $ LoadTags.load(tag_id: <id>, num_tags: <num>)
+
 module LoadTags
   def self.load(tag_id: 1, num_tags: 10)
     tag = ::Tag.find(tag_id)
 
-    entities = ::Entity.first(num_tags)
+    entities = %w[Person Org].map do |entity_type|
+      ::Entity.where(primary_ext: entity_type).limit(num_tags)
+    end.flatten
     lists = ::List.first(num_tags)
     relationships = ::Relationship.first(num_tags)
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -47,14 +47,12 @@ describe 'Tags', type: :feature do
     end
 
     it "shows a list of all tags" do
-     tags.each do |tag|
-       expect(page.find("#tags-index-list"))
-         .to have_selector ".item", count: tags.size
-      end
+      expect(page.find("#tags-index-list"))
+        .to have_selector ".item", count: tags.size
     end
 
     it "shows a link to each tag's homepage" do
-     tags.each{ |tag| expect(page).to have_link(tag.name, href: tag_path(tag)) }
+      tags.each { |tag| expect(page).to have_link(tag.name, href: tag_path(tag)) }
     end
 
     it "shows a description of each tag" do
@@ -67,101 +65,98 @@ describe 'Tags', type: :feature do
       expect(page.all("#tags-index-list .item")[0]).to have_text("aa")
     end
   end
-  
+
   describe "tag homepage" do
+    describe "tabs" do
+      context "with no tab specified" do
+        before { visit "/tags/#{tag.id}" }
 
-    context "with no tab specified" do
-      before { visit "/tags/#{tag.id}" }
+        it "defaults to the entities tab" do
+          expect(page).to have_selector("#tag-nav-tab-entities.active")
+        end
 
-      it "defaults to the entities tab" do
-        expect(page).to have_selector("#tag-nav-tab-entities.active")
+        it "shows the tag title and description" do
+          expect(page).to have_text tag.name
+          expect(page).to have_text tag.description
+        end
       end
 
-      it "shows the tag title and description" do
-        expect(page).to have_text tag.name
-        expect(page).to have_text tag.description
-      end
+      Tagable.categories.each do |tagable_category|
+        context "on #{tagable_category} tab" do
+          context "#{tagable_category} is grouped by type" do
+            it "shows a tag list for each type"
+          end
 
-      # NOTE(ag|Thu 14 Sep 2017): this test would make more sense below
-      # *but* because we can't programatically set the description for
-      # every tagable in the same way, we do it here for convenience
-      it "truncates descriptions longer than 90 characters" do
-        n_tagables(1, Entity.category_str)
-          .first
-          .tag(tag.id)
-          .update(blurb: ("a" * 91))
-        refresh_page
-        expect(
-          page.all("#tagable-list .tagable-list-item-description").first.text
-        ).to eq("a" * 87 + "...")
+          context "#{tagable_category} is note grouped by type" do
+            it "shows one tag list"
+          end
+        end
       end
     end
 
-    Tagable.classes.map(&:category_str).each do |tagable_category|
+    describe "a tagable list" do
+      # we use entities here arbitrarily
+      let(:tagable_category) { 'entities' }
+      let(:tagables) { [] }
+      before(:each) do
+        tagables
+        visit "/tags/#{tag.id}/#{tagable_category}"
+      end
 
-      context "on #{tagable_category} tab" do
+      context "no tagged items" do
+        let(:tagable_category) { 'relationships' }
+        it "shows an empty list message" do
+          expect(page).not_to have_selector '.tagable-list-item'
+          expect(page.find("#tagable-list")).to have_text "There are no"
+        end
+      end
 
-        context "no tagged #{tagable_category}" do
-          before { visit "/tags/#{tag.id}/#{tagable_category}"}
+      context "less than 20 tagged tagables" do
+        let(:tagables) do
+          n_tagables(2, tagable_category).map { |t| t.tag(tag.id) }
+        end
 
-          it "shows an empty list message" do
-            expect(page).not_to have_selector '.tagable-list-item'
-            expect(page.find("#tagable-list")).to have_text "no #{tagable_category} tagged"
+        it "shows the tag title and description" do
+          expect(page).to have_text tag.name
+          expect(page).to have_text tag.description
+        end
+
+        it "shows a list of tagables" do
+          expect(page.find("#tagable-list"))
+            .to have_selector '.tagable-list-item', count: 2
+        end
+
+        it "renders the name of each tagable as a link" do
+          page.all("#tagable-list .tagable-list-item").each_with_index do |item, i|
+            expect(item).to have_link :class => 'tagable-list-item-name'
           end
         end
 
-        context "less than 20 tagged #{tagable_category}" do
-          let(:tagables) do
-            n_tagables(2, tagable_category).map { |t| t.tag(tag.id) }
-          end
-
-          before do
-            tagables
-            visit "/tags/#{tag.id}/#{tagable_category}"
-          end
-
-          it "shows the tag title and description" do
-            expect(page).to have_text tag.name
-            expect(page).to have_text tag.description
-          end
-
-          it "shows a list of tagged entities" do
-            expect(page.find("#tagable-list"))
-              .to have_selector '.tagable-list-item', count: 2
-          end
-
-          it "renders the name of each #{tagable_category.singularize} as a link" do
-            page.all("#tagable-list .tagable-list-item").each_with_index do |item, i|
-              expect(item).to have_link :class => 'tagable-list-item-name'
-            end
-          end
-
-          it "shows a description of each #{tagable_category.singularize}" do
-            page.all("#tagable-list .tagable-list-item").each_with_index do |item, i|
-              tagable = tagables.reverse[i] # b/c sorting by update reversed order
-              expect(item.find(".tagable-list-item-description")).to have_text(tagable.description)
-            end
-          end
-
-          it "displays last updated date for each #{tagable_category.singularize}" do
-            page.all("#tagable-list .tagable-list-item").each do |item|
-              sort_text = tagable_category == 'entities' ? 'relationships' : 'ago'
-              expect(item.find(".tagable-list-item-sort-info")).to have_text sort_text
-            end
+        it "shows a description of each tagable" do
+          page.all("#tagable-list .tagable-list-item").each do |item|
+            expect(item).to have_selector ".tagable-list-item-description"
           end
         end
 
-        context "more than 20 tagged #{tagable_category}" do
-          let(:tagables) { n_tagables(21, tagable_category) }
-          before do
-            tagables.map { |t| t.tag(tag.id) }
-            visit "/tags/#{tag.id}/#{tagable_category}"
+        it "displays last updated date for each tagable" do
+          page.all("#tagable-list .tagable-list-item").each do |item|
+            sort_text = tagable_category == 'entities' ? 'relationships' : 'ago'
+            expect(item.find(".tagable-list-item-sort-info")).to have_text sort_text
           end
+        end
 
-          it "only shows 10 entities with pagination bar" do
-            expect(page.find("#tagable-list"))
-              .to have_selector '.tagable-list-item', count: 20
-          end
+        it "truncates descriptions longer than 90 characters" do
+          tagables.first.update(blurb: ("a" * 91))
+          refresh_page
+          expect(page).to have_text("a" * 87 + "...")
+        end
+      end
+
+      context "more than 20 tagables" do
+        let(:tagables) { n_tagables(21, tagable_category).map { |t| t.tag(tag.id) } }
+        it "only shows 10 entities with pagination bar" do
+          expect(page.find("#tagable-list"))
+            .to have_selector '.tagable-list-item', count: 20
         end
       end
     end


### PR DESCRIPTION
resolves #307 

____

## Screenshots

**Entity tab with an empty sublist:**

![tag-homepage-subheaders](https://user-images.githubusercontent.com/6032844/30663887-16c7e1ee-9e1a-11e7-891c-d2e6d12c689d.png)

**Entity tab with pagination:**

![tags-homepage-subheaders-pagination](https://user-images.githubusercontent.com/6032844/30663915-285def20-9e1a-11e7-90b6-b22c2e5d356b.png)

__________

## Implementation notes

* show sublists by subtypes for entities (in a manner that is extensible
  to any future tagable class that might have subtypes)
* show subheaders if there are sublists
* infer sublists from a @tagable_subtypes instance variable
* set @tagable_subtypes to `[nil]` if there are no subtypes so we may
  avoid an `if/else` branch and simply always render the `_tagable_list`
  partial in all scenarios, with appropriate locals plugged in based on
  value of @tagable_subtypes
* modify `LoadTags#load` to tag N entities of subtype `Person` and `Org`
* cleanup feature specs for a tagable list

@aepyornis: open to suggestions on optimizing the SQL here.
all i can vouch for is that it is correct...

