### PR TITLE
[#362] switch position of child/parent order on relationship edit page

### DIFF
--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -108,4 +108,14 @@ module RelationshipsHelper
       label + content_tag(:div, class: html_class) { field }
     end
   end
+
+  # <Relationship> -> [ Struct ]
+  # Struct fields: title (String), entity (Entity)
+  def description_fields_titles_and_entites(relationship)
+    titles = Relationship::DESCRIPTION_FIELDS_DISPLAY_NAMES[relationship.category_id]
+    entities = [relationship.entity, relationship.related]
+    titles_and_entities = titles.zip(entities)
+    titles_and_entities.reverse! if relationship.is_hierarchy?
+    titles_and_entities.map { |x| Struct.new(:title, :entity).new(*x) }
+  end
 end

--- a/app/views/relationships/_description_fields_display.html.erb
+++ b/app/views/relationships/_description_fields_display.html.erb
@@ -1,27 +1,17 @@
-<% e1_name, e2_name = Relationship::DESCRIPTION_FIELDS_DISPLAY_NAMES[@relationship.category_id] %>
+<div id="relationship-edit-description-fields-display">
+  <% first_entity, second_entity = description_fields_titles_and_entites(@relationship) %>
+  
+  <%= render partial: 'description_fields_entity_row', locals: { relationship_entity: first_entity }  %>
 
-<div class="row">
-    <div class="col-sm-2">
-	<p><%= e1_name + ':' %></p>
-    </div>
-    <div class="col-sm-5">
-	<%= entity_link(@relationship.entity, html_class: 'link-blue') %>
-    </div>
-</div>
-<% if @relationship.is_reversible?  %>
+  <% if @relationship.is_reversible?  %>
     <div class="row">
-	<div class="col-sm-2 col-sm-offset-2" style="padding-bottom: 7px">
-	    <div style="padding-left: 8px">
-		<%= reverse_link %>
-	    </div>
+      <div class="col-sm-2 col-sm-offset-2" style="padding-bottom: 7px">
+	<div style="padding-left: 8px">
+	  <%= reverse_link %>
 	</div>
+      </div>
     </div>
-<% end  %>
-<div class="row">
-    <div class="col-sm-2">
-	<p><%= e2_name + ':' %></p>
-    </div>
-    <div class="col-sm-5">
-	<%= entity_link(@relationship.related, html_class: 'link-blue') %>
-    </div>
+  <% end  %>
+
+  <%= render partial: 'description_fields_entity_row', locals: { relationship_entity: second_entity }  %>
 </div>

--- a/app/views/relationships/_description_fields_entity_row.html.erb
+++ b/app/views/relationships/_description_fields_entity_row.html.erb
@@ -1,0 +1,10 @@
+<%# Locals: relationship_entity (Struct)  %>
+
+<div class="row">
+  <div class="col-sm-2">
+    <p><%= relationship_entity.title + ':' %></p>
+  </div>
+  <div class="col-sm-5">
+    <%= link_to relationship_entity.entity.name, relationship_entity.entity %>
+  </div>
+</div>

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -42,6 +42,10 @@ FactoryGirl.define do
     category_id Relationship::OWNERSHIP_CATEGORY
   end
 
+  factory :hierarchy_relationship, class: Relationship do
+    category_id Relationship::HIERARCHY_CATEGORY
+  end
+
   factory :relationship, class: Relationship do
     association :entity, factory: :person, strategy: :build
     association :related, factory: :mega_corp_llc, strategy: :build

--- a/spec/features/edit_relationship_page_spec.rb
+++ b/spec/features/edit_relationship_page_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'Edit Relationship Page', type: :feature do
+  let(:user) { create_basic_user }
+  let(:child_org) { create(:entity_org, name: 'child org') }
+  let(:parent_org) { create(:entity_org, name: 'parent org') }
+  let(:hierarchy_relationship) do
+    create(:hierarchy_relationship, entity: child_org, related: parent_org, last_user_id: user.sf_guard_user_id)
+  end
+
+  context 'user is not logged in' do
+    before { visit edit_relationship_path(hierarchy_relationship) }
+    redirects_to_login_page
+  end
+
+  context 'user is logged in' do
+    before { login_as(user, scope: :user) }
+    after { logout(user) }
+
+    context 'Editing a hiearchical relationship' do
+      before { visit edit_relationship_path(hierarchy_relationship) }
+
+      it 'displays relationship title with link' do
+        page_has_selector 'h1.relationship-title-link a', count: 1, text: hierarchy_relationship.name
+        expect(page.all('h1.relationship-title-link a').first['href'])
+          .to eql relationship_path(hierarchy_relationship)
+      end
+
+      it 'Shows parent above child' do
+        selector = "#relationship-edit-description-fields-display p"
+        page_has_selector selector, count: 2
+        expect(page.all(selector).map(&:text)).to eql ['Parent:', 'Child:']
+      end
+    end # end 'hiearchical relationship
+
+    context 'editing a membership relationship' do
+      let(:membership_relationship) do
+        create(:membership_relationship, entity: create(:entity_person), related: create(:entity_org), last_user_id: user.sf_guard_user_id)
+      end
+
+      before { visit edit_relationship_path(membership_relationship) }
+
+      it "shows links to entities in correct order: 'member', 'organization'" do
+        selector = "#relationship-edit-description-fields-display p"
+        page_has_selector selector, count: 2
+        expect(page.all(selector).map(&:text)).to eql ['Member:', 'Organization:']
+      end
+    end
+  end # end 'user is logged in'
+end

--- a/spec/support/feature_macros.rb
+++ b/spec/support/feature_macros.rb
@@ -9,11 +9,17 @@ end
 # for use in example groups
 module FeatureGroupMacros
   include FeatureSharedMacros
-  
+
   def denies_access
     it 'denies access' do
       expect(page.status_code).to eq 403
       expect(page).to have_content 'Bad Credentials'
+    end
+  end
+
+  def redirects_to_login_page
+    it 'redirects to /login' do
+      expect(page.current_path).to eql '/login'
     end
   end
 end


### PR DESCRIPTION
"Parent" now appears before "Child" on the edit relationship page:

![child_parent_edit_page](https://user-images.githubusercontent.com/8505044/31458197-53e092e6-ae8d-11e7-8876-53556771a161.png)

This resolves #362 and #259 

Also see https://github.com/public-accountability/littlesis-browser-addon/issues/20 for related changes to the browser extension
