### PR TITLE
Org interlocks tab uses rails

### DIFF
--- a/app/helpers/entities_helper.rb
+++ b/app/helpers/entities_helper.rb
@@ -206,7 +206,7 @@ module EntitiesHelper
   def entity_tabs(entity, active_tab)
     tab_contents = [
       { text: 'Relationships',  path: entity_path(entity) },
-      { text: 'Interlocks',     path: entity.person? ? interlocks_entity_path(entity) : entity.legacy_url('interlocks') },
+      { text: 'Interlocks',     path: interlocks_entity_path(entity) },
       { text: 'Giving',         path: entity.legacy_url('giving') },
       { text: 'Political',      path: political_entity_path(entity) },
       { text: 'Data',           path: datatable_entity_path(entity) }
@@ -217,6 +217,27 @@ module EntitiesHelper
           link_to tab[:text], tab[:path]
         end
       end.reduce(:+)
+    end
+  end
+
+  def entity_interlocks_header_for(e)
+    title, subtitle = entity_interlocks_title_and_subtitle_for(e)
+    content_tag(:div, id: "entity-interlocks-header") do
+      content_tag(:div, title, id: "entity-interlocks-title") +
+        content_tag(:div, subtitle, id: "entity-interlocks-subtitle")
+    end
+  end
+
+  private
+
+  def entity_interlocks_title_and_subtitle_for(e)
+    case e.primary_ext
+    when "Person"
+      ["People in Common Orgs",
+       "People with positions in the same orgs as #{e.name}"]
+    when "Org"
+      ["Orgs with Common People",
+       "Leadership and staff of #{e.name} also have positions in these orgs"]
     end
   end
 end

--- a/app/models/concerns/interlocks.rb
+++ b/app/models/concerns/interlocks.rb
@@ -1,53 +1,76 @@
 module Interlocks
   # extend ActiveSupport::Concern
   def interlocks(page = 1)
-    # TODO: create position_scope for Link
-    org_ids = connecting_ids(rel_cat_id)
-    connected_id_hashes = paginate(page,
-                                   Entity::PER_PAGE,
-                                   connected_id_hashes_for(org_ids, rel_cat_id))
-
-    entities_by_id = Entity.lookup_table_for(collapse(connected_id_hashes))
-
-    connected_entities = connected_id_hashes.map do |connected_id_hash|
+    id_hashes = paginate(page, Entity::PER_PAGE, connected_id_hashes)
+    entities_by_id = Entity.lookup_table_for(collapse(id_hashes))
+    id_hashes.map do |id_hash|
       {
-        "connected_entity" => entities_by_id.fetch(connected_id_hash[:connected_id]),
-        "connecting_entities" => connected_id_hash[:connecting_ids].map { |id| entities_by_id.fetch(id) }
+        "connected_entity" => entities_by_id.fetch(id_hash[:connected_id]),
+        "connecting_entities" => id_hash[:connecting_ids].map { |id| entities_by_id.fetch(id) }
       }
     end
-    connected_entities
   end
 
   private
 
-  def rel_cat_id
-    Relationship::POSITION_CATEGORY
-  end
-
-  def connecting_ids(cat_id)
-    links
-      .where(entity1_id: id,
-             category_id: cat_id,
-             is_reverse: false)
-      .pluck(:entity2_id)
+  def connecting_ids
+    relationships
+      .where(root_entity_id_key => id, category_id: rel_category_ids)
+      .pluck(connecting_entity_id_key)
   end
 
   # TODO (ag|Tue 03 Oct 2017): extract object for this?
+  # ---
   # type ConnectedIdHash = { connected_id   => Integer,
   #                          connecting_ids => [Integer] }
   # ---
   # [Integer], Integer -> [ConnectedIdHash]
-  def connected_id_hashes_for(connecting_ids, rel_category_id)
-    Link
-      .where(entity2_id: connecting_ids,
-             category_id: rel_category_id,
-             is_reverse: false)
+  def connected_id_hashes
+    Relationship
+      .where(connecting_entity_id_key => connecting_ids, category_id: rel_category_ids)
       .to_a
-      .group_by(&:entity1_id)
-      .tap { |grouped_ids| grouped_ids.delete(id) }
-      .map { |connected_id, links| { connected_id: connected_id,
-                                     connecting_ids: links.map(&:entity2_id).uniq } }
+      .group_by(&root_entity_id_key)
+      .tap { |grouped_ids| grouped_ids.delete(id) } # filter out root id
+      .map { |connected_id, rels| connected_id_hash_for(connected_id, rels) }
       .sort { |a, b| b[:connecting_ids].count <=> a[:connecting_ids].count }
+  end
+
+  def connected_id_hash_for(connected_id, rels)
+    {
+      connected_id:    connected_id,
+      connecting_ids:  connecting_ids_for(rels)
+    }
+  end
+
+  def connecting_ids_for(relationships)
+    relationships.map(&connecting_entity_id_key).uniq
+  end
+
+  def rel_category_ids
+    case primary_ext
+    when "Person"
+      [Relationship::POSITION_CATEGORY]
+    when "Org"
+      [Relationship::POSITION_CATEGORY, Relationship::OWNERSHIP_CATEGORY]
+    end
+  end
+
+  def root_entity_id_key
+    case primary_ext
+    when "Person"
+      :entity1_id
+    when "Org"
+      :entity2_id
+    end
+  end
+
+  def connecting_entity_id_key
+    case primary_ext
+    when "Person"
+      :entity2_id
+    when "Org"
+      :entity1_id
+    end
   end
 
   # Array(ConnectedIdHash) => [Integer]

--- a/app/models/concerns/interlocks.rb
+++ b/app/models/concerns/interlocks.rb
@@ -47,12 +47,11 @@ module Interlocks
   end
 
   def rel_category_ids
-    case primary_ext
-    when "Person"
-      [Relationship::POSITION_CATEGORY]
-    when "Org"
-      [Relationship::POSITION_CATEGORY, Relationship::OWNERSHIP_CATEGORY]
-    end
+    # TODO (ag|03-Oct-2017):
+    # * eventually we would like to include OWNERSHIP_CATEGORY for people
+    # * as symphony does not do this and it contradicts the user-facing text
+    #   in `EntitiesHelper#entity_interlocks_header_for`, leave this unimplemented for now
+    [Relationship::POSITION_CATEGORY]
   end
 
   def root_entity_id_key

--- a/app/models/concerns/interlocks.rb
+++ b/app/models/concerns/interlocks.rb
@@ -3,18 +3,19 @@ module Interlocks
   def interlocks(page = 1)
     # TODO: create position_scope for Link
     org_ids = connecting_ids(rel_cat_id)
-    people_and_org_ids = paginate(page,
-                                  Entity::PER_PAGE,
-                                  connected_id_hashes_for(org_ids, rel_cat_id))
+    connected_id_hashes = paginate(page,
+                                   Entity::PER_PAGE,
+                                   connected_id_hashes_for(org_ids, rel_cat_id))
 
-    entities_by_id = Entity.lookup_table_for(collapse(people_and_org_ids))
+    entities_by_id = Entity.lookup_table_for(collapse(connected_id_hashes))
 
-    people_and_org_ids.map do |connected_id_hash|
+    connected_entities = connected_id_hashes.map do |connected_id_hash|
       {
-        "person" => entities_by_id.fetch(connected_id_hash[:connected_id]),
-        "orgs" => connected_id_hash[:connecting_ids].map { |id| entities_by_id.fetch(id) }
+        "connected_entity" => entities_by_id.fetch(connected_id_hash[:connected_id]),
+        "connecting_entities" => connected_id_hash[:connecting_ids].map { |id| entities_by_id.fetch(id) }
       }
     end
+    connected_entities
   end
 
   private
@@ -31,6 +32,7 @@ module Interlocks
       .pluck(:entity2_id)
   end
 
+  # TODO (ag|Tue 03 Oct 2017): extract object for this?
   # type ConnectedIdHash = { connected_id   => Integer,
   #                          connecting_ids => [Integer] }
   # ---

--- a/app/views/entities/_interlocks.html.erb
+++ b/app/views/entities/_interlocks.html.erb
@@ -1,42 +1,36 @@
 <% cache(['interlocks', @entity.alt_cache_key,  params[:page] ], expires_in: 2.days) do %>
 
-    <% interlocks = @entity.interlocks(params[:page]) %>
+  <% interlocks = @entity.interlocks(params[:page]) %>
 
-    <div id="entity-interlocks-container">
-	<div id="entity-interlocks-header">
-	    <div id="entity-interlocks-title">
-		People in Common Orgs
-	    </div>
-	    <div id="entity-interlocks-subtitle">
-		People with positions in the same orgs as <%=  @entity.name %>
-	    </div>
-	</div>
+  <div id="entity-interlocks-container">
 
-	<table class="table" id="entity-interlocks-table">
-	    <thead>
-		<tr>
-		    <th id="connecting-entity-header">Person</th>
-		    <th id="connected-entity-header">Common Orgs</th>
-		</tr>
-	    </thead>
-	    <tbody>
-		<% interlocks.each do |connected_entity_hash| %>
-		    <tr>
-		        <td class="connected-entity-cell">
-                          <% connected_entity =  connected_entity_hash['connected_entity'] %>
-			  <%= link_to connected_entity.name, connected_entity %>
-			</td>
-			<td class="connecting-entities-cell">
-			    <%= interlocks_entity_links(connected_entity_hash['connecting_entities']) %>
-			</td>
-		    </tr>
-		<% end %>
-	    </tbody>
-	</table>
+    <%= entity_interlocks_header_for(@entity)  %>
 
-	<div id="entity-interlocks-pagination">
-	    <%= paginate interlocks %>
-	</div>
+    <table class="table" id="entity-interlocks-table">
+      <thead>
+	<tr>
+	  <th id="connecting-entity-header">Person</th>
+	  <th id="connected-entity-header">Common Orgs</th>
+	</tr>
+      </thead>
+      <tbody>
+	<% interlocks.each do |connected_entity_hash| %>
+	  <tr>
+	    <td class="connected-entity-cell">
+              <% connected_entity =  connected_entity_hash['connected_entity'] %>
+	      <%= link_to connected_entity.name, connected_entity %>
+	    </td>
+	    <td class="connecting-entities-cell">
+	      <%= interlocks_entity_links(connected_entity_hash['connecting_entities']) %>
+	    </td>
+	  </tr>
+	<% end %>
+      </tbody>
+    </table>
+
+    <div id="entity-interlocks-pagination">
+      <%= paginate interlocks %>
     </div>
+  </div>
 
 <% end  %>

--- a/app/views/entities/_interlocks.html.erb
+++ b/app/views/entities/_interlocks.html.erb
@@ -22,11 +22,12 @@
 	    <tbody>
 		<% interlocks.each do |connected_entity_hash| %>
 		    <tr>
-			<td class="connected-entity-cell">
-			    <%= link_to connected_entity_hash['person'].name,  connected_entity_hash['person'] %>
+		        <td class="connected-entity-cell">
+                          <% connected_entity =  connected_entity_hash['connected_entity'] %>
+			  <%= link_to connected_entity.name, connected_entity %>
 			</td>
 			<td class="connecting-entities-cell">
-			    <%= interlocks_entity_links(connected_entity_hash['orgs']) %>
+			    <%= interlocks_entity_links(connected_entity_hash['connecting_entities']) %>
 			</td>
 		    </tr>
 		<% end %>

--- a/spec/factories/entities.rb
+++ b/spec/factories/entities.rb
@@ -62,4 +62,8 @@ FactoryGirl.define do
     blurb 'Ruining our democracy one dollar at a time'
     primary_ext 'Org'
   end
+
+  trait :with_last_user_id do
+    last_user_id APP_CONFIG['system_user_id']
+  end
 end

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -31,7 +31,13 @@ FactoryGirl.define do
   factory :position_relationship, class: Relationship do
     entity1_id 100
     entity2_id 200
-    category_id 1
+    category_id Relationship::POSITION_CATEGORY
+  end
+
+  factory :ownership_relationship, class: Relationship do
+    entity1_id 100 # hmm... why do we do this? is this good? (ag|Tue 03 Oct 2017)
+    entity2_id 200
+    category_id Relationship::OWNERSHIP_CATEGORY
   end
 
   factory :relationship, class: Relationship do

--- a/spec/features/entity_page_spec.rb
+++ b/spec/features/entity_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe "Entity Page", :interlocks_helper, :pagination_helper, type: :feature do
-  # TODO: include Routes (which will force internal handling of /people/..., /orgs/... routes)
+  include Routes
   let(:user) { create_basic_user }
   let(:person){ create(:entity_person, last_user_id: user.sf_guard_user.id) }
   let(:org){ create(:entity_org, last_user_id: user.sf_guard_user.id) }
@@ -196,7 +196,7 @@ describe "Entity Page", :interlocks_helper, :pagination_helper, type: :feature d
 
         it "displays the most-interlocked person's name as link" do
           expect(subject.find('.connected-entity-cell'))
-            .to have_link(person.name, href: "/person/#{people[3].to_param}")
+            .to have_link(person.name, href: entity_path(people[3]))
         end
 
         it "displays interlocking orgs' names as links in same row as interlocked people" do

--- a/spec/features/entity_page_spec.rb
+++ b/spec/features/entity_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe "Entity Page", :interlocks_helper, :pagination_helper, type: :feature do
-  include Routes
+  # TODO: include Routes (which will force internal handling of /people/..., /orgs/... routes)
   let(:user) { create_basic_user }
   let(:person){ create(:entity_person, last_user_id: user.sf_guard_user.id) }
   let(:org){ create(:entity_org, last_user_id: user.sf_guard_user.id) }
@@ -23,7 +23,6 @@ describe "Entity Page", :interlocks_helper, :pagination_helper, type: :feature d
       should_visit_entity_page "/person/#{person.to_param}"
       should_visit_entity_page "/person/#{person.to_param}/interlocks"
     end
-
     it 'accepts org as an valid entities slug' do
       should_visit_entity_page "/org/#{org.to_param}"
       should_visit_entity_page "/org/#{org.to_param}/interlocks"
@@ -167,42 +166,45 @@ describe "Entity Page", :interlocks_helper, :pagination_helper, type: :feature d
   end
 
   describe "interlocks tab" do
-    let(:people) { Array.new(4) { create(:entity_person, last_user_id: APP_CONFIG['system_user_id']) } }
-    let(:person) { people.first }
-    let(:orgs) { Array.new(3) { create(:entity_org) } }
+    let(:interlocks) {}
+    let(:root_entity) {}
+
     before do
-      interlock_people_via_orgs(people, orgs)
-      visit interlocks_entity_path(person)
+      interlocks
+      visit interlocks_entity_path(root_entity)
     end
 
-    describe "main container" do
-      it 'on the interlocks tab' do
-        expect(page).to have_current_path interlocks_entity_path(person)
-      end
+    context "for a person" do
+      let(:people) { Array.new(4) { create(:entity_person, :with_last_user_id) } }
+      let(:orgs) { Array.new(3) { create(:entity_org) } }
+      let(:root_entity) { people.first }
+      let(:interlocks) { interlock_people_via_orgs(people, orgs)}
 
-      it "shows a header and subheader" do
-        expect(page.find("#entity-interlocks-title"))
-          .to have_text "People in Common Orgs"
-        expect(page.find("#entity-interlocks-subtitle"))
-          .to have_text "same orgs as #{person.name}"
-      end
-
-      it "has a table of connected entites" do
-        expect(page.find("#entity-interlocks-table tbody")).to have_selector "tr", count: 3
-      end
-
-      describe "first row" do
-        subject { page.all("#entity-interlocks-table tbody tr").first }
-
-        it "displays the most-interlocked person's name as link" do
-          expect(subject.find('.connected-entity-cell'))
-            .to have_link(person.name, href: entity_path(people[3]))
+      describe "table layout" do
+        it "shows a header and subheader" do
+          expect(page.find("#entity-interlocks-title"))
+            .to have_text "People in Common Orgs"
+          expect(page.find("#entity-interlocks-subtitle"))
+            .to have_text "same orgs as #{person.name}"
         end
 
-        it "displays interlocking orgs' names as links in same row as interlocked people" do
-          orgs.each do |org|
-            expect(subject.find('.connecting-entities-cell'))
-              .to have_link(org.name, href: "/org/#{org.to_param}")
+        it "has a table of connected entites" do
+          expect(page.find("#entity-interlocks-table tbody")).to have_selector "tr", count: 3
+        end
+
+        describe "first row" do
+          subject { page.all("#entity-interlocks-table tbody tr").first }
+
+          it "displays the most-interlocked person's name as link" do
+            expect(subject.find('.connected-entity-cell'))
+              .to have_link(person.name, href: entity_path(people[3]))
+          end
+
+          it "displays interlocking orgs' names as links in same row as interlocked people" do
+            orgs.each do |org|
+              expect(subject.find('.connecting-entities-cell'))
+                .to have_link(org.name, href: entity_path(org))
+            end
           end
         end
       end
@@ -232,6 +234,40 @@ describe "Entity Page", :interlocks_helper, :pagination_helper, type: :feature d
           it "only shows #{Entity::PER_PAGE} rows" do
             expect(page.find("#entity-interlocks-table tbody"))
               .to have_selector "tr", count: Entity::PER_PAGE
+          end
+        end
+      end
+    end
+
+    context "for an organization" do
+      let(:orgs) { Array.new(4) { create(:entity_org, :with_last_user_id) } }
+      let(:people) { Array.new(3) { create(:entity_person) } }
+      let(:root_entity) { orgs.first }
+      let(:interlocks) { interlock_orgs_via_people(orgs, people) }
+
+      it "shows a header and subheader" do
+        expect(page.find("#entity-interlocks-title"))
+          .to have_text "Orgs with Common People"
+        expect(page.find("#entity-interlocks-subtitle"))
+          .to have_text "of #{org.name} also have"
+      end
+
+      it "has a table of connected entites" do
+        expect(page.find("#entity-interlocks-table tbody")).to have_selector "tr", count: 3
+      end
+
+      describe "first row" do
+        subject { page.all("#entity-interlocks-table tbody tr").first }
+
+        it "displays the most-interlocked org's name as link" do
+          expect(subject.find('.connected-entity-cell'))
+            .to have_link(org.name, href: entity_path(orgs[3]))
+        end
+
+        it "displays interlocking peoples' names as links in same row as interlocked org" do
+          people.each do |person|
+            expect(subject.find('.connecting-entities-cell'))
+              .to have_link(person.name, href: entity_path(person))
           end
         end
       end

--- a/spec/models/concerns/interlocks_spec.rb
+++ b/spec/models/concerns/interlocks_spec.rb
@@ -6,25 +6,25 @@ describe 'Entity: Interlocks', :interlocks_helper, :pagination_helper, type: :mo
     let(:people) { Array.new(4) { create(:entity_person) } }
     let(:person) { people.first }
     let(:orgs) { Array.new(3) { create(:entity_org) } }
+
     before { interlock_people_via_orgs(people, orgs) }
 
-    subject { person.interlocks.to_a }
+    context "with less interlocks than pagination limit" do
 
-    context "with less than #{Entity::PER_PAGE} interlocks" do
-      it "returns a list of people in common orgs" do
-        expect(subject)
+      it "lists all people in common orgs" do
+        expect(person.interlocks.to_a)
           .to eq([
                    {
-                     "person" => people[3],
-                     "orgs" => orgs.take(3)
+                     "connected_entity"    => people[3],
+                     "connecting_entities" => orgs.take(3)
                    },
                    {
-                     "person" => people[2],
-                     "orgs" => orgs.take(2)
+                     "connected_entity"    => people[2],
+                     "connecting_entities" => orgs.take(2)
                    },
                    {
-                     "person" => people[1],
-                     "orgs" => orgs.take(1)
+                     "connected_entity"    => people[1],
+                     "connecting_entities" => orgs.take(1)
                    }
                  ])
       end

--- a/spec/models/concerns/interlocks_spec.rb
+++ b/spec/models/concerns/interlocks_spec.rb
@@ -45,4 +45,33 @@ describe 'Entity: Interlocks', :interlocks_helper, :pagination_helper, type: :mo
       end
     end
   end
+
+  context "for an org" do
+    let(:orgs) { Array.new(4) { create(:entity_org) } }
+    let(:org) { orgs.first }
+    let(:people) { Array.new(3) { create(:entity_person) } }
+
+    before { interlock_orgs_via_people(orgs, people) }
+
+    context "with less interlocks than pagination limit" do
+
+      it "lists all orgs with common staff or owners" do
+        expect(org.interlocks.to_a)
+          .to eql([
+                    {
+                      "connected_entity" => orgs[3],
+                      "connecting_entities" => people.take(3)
+                    },
+                    {
+                      "connected_entity" => orgs[2],
+                      "connecting_entities" => people.take(2)
+                    },
+                    {
+                      "connected_entity" => orgs[1],
+                      "connecting_entities" => people.take(1)
+                    }
+                  ])
+      end
+    end
+  end
 end

--- a/spec/support/interlocks_helper.rb
+++ b/spec/support/interlocks_helper.rb
@@ -1,6 +1,7 @@
 module InterlocksExampleHelper
   def interlock_people_via_orgs(people, orgs)
-    # person[0] is related to all orgs, person[n] is related to n orgs
+    # person[0] is the root of the interlocks tree and is related to all orgs
+    # person[n] is a leaf of the interlocks tree and is related to n orgs
     people.each_with_index do |p, idx|
       org_subset = idx.zero? ? orgs : orgs.take(idx)
       org_subset.each { |o| create(:position_relationship, entity: p, related: o) }
@@ -8,10 +9,17 @@ module InterlocksExampleHelper
   end
 
   def interlock_orgs_via_people(orgs, people)
-    # org[0] is related to all people, org[n] is related to n people
-    orgs.each_with_index do |o, idx|
-      people_subset = idx.zero? ? people : people.take(idx)
-      people_subset.each { |p| create(:position_relationship, entity: p, related: o) }
+    # org[0] is the root of the interlocks tree and is related to all people
+    # org[n] is a leaf of the interlocks tree and is related to n people
+    orgs.each_with_index do |o, i|
+      people_subset = i.zero? ? people : people.take(i)
+      people_subset.each_with_index do |p, j|
+        if j.even?
+          create(:position_relationship, entity: p, related: o)
+        else
+          create(:ownership_relationship, entity: p, related: o)
+        end
+      end
     end
   end
 end

--- a/spec/support/interlocks_helper.rb
+++ b/spec/support/interlocks_helper.rb
@@ -13,13 +13,7 @@ module InterlocksExampleHelper
     # org[n] is a leaf of the interlocks tree and is related to n people
     orgs.each_with_index do |o, i|
       people_subset = i.zero? ? people : people.take(i)
-      people_subset.each_with_index do |p, j|
-        if j.even?
-          create(:position_relationship, entity: p, related: o)
-        else
-          create(:ownership_relationship, entity: p, related: o)
-        end
-      end
+      people_subset.each { |p| create(:position_relationship, entity: p, related: o) }
     end
   end
 end

--- a/spec/support/interlocks_helper.rb
+++ b/spec/support/interlocks_helper.rb
@@ -1,10 +1,17 @@
 module InterlocksExampleHelper
   def interlock_people_via_orgs(people, orgs)
     # person[0] is related to all orgs, person[n] is related to n orgs
-    people.each_with_index do |person, idx|
-      (idx.zero? ? orgs : orgs.take(idx)).each do |org|
-        create(:position_relationship, entity: person, related: org)
-      end
+    people.each_with_index do |p, idx|
+      org_subset = idx.zero? ? orgs : orgs.take(idx)
+      org_subset.each { |o| create(:position_relationship, entity: p, related: o) }
+    end
+  end
+
+  def interlock_orgs_via_people(orgs, people)
+    # org[0] is related to all people, org[n] is related to n people
+    orgs.each_with_index do |o, idx|
+      people_subset = idx.zero? ? people : people.take(idx)
+      people_subset.each { |p| create(:position_relationship, entity: p, related: o) }
     end
   end
 end


### PR DESCRIPTION
resolves #334 

----

## Artifacts

New page, same as the old page:

![interlocks-tab-orgs](https://user-images.githubusercontent.com/6032844/31153524-a89bdf3a-a86f-11e7-823a-e51e9186a166.png)

## Implementation Notes:

### in Interlocks module:

* replace `person` and `orgs` keys with `connected_entity` and `connecting_entities`
* add helper functions to abstract over entity & category ids
  * `#root_entity_id_key` switches on `primary_ext` to determine the hash key we should use to query an interlock tree's root entity -- (either `:entity1_id` or `:entity2_id`)
  * `#connecting_entity_id_key` switches on `primary_ext` to determine the hash key we should use to query an interlock tree's first-hop nodes (ie: connecting entities) -- (either `:entity1_id or :entity2_id)

### in views:

* use generalized key names for `connected_id` has in `_interlocks` partial (eliminating `person` and `orgs` as in `interlocks.rb`
* create `#entity_interlocks_header` helper to dynamically generate title and subtitle text for interlocks table for both people and orgs
* eliminate legacy urls in interlock tab hrefs for people

### in specs:

* add `:with_last_user_id` trait for entity factories
* add `:ownership_relationship` factory
* add slightly more future-proof comments to interlock creation helpers

## Left TODO

* commit 2966642 added owernship relationships as a valid interlock relationship
* commit 35f34e2 removed them to keep parity with symfony and left a comment about adding them back in later


