### PR TITLE
Recent edits by tag

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,10 +1,9 @@
 class TagsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
-  before_action -> { check_permission('admin') }, except: [:index, :show, :tag_request]
-  before_action :set_tag, only: [:edit, :update, :destroy, :show]
+  before_action :authenticate_user!, except: [:index, :show, :edits]
+  before_action -> { check_permission('admin') }, except: [:index, :show, :edits, :tag_request]
+  before_action :set_tag, only: [:edit, :update, :destroy, :show, :edits]
   before_action :set_tags, only: [:index]
   before_action :set_tagables, only: [:show]
-
 
   def index; end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -37,7 +37,7 @@ class TagsController < ApplicationController
   end
 
   def edits
-    @recent_edits = @tag.recent_edits params.fetch(:page, 1)
+    @recent_edits = @tag.recent_edits_for_homepage params.fetch(:page, 1)
   end
 
   # COMPLEX ACTIONS

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -37,6 +37,9 @@ class TagsController < ApplicationController
     redirect_to admin_tags_path, notice: 'The tag has been removed'
   end
 
+  def edits
+  end
+
   # COMPLEX ACTIONS
 
   def tag_request

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -37,6 +37,7 @@ class TagsController < ApplicationController
   end
 
   def edits
+    @recent_edits = @tag.recent_edits params.fetch(:page, 1)
   end
 
   # COMPLEX ACTIONS

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -21,4 +21,29 @@ module TagsHelper
     return "#{tagable.num_related} #{tag.name} relationships" if tagable.is_a? Entity
     "edited #{time_ago_in_words(tagable.updated_at)} ago"
   end
+
+  def tagable_link(tagable)
+    link_to tagable.name, send("#{tagable.class.name.downcase}_path", tagable)
+  end
+
+  def tags_format_edited_by(edit_event)
+    if edit_event['event'] == 'tag_added' || edit_event['tagable_class'] == 'List'
+      "Edited #{time_ago_in_words(edit_event['event_timestamp'])} ago"
+    else
+      username = edit_event['tagable']&.last_user&.user&.username || 'System'
+      "Edited #{time_ago_in_words(edit_event['event_timestamp'])} ago by #{username}"
+    end
+  end
+
+  def tags_format_edit_event(edit_event)
+    case edit_event['event']
+    when 'tagable_updated'
+      "#{edit_event['tagable_class']} updated"
+    when 'tag_added'
+      'Tagged'
+    else
+      ''
+    end
+  end
+
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -26,7 +26,7 @@ module TagsHelper
     link_to tagable.name, send("#{tagable.class.name.downcase}_path", tagable)
   end
 
-  def tags_format_edited_by(edit_event)
+  def tags_edits_format_time(edit_event)
     if edit_event['event'] == 'tag_added' || edit_event['tagable_class'] == 'List'
       "Edited #{time_ago_in_words(edit_event['event_timestamp'])} ago"
     else
@@ -35,15 +35,8 @@ module TagsHelper
     end
   end
 
-  def tags_format_edit_event(edit_event)
-    case edit_event['event']
-    when 'tagable_updated'
-      "#{edit_event['tagable_class']} updated"
-    when 'tag_added'
-      'Tagged'
-    else
-      ''
-    end
+  def tags_edits_format_action(edit_event)
+    action_text = { 'tagable_updated' => 'updated', 'tag_added' => 'tagged' }
+    "#{edit_event['tagable_class']} #{action_text[edit_event['event']]}"
   end
-
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -48,6 +48,13 @@ class Tag < ActiveRecord::Base
     restricted
   end
 
+  def recent_edits_for_homepage(page = 1)
+    Kaminari
+      .paginate_array(recent_edits(page), total_count: taggings.count * 2)
+      .page(page)
+      .per(TAGABLE_PAGINATION_LIMIT)
+  end
+
   def recent_edits(page = 1)
     sql = <<-SQL
       (
@@ -78,7 +85,7 @@ class Tag < ActiveRecord::Base
       )
         ORDER BY event_timestamp DESC
         LIMIT #{TAGABLE_PAGINATION_LIMIT}
-        OFFSET #{ (page - 1) * TAGABLE_PAGINATION_LIMIT }
+        OFFSET #{ (page.to_i - 1) * TAGABLE_PAGINATION_LIMIT }
     SQL
 
     # NOTE: our version of Mysql2::Result is missing the very convenient method: #to_hash ...why?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,33 +50,32 @@ class Tag < ActiveRecord::Base
 
   def recent_edits(page = 1)
     sql = <<-SQL
