### PR TITLE
Lists tab on homepage sorted by number of list members

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -18,8 +18,15 @@ module TagsHelper
   end
 
   def tagable_list_sort_info(tagable, tag)
-    return "#{tagable.num_related} #{tag.name} relationships" if tagable.is_a? Entity
-    "edited #{time_ago_in_words(tagable.updated_at)} ago"
+    # TODO(ag): move this to an instance method on Tagable?
+    case tagable
+    when Entity
+      "#{tagable.relationship_count} #{tag.name} relationships"
+    when List
+      "#{tagable.entity_count} list members"
+    when Relationship
+      "edited #{time_ago_in_words(tagable.updated_at)} ago"
+    end
   end
 
   def tagable_link(tagable)

--- a/app/models/concerns/pagination.rb
+++ b/app/models/concerns/pagination.rb
@@ -1,0 +1,10 @@
+module Pagination
+  extend ActiveSupport::Concern
+
+  def paginate(page, per, records, count)
+    Kaminari
+      .paginate_array(records, total_count: count)
+      .page(page)
+      .per(per)
+  end
+end

--- a/app/models/concerns/pagination.rb
+++ b/app/models/concerns/pagination.rb
@@ -1,7 +1,5 @@
 module Pagination
-  extend ActiveSupport::Concern
-
-  def paginate(page, per, records, count)
+  def paginate(page, per, count, records)
     Kaminari
       .paginate_array(records, total_count: count)
       .page(page)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,5 @@
 class Tag < ActiveRecord::Base
+  include Pagination
   TAGABLE_PAGINATION_LIMIT = 20
 
   has_many :taggings
@@ -124,15 +125,10 @@ class Tag < ActiveRecord::Base
 
   def entities_for_homepage(page = 1)
     %w[Person Org].reduce({}) do |acc, type|
-      acc.merge(type => paginate(page, *sort_and_count_entities(type, page)))
+      acc.merge(type => paginate(page,
+                                 TAGABLE_PAGINATION_LIMIT,
+                                 *sort_and_count_entities(type, page)))
     end
-  end
-
-  def paginate(page, records, count)
-    Kaminari
-      .paginate_array(records, total_count: count)
-      .page(page)
-      .per(TAGABLE_PAGINATION_LIMIT)
   end
 
   def sort_and_count_entities(entity_type, page = 1)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -38,14 +38,15 @@ describe Tag do
     end
 
     describe "querying tagables for tag homepage" do
-      let(:entities_by_type) do
-        {
-          'Person' => Array.new(5) { create(:entity_person).tag(tag.id) },
-          'Org' => Array.new(5) { create(:entity_org).tag(tag.id) }
-        }
-      end
-
       context "entities" do
+
+        let(:entities_by_type) do
+          {
+            'Person' => Array.new(5) { create(:entity_person).tag(tag.id) },
+            'Org' => Array.new(5) { create(:entity_org).tag(tag.id) }
+          }
+        end
+
         before do
           relate = ->(x, ys) { ys.each { |y| create(:generic_relationship, entity: x, related: y) } }
           entities_by_type.each do |_, es|
@@ -60,7 +61,7 @@ describe Tag do
         it 'lists entities by type, sorted by relationships to same-tagged entities of any type' do
           tagable_list = tag.tagables_for_homepage(Entity.category_str)
           entities_by_type.each do |type, es|
-            id_counts = tagable_list[type].map { |p| [p.id, p.num_related] }
+            id_counts = tagable_list[type].map { |p| [p.id, p.relationship_count] }
 
             expect(id_counts[0]).to eq [es[4].id, 3]
             expect(id_counts[1, 2].to_set).to eq [[es[3].id, 2], [es[2].id, 2]].to_set
@@ -70,27 +71,58 @@ describe Tag do
         end
       end
 
-      context 'all other tagables' do
-        let(:lists) { Array.new(2) { create(:list)} }
-        let(:relationships) do
-          Array.new(2) do
-            create(:generic_relationship,
-                   entity: create(:entity_person),
-                   related: create(:entity_org))
+      context "lists" do
+
+        describe "sorting" do
+
+          let(:lists) { Array.new(2) { create(:list).tag(tag.id) } }
+          let(:tagables) { tag.tagables_for_homepage('lists') }          
+
+          before do
+            create(:list_entity, list_id: lists.second.id, entity_id: create(:entity_org).id)
+          end
+
+          it "lists tagged lists sorted by number of list members" do
+            expect(tagables.to_a).to eq lists.reverse
+          end
+
+          it "appends an `entities_count` field to List models" do
+            expect(tagables.map(&:entity_count)).to eq [1,0]
           end
         end