-      SELECT *
-      FROM (
-            SELECT taggings.id as tagging_id,
-	           taggings.tagable_id,
-	           taggings.tagable_class,
-	           taggings.created_at as tagging_created_at,
-       	           COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at) AS event_timestamp,
-	           'tagable_updated' as event
-	    FROM taggings
-	    LEFT JOIN entity ON taggings.tagable_id = entity.id AND taggings.tagable_class = 'Entity'
- 	    LEFT JOIN ls_list ON taggings.tagable_id = ls_list.id AND taggings.tagable_class = 'List'
-	    LEFT JOIN relationship ON taggings.tagable_id = relationship.id AND taggings.tagable_class = 'Relationship'
-	    WHERE taggings.tag_id = #{id}
-                  # adding a tag triggers a callback that also updates the tagable. This clause excludes those updates
-	          AND abs(TIMESTAMPDIFF(SECOND, taggings.created_at, COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at))) > 100
-
-            UNION
-
-            SELECT taggings.id as tagging_id,
-	           taggings.tagable_id,
-	           taggings.tagable_class,
-	           taggings.created_at AS tagging_created_at,
-	           taggings.created_at AS event_timestamp,
-	           'tag_added' AS event
-            FROM taggings
-	    WHERE taggings.tag_id = #{id}
-      ) AS tag_edit_history
+      (
+        SELECT taggings.id as tagging_id,
+                taggings.tagable_id,
+                taggings.tagable_class,
+                taggings.created_at as tagging_created_at,
+                COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at) AS event_timestamp,
+	        'tagable_updated' as event
+	FROM taggings
+	LEFT JOIN entity ON taggings.tagable_id = entity.id AND taggings.tagable_class = 'Entity'
+ 	LEFT JOIN ls_list ON taggings.tagable_id = ls_list.id AND taggings.tagable_class = 'List'
+	LEFT JOIN relationship ON taggings.tagable_id = relationship.id AND taggings.tagable_class = 'Relationship'
+	WHERE taggings.tag_id = #{id}
+              # adding a tag triggers a callback that also updates the tagable. This clause excludes those updates
+	      AND abs(TIMESTAMPDIFF(SECOND, taggings.created_at, COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at))) > 100
+      )
+        UNION
+      (
+        SELECT taggings.id as tagging_id,
+	       taggings.tagable_id,
+	       taggings.tagable_class,
+	       taggings.created_at AS tagging_created_at,
+	       taggings.created_at AS event_timestamp,
+	       'tag_added' AS event
+        FROM taggings
+	WHERE taggings.tag_id = #{id}
+      )
         ORDER BY event_timestamp DESC
         LIMIT #{TAGABLE_PAGINATION_LIMIT}
         OFFSET #{ (page - 1) * TAGABLE_PAGINATION_LIMIT }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -56,14 +56,13 @@ class Tag < ActiveRecord::Base
       .per(TAGABLE_PAGINATION_LIMIT)
   end
 
-  # -> [ ActiveRecord ]
-  # recent_edits_query returns an array of hashes.
+  # -> [ Hash ]
   # This takes those and turn them into an array of Tagables
   def recent_edits(page = 1)
     edits = recent_edits_query(page)
     active_record_lookup = active_record_lookup_for_recent_edits(edits)
-    edits.map do |h|
-      active_record_lookup.fetch(h['tagable_class']).fetch(h['tagable_id'])
+    edits.map do |edit|
+      edit.tap { |h| h.store 'tagable', active_record_lookup.dig(h['tagable_class'], h['tagable_id']) }
     end
   end
 

--- a/app/views/tags/_header.html.erb
+++ b/app/views/tags/_header.html.erb
@@ -1,12 +1,16 @@
+<%#
+ locals: tag (Tag), active_tab (symbol)
+%>
+
 <div id="tag-header">
 
     <div id="tag-title">
 	<div id="tag-name">
-            Tag: <%= content_tag :span, @tag.name, class: "big-tag" %>
+            Tag: <%= content_tag :span, tag.name, class: "big-tag" %>
 	</div>
 
 	<div id="tag-description">
-            <%= @tag.description %>
+            <%= tag.description %>
 	</div>
     </div>
 
@@ -17,12 +21,11 @@
 
 <div id="tag-nav">
     <ul class="nav nav-tabs">
-	<% Tagable.classes.each do |tc|  %>
+	<% (Tagable.categories + [:edits]).each do |tab|  %>
             <li role="presentation"
-		      id="tag-nav-tab-<%= tc.category_str%>"
-		      class=<%= tc == Tagable.class_of(@tagable_category) ? "active" : "inactive" %>
-            >
-		<%=  link_to tc.category_str.capitalize,"/tags/#{@tag.id}/#{tc.category_str}" %>
+		      id="tag-nav-tab-<%= tab %>"
+		      class=<%= active_tab == tab ? "active" : "inactive" %> >
+		<%=  link_to tab.to_s.capitalize,"/tags/#{tag.id}/#{tab}" %>
             </li>
 	<% end %>
     </ul>

--- a/app/views/tags/_header.html.erb
+++ b/app/views/tags/_header.html.erb
@@ -1,0 +1,29 @@
+<div id="tag-header">
+
+    <div id="tag-title">
+	<div id="tag-name">
+            Tag: <%= content_tag :span, @tag.name, class: "big-tag" %>
+	</div>
+
+	<div id="tag-description">
+            <%= @tag.description %>
+	</div>
+    </div>
+
+    <div id="tag-overview-link">
+	<%= link_to "see all tags", tags_path  %>
+    </div>
+</div>
+
+<div id="tag-nav">
+    <ul class="nav nav-tabs">
+	<% Tagable.classes.each do |tc|  %>
+            <li role="presentation"
+		      id="tag-nav-tab-<%= tc.category_str%>"
+		      class=<%= tc == Tagable.class_of(@tagable_category) ? "active" : "inactive" %>
+            >
+		<%=  link_to tc.category_str.capitalize,"/tags/#{@tag.id}/#{tc.category_str}" %>
+            </li>
+	<% end %>
+    </ul>
+</div>

--- a/app/views/tags/edits.html.erb
+++ b/app/views/tags/edits.html.erb
@@ -2,28 +2,26 @@
     <%= render partial: 'header', locals: { tag: @tag, active_tab: :edits } %>
 </div>
 
-<div id="tag-homepage-edits-table-container">
+<div id="tag-homepage-edits-table-container" class="top-1em">
     <table class="table" id="tag-homepage-edits-table">
 	<thead>
 	    <tr>
-		<th>Edited By</th>
+		<th>Edited At</th>
 		<th>Resource</th>
 	        <th>Event</th>
-		<th>Description</th>
 	    </tr>
 	</thead>
 	<tbody>
-	    <% @recent_edits.each do |edit| %>
+	    <% @recent_edits.each do |edit_event| %>
 		<tr>
-		    <td><%= time_ago_in_words edit['event_timestamp'] %> ago</td>
-		    <td><%= edit['tagable_class']%></td>
-		    <td><%= edit['event']%></td>
-		    <td>??</td>
+		    <td><%= tags_format_edited_by edit_event %></td>
+		    <td> <%= tagable_link edit_event['tagable'] %></td>
+		    <td><%= tags_format_edit_event edit_event %></td>
 		</tr>
 	    <% end %>
 	</tbody>
     </table>
 
     <%= link_to_previous_page @recent_edits, 'Previous Page' %>
-    <%= link_to_next_page @recent_edits, 'Next Page' %>
+    <%= link_to_next_page @recent_edits, 'Next Page', class: 'pull-right' %>
 </div>

--- a/app/views/tags/edits.html.erb
+++ b/app/views/tags/edits.html.erb
@@ -23,4 +23,7 @@
 	    <% end %>
 	</tbody>
     </table>
+
+    <%= link_to_previous_page @recent_edits, 'Previous Page' %>
+    <%= link_to_next_page @recent_edits, 'Next Page' %>
 </div>

--- a/app/views/tags/edits.html.erb
+++ b/app/views/tags/edits.html.erb
@@ -1,0 +1,3 @@
+<div id="tag-show-container">
+    <%= render partial: 'header', locals: { tag: @tag, active_tab: :edits } %>
+</div>

--- a/app/views/tags/edits.html.erb
+++ b/app/views/tags/edits.html.erb
@@ -6,17 +6,17 @@
     <table class="table" id="tag-homepage-edits-table">
 	<thead>
 	    <tr>
-		<th>Edited At</th>
-		<th>Resource</th>
-	        <th>Event</th>
+		<th>Tagged Resource</th>
+		<th>Action</th>
+		<th>Time</th>
 	    </tr>
 	</thead>
 	<tbody>
 	    <% @recent_edits.each do |edit_event| %>
 		<tr>