-        categories = Tagable.categories.reject { |c| c == Entity.category_sym }
 
-        categories.each do |tagable_cat|
-          before do
-            send(tagable_cat).each{ |t| t.tag(tag.id)}
-            send(tagable_cat).first.update_column(:updated_at, 1.day.ago)
+        describe "pagination" do
+
+          let(:page_limit){ Tag::TAGABLE_PAGINATION_LIMIT }
+          let(:lists) { Array.new(page_limit + 1) { create(:list).tag(tag.id) } }
+          before { lists }
+          
+          it "shows records corresponding to a given page" do
+            expect(tag.tagables_for_homepage('lists', 2).size).to eq 1
           end
-          context tagable_cat do
-            it "sorts #{tagable_cat} by date" do
-              expect(tag.tagables_for_homepage(tagable_cat).to_a).to eq send(tagable_cat).reverse
-            end
+
+          it "limits the number of records shown on a given page" do
+            expect(tag.tagables_for_homepage('lists').size).to eq 20
           end
+        end
+      end
+
+      context "relationships" do
+        let(:relationships) do
+          Array.new(2) do
+            create(
+              :generic_relationship,
+              entity: create(:entity_person),
+              related: create(:entity_org)
+            ).tag(tag.id)
+          end
+        end
+
+        before { relationships.first.update_column(:updated_at, 1.day.ago) }
+
+        it "lists tagged relationships sorted in descending order of last edit" do
+          expect(tag.tagables_for_homepage('relationships').to_a)
+            .to eq relationships.reverse
         end
       end
     end
@@ -235,5 +267,6 @@ describe Tag do
                                  'real estate' => @real_estate)
       end
     end
+    
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -150,20 +150,20 @@ describe Tag do
         before { entities; relationships; lists; }
 
         def it_contains_all_tagables
-          expect(Set.new(tag.recent_edits_query.map { |x| x['tagable_id'] }))
+          expect(Set.new(tag.send(:recent_edits_query).map { |x| x['tagable_id'] }))
             .to eql Set.new( (entities + lists + relationships).map(&:id) )
         end
 
         it 'contains a list of tag_added events' do
-          expect(tag.recent_edits_query.length).to eql 6
+          expect(tag.send(:recent_edits_query).length).to eql 6
           it_contains_all_tagables
         end
 
         it 'also contains a tagable_updated event' do
           relationships[0].update_column(:updated_at, Date.tomorrow)
-          expect(tag.recent_edits_query.length).to eql 7
+          expect(tag.send(:recent_edits_query).length).to eql 7
           it_contains_all_tagables
-          expect(tag.recent_edits_query[0])
+          expect(tag.send(:recent_edits_query)[0])
             .to eq(
                   "tagging_id" => relationships[0].taggings.first.id,
                   "tagable_id" => relationships[0].id,
@@ -177,11 +177,11 @@ describe Tag do
         it 'recent_edits returns an array of active record objects' do
           relationships[0].update_column(:updated_at, Date.tomorrow)
 
-          tag.recent_edits.each do |edit|
+          tag.send(:recent_edits).each do |edit|
             expect(Tagable.classes).to include edit['tagable'].class
           end
 
-          expect(tag.recent_edits.first['tagable']).to eq relationships[0]
+          expect(tag.send(:recent_edits).first['tagable']).to eq relationships[0]
           
         end
       end


### PR DESCRIPTION
resolves #309 

____________________

## Screenshot

![tags-homepage-list-sort](https://user-images.githubusercontent.com/6032844/30719241-b924fe5a-9ef0-11e7-98e7-e3a0373f5af4.png)

## Implementation Notes

* extract generic `Pagination` module, observe its contract in `tag.rb`
* use dynamic method delegation in `#tagables_for_homepage`
* try to establish conventions for helpers for `#tagables_for_homepage`
* use custom sql query for list sorting (as with entity sorting)
* introduce pagination test at model level
* mark helpers for `recent_edits_for_homepage` as private