-		    <td><%= tags_format_edited_by edit_event %></td>
-		    <td> <%= tagable_link edit_event['tagable'] %></td>
-		    <td><%= tags_format_edit_event edit_event %></td>
+		    <td><%= tagable_link edit_event['tagable'] %></td>
+		    <td><%= tags_edits_format_action(edit_event) %></td>
+		    <td><%= tags_edits_format_time(edit_event) %></td>
 		</tr>
 	    <% end %>
 	</tbody>

--- a/app/views/tags/edits.html.erb
+++ b/app/views/tags/edits.html.erb
@@ -1,3 +1,26 @@
 <div id="tag-show-container">
     <%= render partial: 'header', locals: { tag: @tag, active_tab: :edits } %>
 </div>
+
+<div id="tag-homepage-edits-table-container">
+    <table class="table" id="tag-homepage-edits-table">
+	<thead>
+	    <tr>
+		<th>Edited By</th>
+		<th>Resource</th>
+	        <th>Event</th>
+		<th>Description</th>
+	    </tr>
+	</thead>
+	<tbody>
+	    <% @recent_edits.each do |edit| %>
+		<tr>
+		    <td><%= time_ago_in_words edit['event_timestamp'] %> ago</td>
+		    <td><%= edit['tagable_class']%></td>
+		    <td><%= edit['event']%></td>
+		    <td>??</td>
+		</tr>
+	    <% end %>
+	</tbody>
+    </table>
+</div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,6 +1,8 @@
 <div id="tag-show-container">
 
-  <%= render partial: 'header' %>
+    <%= render partial: 'header',
+        locals: { tag: @tag, active_tab: @tagable_category.to_sym }
+    %>
   
   <div id="tagable-lists">
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,34 +1,6 @@
 <div id="tag-show-container">
 
-  <div id="tag-header">
-
-    <div id="tag-title">
-      <div id="tag-name">
-        Tag: <%= content_tag :span, @tag.name, class: "big-tag" %>
-      </div>
-
-      <div id="tag-description">
-        <%= @tag.description %>
-      </div>
-    </div>
-
-    <div id="tag-overview-link">
-      <%= link_to "see all tags", tags_path  %>
-    </div>
-  </div>
-
-  <div id="tag-nav">
-    <ul class="nav nav-tabs">
-      <% Tagable.classes.each do |tc|  %>
-        <li role="presentation"
-            id="tag-nav-tab-<%= tc.category_str%>"
-            class=<%= tc == Tagable.class_of(@tagable_category) ? "active" : "inactive" %>
-        >
-          <%=  link_to tc.category_str.capitalize,"/tags/#{@tag.id}/#{tc.category_str}" %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <%= render partial: 'header' %>
   
   <div id="tagable-lists">
 
@@ -43,4 +15,4 @@
 
   </div>
 
-  <div class=".tag-show-container">
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,7 @@ Lilsis::Application.routes.draw do
   post '/tags/request' => 'tags#tag_request'
   resources :tags, only: [:edit, :create, :update, :destroy, :show, :index] do
     member do
+      get '/edits' => 'tags#edits'
       get '/:tagable_category' => 'tags#show',
           constraints: {
             tagable_category: /#{Tagable.categories.join('|')}/

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -9,6 +9,9 @@ describe TagsController, type: :controller do
   it { should route(:delete, '/tags/456').to(action: :destroy, id: 456) }
   it { should route(:get, '/tags/request').to(action: :tag_request) }
   it { should route(:post, '/tags/request').to(action: :tag_request) }
+
+  it { should route(:get, 'tags/456/edits').to(action: :edits, id: 456) }
+
   Tagable.categories.each do |tagable_category|
     it do
       should(route(:get, "/tags/456/#{tagable_category}")

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -86,6 +86,8 @@ describe 'Tags', type: :feature do
           expect(page).to have_text tag.name
           expect(page).to have_text tag.description
         end
+
+        it "shows edit tab"
       end
 
       Tagable.categories.each do |tagable_category|
@@ -187,5 +189,23 @@ describe 'Tags', type: :feature do
         end
       end
     end
-  end
+
+    describe 'edits tab' do
+      it "has header with text edits"
+
+      it "contains list of edits"
+
+      describe 'list of edits' do
+        it "contains recently edited entity that is tagged"
+
+        it "contains entity that was recently tagged (add tag)"
+
+        it "contains entity that was recently un-tagged"
+
+        it "containts list that was recently tagged"
+
+        it "contains list that was recently updated"
+      end
+    end # end describe edits tab
+  end # end describe tag homepage
 end

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -217,7 +217,7 @@ describe 'Tags', :tagging_helper, type: :feature do
           edits_table_has_correct_row_count(1)
 
           it 'contains "tagged" text' do
-            expect(page.find('#tag-homepage-edits-table tbody')).to have_text 'Tagged'
+            expect(page.find('#tag-homepage-edits-table tbody')).to have_text 'tagged'
             expect(page.find('#tag-homepage-edits-table tbody')).not_to have_text 'updated'
           end
         end
@@ -227,7 +227,7 @@ describe 'Tags', :tagging_helper, type: :feature do
           edits_table_has_correct_row_count(2)
 
           it 'contains "tagged" and "updated" text' do
-            expect(page.find('#tag-homepage-edits-table tbody')).to have_text 'Tagged'
+            expect(page.find('#tag-homepage-edits-table tbody')).to have_text 'tagged'
             expect(page.find('#tag-homepage-edits-table tbody')).to have_text 'Entity updated'
           end
         end

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -191,7 +191,12 @@ describe 'Tags', type: :feature do
     end
 
     describe 'edits tab' do
-      it "has header with text edits"
+      before(:each) { visit "/tags/#{tag.id}/edits" }
+
+      it "has header with active edit tab" do
+        expect(page).to have_selector 'li#tag-nav-tab-edits.active'
+        expect(page).to have_selector 'li#tag-nav-tab-edits.active a', text: 'Edits'
+      end
 
       it "contains list of edits"
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -220,7 +220,7 @@ describe 'Tags', :tagging_helper, type: :feature do
           edits_table_has_correct_row_count(2)
         end
 
-        context 'a list and a relationship was recently tagged' do
+        context 'a list and a relationship were recently tagged' do
           let(:setup) do
             proc {
               list

--- a/spec/helpers/tags_helper_spec.rb
+++ b/spec/helpers/tags_helper_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe TagsHelper, type: :helper do
 
-  describe '#tags_format_edit_event' do
-    subject { helper.tags_format_edited_by(edit_event) }
+  describe '#tags_edits_format_time' do
+    subject { helper.tags_edits_format_time(edit_event) }
 
     let(:username) { Faker::Internet.user_name }
     let(:mock_entity) do
@@ -38,11 +38,11 @@ describe TagsHelper, type: :helper do
     end
   end
 
-  describe '#tags_format_edit_event' do
-    subject { helper.tags_format_edit_event(edit_event) }
+  describe '#tags_edits_format_action' do
+    subject { helper.tags_edits_format_action(edit_event) }
     context 'tag added event' do
-      let(:edit_event) { { 'event' => 'tag_added' } }
-      it { is_expected.to eql 'Tagged' }
+      let(:edit_event) { { 'event' => 'tag_added', 'tagable_class' => 'Relationship' } }
+      it { is_expected.to eql 'Relationship tagged' }
     end
 
     context 'update event' do

--- a/spec/helpers/tags_helper_spec.rb
+++ b/spec/helpers/tags_helper_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe TagsHelper, type: :helper do
+
+  describe '#tags_format_edit_event' do
+    subject { helper.tags_format_edited_by(edit_event) }
+
+    let(:username) { Faker::Internet.user_name }
+    let(:mock_entity) do
+      user = build(:user, username: username)
+      build(:org).tap do |org|
+        allow(org).to receive(:last_user).and_return(double(:user => user))
+      end
+    end
+
+    context 'event is tag_added' do
+      let(:edit_event) { { 'event' => 'tag_added', 'event_timestamp' => 1.day.ago } }
+      it { is_expected.to eql "Edited 1 day ago" }
+    end
+
+    context 'tagable is a list' do
+      let(:edit_event) do
+        { 'event' => 'tagable_updated', 'event_timestamp' => 1.day.ago, 'tagable_class' => 'List' }
+      end
+      it { is_expected.to eql "Edited 1 day ago" }
+    end
+
+    context 'event is not tag_added and is an entity' do
+      let(:edit_event) do
+        {
+          'event' => 'tagable_updated',
+          'tagable_class' => 'Entity',
+          'event_timestamp' => 1.day.ago,
+          'tagable' => mock_entity
+        }
+      end
+      it { is_expected.to eql "Edited 1 day ago by #{username}" }
+    end
+  end
+
+  describe '#tags_format_edit_event' do
+    subject { helper.tags_format_edit_event(edit_event) }
+    context 'tag added event' do
+      let(:edit_event) { { 'event' => 'tag_added' } }
+      it { is_expected.to eql 'Tagged' }
+    end
+
+    context 'update event' do
+      let(:edit_event) { { 'event' => 'tagable_updated', 'tagable_class' => 'List' } }
+      it { is_expected.to eql 'List updated' }
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -145,11 +145,11 @@ describe Tag do
         it 'recent_edits returns an array of active record objects' do
           relationships[0].update_column(:updated_at, Date.tomorrow)
 
-          tag.recent_edits.each do |tagable|
-            expect(Tagable.classes).to include tagable.class
+          tag.recent_edits.each do |edit|
+            expect(Tagable.classes).to include edit['tagable'].class
           end
 
-          expect(tag.recent_edits.first).to eq relationships[0]
+          expect(tag.recent_edits.first['tagable']).to eq relationships[0]
           
         end
       end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -118,20 +118,20 @@ describe Tag do
         before { entities; relationships; lists; }
 
         def it_contains_all_tagables
-          expect(Set.new(tag.recent_edits.map { |x| x['tagable_id'] }))
+          expect(Set.new(tag.recent_edits_query.map { |x| x['tagable_id'] }))
             .to eql Set.new( (entities + lists + relationships).map(&:id) )
         end
 
         it 'contains a list of tag_added events' do
-          expect(tag.recent_edits.length).to eql 6
+          expect(tag.recent_edits_query.length).to eql 6
           it_contains_all_tagables
         end
 
         it 'also contains a tagable_updated event' do
           relationships[0].update_column(:updated_at, Date.tomorrow)
-          expect(tag.recent_edits.length).to eql 7
+          expect(tag.recent_edits_query.length).to eql 7
           it_contains_all_tagables
-          expect(tag.recent_edits[0])
+          expect(tag.recent_edits_query[0])
             .to eq(
                   "tagging_id" => relationships[0].taggings.first.id,
                   "tagable_id" => relationships[0].id,
@@ -140,6 +140,17 @@ describe Tag do
                   "event_timestamp" => relationships[0].updated_at,
                   "event" => "tagable_updated"
                 )
+        end
+
+        it 'recent_edits returns an array of active record objects' do
+          relationships[0].update_column(:updated_at, Date.tomorrow)
+
+          tag.recent_edits.each do |tagable|
+            expect(Tagable.classes).to include tagable.class
+          end
+
+          expect(tag.recent_edits.first).to eq relationships[0]
+          
         end
       end
     end

--- a/spec/support/tagging_helper.rb
+++ b/spec/support/tagging_helper.rb
@@ -21,4 +21,10 @@ module TaggingHelpers
       expect(response).to have_http_status :forbidden
     end
   end
+
+  def edits_table_has_correct_row_count(n)
+    it "the edits table contains #{n} row(s)" do
+      expect(page).to have_selector '#tag-homepage-edits-table tbody tr', count: n
+    end
+  end
 end

--- a/spec/views/tags/_header.html.erb_spec.rb
+++ b/spec/views/tags/_header.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'partial: tags/header', :type => :view do
+  let(:tag) { build(:tag) }
+  let(:active_tab) { :entities }
+
+  before(:each) do
+    render partial: 'tags/header.html.erb', locals: { tag: tag, active_tab: active_tab }
+  end
+
+  it 'contains correct tabs: all tagable classes and edits' do
+    css 'ul.nav-tabs li', count: Tagable.categories.count + 1
+    (Tagable.categories + [:edits]). each { |tab| css "\#tag-nav-tab-#{tab}" }
+  end
+
+  context 'lists tab is active' do
+    let(:active_tab) { :lists }
+
+    it 'sets correct active/inactive classes' do
+      css 'li#tag-nav-tab-lists.active', count: 1
+      not_css 'li#tag-nav-tab-lists.inactive'
+      css 'li#tag-nav-tab-entities.inactive'
+    end
+  end
+
+  context 'edits tab is active' do
+    let(:active_tab) { :edits }
+
+    it 'sets correct active/inactive classes' do
+      css 'li#tag-nav-tab-edits.active', count: 1
+      not_css 'li#tag-nav-tab-edits.inactive'
+      css 'li#tag-nav-tab-entities.inactive'
+    end
+  end
+end


### PR DESCRIPTION
One idea I though of doing for this but didn't : adding last_user_id to Tagging to keep track of who added the tag...but perhaps it's not essential?

There's likely many style improvements to be made. Happy to get advice on that. 

![tags_edits](https://user-images.githubusercontent.com/8505044/30698449-02785f2a-9eb0-11e7-8e8d-a544662c46df.png)
