### PR TITLE
Add `edited by` column to tags edit page

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -34,16 +34,20 @@ module TagsHelper
   end
 
   def tags_edits_format_time(edit_event)
-    if edit_event['event'] == 'tag_added' || edit_event['tagable_class'] == 'List'
-      "Edited #{time_ago_in_words(edit_event['event_timestamp'])} ago"
-    else
-      username = edit_event['tagable']&.last_user&.user&.username || 'System'
-      "Edited #{time_ago_in_words(edit_event['event_timestamp'])} ago by #{username}"
-    end
+    "#{time_ago_in_words(edit_event['event_timestamp'])} ago"
   end
 
   def tags_edits_format_action(edit_event)
     action_text = { 'tagable_updated' => 'updated', 'tag_added' => 'tagged' }
     "#{edit_event['tagable_class']} #{action_text[edit_event['event']]}"
+  end
+
+  def tags_edits_format_editor(edit_event)
+    e = edit_event['editor']
+    e.username == "system" ? "System" : link_to(e.username, legacy_user_path(e))
+  end
+
+  def legacy_user_path(user)
+    "/user/#{user.username}"
   end
 end

--- a/app/models/concerns/tagable.rb
+++ b/app/models/concerns/tagable.rb
@@ -51,10 +51,11 @@ module Tagable
   end
 
   def tag(name_or_id, user_id = APP_CONFIG['system_user_id'])
-    Tagging.find_or_create_by(tag_id:         parse_tag_id!(name_or_id),
-                              tagable_class:  self.class.name,
-                              tagable_id:     id,
-                              last_user_id:   user_id)
+    t = Tagging
+        .find_or_initialize_by(tag_id:         parse_tag_id!(name_or_id),
+                               tagable_class:  self.class.name,
+                               tagable_id:     id)
+    t.update(last_user_id: user_id) unless t.persisted?
     self
   end
 

--- a/app/models/concerns/tagable.rb
+++ b/app/models/concerns/tagable.rb
@@ -50,16 +50,17 @@ module Tagable
     self
   end
 
-  def tag(name_or_id)
+  def tag(name_or_id, user_id = APP_CONFIG['system_user_id'])
     Tagging.find_or_create_by(tag_id:         parse_tag_id!(name_or_id),
                               tagable_class:  self.class.name,
-                              tagable_id:     self.id)
+                              tagable_id:     id,
+                              last_user_id:   user_id)
     self
   end
 
-  def tag_without_callbacks(name_or_id)
+  def tag_without_callbacks(name_or_id, user_id = APP_CONFIG['system_user_id'])
     Tagging.skip_callback(:save, :after, :update_tagable_timestamp)
-    tag(name_or_id)
+    tag(name_or_id, user_id)
   ensure
     Tagging.set_callback(:save, :after, :update_tagable_timestamp)
   end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -753,7 +753,7 @@ class Entity < ActiveRecord::Base
       aliases.create(name: name, is_primary: false, last_user_id: Lilsis::Application.config.system_user_id)
     end
 
-    association_data['tags'].each { |tag_name| tag_without_callbacks(tag_name) }
+    association_data['tags'].each { |tag_name| add_tag_without_callbacks(tag_name) }
     Image.unscoped.where(entity_id: self.id).update_all(is_deleted: false)
 
     update(is_deleted: false)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -93,7 +93,7 @@ class Tag < ActiveRecord::Base
 
   def recent_edits(page = 1)
     edit_id_hashes = recent_edit_ids(page)
-    edits_by_class_and_id = edits_by_class_and_id_for(edit_id_hashes)
+    tagables_by_class_and_id = tagables_by_class_and_id_for(edit_id_hashes)
     editors_by_id = editors_by_id(edit_id_hashes)
 
     edit_id_hashes.map do |h|
@@ -101,7 +101,7 @@ class Tag < ActiveRecord::Base
         'tagable_class'   => h['tagable_class'],
         'event'           => h['event'],
         'event_timestamp' => h['event_timestamp'],
-        'tagable'         => edits_by_class_and_id.dig(h['tagable_class'], h['tagable_id']),
+        'tagable'         => tagables_by_class_and_id.dig(h['tagable_class'], h['tagable_id']),
         'editor'          => editors_by_id[h['editor_id']]
       }
     end
@@ -241,13 +241,13 @@ class Tag < ActiveRecord::Base
     result
   end
 
-  # type EditsByClassAndId = {
+  # type TagablesByClassAndId = {
   #   "Relationship" => { [id: Integer] => Relationship }
   #   "Entity"       => { [id: Integer] => Entity }
   #   "List"         => { [id: Integer] => List }
   # }
-  # [EditsIdHash] -> EditsByClassAndId
-  def edits_by_class_and_id_for(edits_id_hash)
+  # [EditsIdHash] -> TagablesByClassAndId
+  def tagables_by_class_and_id_for(edits_id_hash)
     base = { "Relationship" => {}, "Entity" => {}, "List" => {} }
     edits_id_hash
       .group_by { |h| h['tagable_class'] }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -49,73 +49,9 @@ class Tag < ActiveRecord::Base
     restricted
   end
 
-  # int -> Kaminari::PaginatableArray
-  def recent_edits_for_homepage(page = 1)
-    paginate(
-      page,
-      PER_PAGE,
-      recent_edits(page),
-      taggings.count * 2
-    )
-  end
-
+  # Integer -> Kaminari::PaginatableArray
   def tagables_for_homepage(tagable_category, page = 1)
     send("#{tagable_category}_for_homepage", page)
-  end
-
-  private
-  # -> [Hash]
-  # Adds the ActiveRecord Tagable with key 'tagable' to
-  # each hash provided by #recent_edits_query.
-  def recent_edits(page = 1)
-    edits = recent_edits_query(page)
-    active_record_lookup = active_record_lookup_for_recent_edits(edits)
-    edits.map do |edit|
-      edit.tap { |h| h.store 'tagable', active_record_lookup.dig(h['tagable_class'], h['tagable_id']) }
-    end
-  end
-
-  # int -> [ Hash ]
-  # Hash keys: tagging_id, tagable_id, tagable_class, tagging_created_at, event_timestamp, event
-  def recent_edits_query(page = 1)
-    sql = <<-SQL
-      (
-        SELECT taggings.id as tagging_id,
-                taggings.tagable_id,
-                taggings.tagable_class,
-                taggings.created_at as tagging_created_at,
-                COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at) AS event_timestamp,
-	        'tagable_updated' as event
-	FROM taggings
-	LEFT JOIN entity ON taggings.tagable_id = entity.id AND taggings.tagable_class = 'Entity'
- 	LEFT JOIN ls_list ON taggings.tagable_id = ls_list.id AND taggings.tagable_class = 'List'
-	LEFT JOIN relationship ON taggings.tagable_id = relationship.id AND taggings.tagable_class = 'Relationship'
-	WHERE taggings.tag_id = #{id}
-              # adding a tag triggers a callback that also updates the tagable. This clause excludes those updates
-	      AND abs(TIMESTAMPDIFF(SECOND, taggings.created_at, COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at))) > 100
-      )
-        UNION
-      (
-        SELECT taggings.id as tagging_id,
-	       taggings.tagable_id,
-	       taggings.tagable_class,
-	       taggings.created_at AS tagging_created_at,
-	       taggings.created_at AS event_timestamp,
-	       'tag_added' AS event
-        FROM taggings
-	WHERE taggings.tag_id = #{id}
-      )
-        ORDER BY event_timestamp DESC
-        LIMIT #{PER_PAGE}
-        OFFSET #{ (page.to_i - 1) * PER_PAGE }
-    SQL
-
-    # NOTE: our version of Mysql2::Result is missing the very convenient method: #to_hash ...why?
-    # we should be able to do ActiveRecord::Base.connection.execute(sql).to_hash instead of
-    # populating the array ourselves...
-    result = []
-    ActiveRecord::Base.connection.execute(sql).each(:as => :hash) { |h| result << h }
-    result
   end
 
   def entities_for_homepage(page = 1)
@@ -126,11 +62,54 @@ class Tag < ActiveRecord::Base
     end
   end
 
+  def lists_for_homepage(page = 1)
+    paginate(page,
+             PER_PAGE,
+             *count_and_sort_lists(page))
+  end
+
+  def relationships_for_homepage(page = 1)
+    relationships
+      .order(updated_at: :desc)
+      .page(page)
+      .per(PER_PAGE)
+  end
+
+  def recent_edits_for_homepage(page = 1)
+    paginate(page,
+             PER_PAGE,
+             recent_edits(page),
+             taggings.count * 2)
+  end
+
+  # type EditsIdHash = {
+  #   tagable:            Tagable,
+  #   tagable_class:      String,
+  #   event_timestamp:    Timestamp,
+  #   editor:             User, (Rails user)
+  #   event:              Enum('tag_added', 'tagable_updated')
+  # }
+  # Integer -> [EditsHash]
+
+  def recent_edits(page = 1)
+    edit_id_hashes = recent_edit_ids(page)
+    edits_by_class_and_id = edits_by_class_and_id_for(edit_id_hashes)
+    editors_by_id = editors_by_id(edit_id_hashes)
+
+    edit_id_hashes.map do |h|
+      {
+        'tagable_class'   => h['tagable_class'],
+        'event'           => h['event'],
+        'event_timestamp' => h['event_timestamp'],
+        'tagable'         => edits_by_class_and_id.dig(h['tagable_class'], h['tagable_id']),
+        'editor'          => editors_by_id[h['editor_id']]
+      }
+    end
+  end
+
+  private
+
   def count_and_sort_entities(entity_type, page = 1)
-    # return tuple of:
-    # (1) all entities of type `entity_type` tagged `self`,
-    #     sorted by # relationships to other entities also tagged `self`
-    # (2) count of all entities of type `entity_type` tagged `self`
     [
       entities_by_relationship_count(entity_type, page),
       entities.where(primary_ext: entity_type).count
@@ -187,14 +166,6 @@ class Tag < ActiveRecord::Base
     Entity.find_by_sql(sql)
   end
 
-  def lists_for_homepage(page = 1)
-    paginate(
-      page,
-      PER_PAGE,
-      *count_and_sort_lists(page)
-    )
-  end
-
   def count_and_sort_lists(page = 1)
     [lists_by_entity_count(page), lists.count]
   end
@@ -204,12 +175,10 @@ class Tag < ActiveRecord::Base
     query = <<-SQL
       SELECT DISTINCT ls_list.*, COUNT(ls_list_entity.id) AS entity_count
       FROM ls_list
-      INNER JOIN taggings 
-        ON ls_list.id = taggings.tagable_id 
-        AND taggings.tag_id = #{id} 
+      INNER JOIN taggings ON ls_list.id = taggings.tagable_id
+        AND taggings.tag_id = #{id}
         AND taggings.tagable_class = 'List'
-      LEFT JOIN ls_list_entity 
-        ON ls_list_entity.list_id = ls_list.id
+      LEFT JOIN ls_list_entity ON ls_list_entity.list_id = ls_list.id
       WHERE ls_list.is_deleted = 0
       GROUP BY ls_list.id
       ORDER BY entity_count DESC
@@ -219,29 +188,85 @@ class Tag < ActiveRecord::Base
     List.find_by_sql query
   end
 
-  def relationships_for_homepage(page = 1)
-    relationships
-      .order(updated_at: :desc)
-      .page(page)
-      .per(PER_PAGE)
+  # type EditsIdHash = {
+  #   tagging_id:          Integer,
+  #   tagable_id:          Integer,
+  #   tagable_class:       String,
+  #   tagging_created_at:  Timestamp,
+  #   event_timestamp:     Timestamp,
+  #   editor:              Integer,
+  #   event:               Enum('tag_added', 'tagable_updated')
+  # }
+  # Integer -> [EditsIdHash]
+  def recent_edit_ids(page = 1)
+    sql = <<-SQL
+      (
+        SELECT taggings.id as tagging_id,
+               taggings.tagable_id,
+               taggings.tagable_class,
+               taggings.created_at as tagging_created_at,
+               COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at) AS event_timestamp,
+               COALESCE(entity.last_user_id, ls_list.last_user_id, relationship.last_user_id) AS editor_id,
+               'tagable_updated' as event
+	FROM taggings
+	LEFT JOIN entity ON taggings.tagable_id = entity.id AND taggings.tagable_class = 'Entity'
+ 	LEFT JOIN ls_list ON taggings.tagable_id = ls_list.id AND taggings.tagable_class = 'List'
+	LEFT JOIN relationship ON taggings.tagable_id = relationship.id AND taggings.tagable_class = 'Relationship'
+	WHERE taggings.tag_id = #{id}
+            # adding a tag triggers a callback that also updates the tagable. This clause excludes those updates
+	    AND abs(TIMESTAMPDIFF(SECOND, taggings.created_at, COALESCE(entity.updated_at, ls_list.updated_at, relationship.updated_at))) > 100
+      )
+        UNION
+      (
+        SELECT taggings.id as tagging_id,
+	       taggings.tagable_id,
+	       taggings.tagable_class,
+	       taggings.created_at AS tagging_created_at,
+	       taggings.created_at AS event_timestamp,
+               taggings.last_user_id AS editor_id,
+	       'tag_added' AS event
+        FROM taggings
+	WHERE taggings.tag_id = #{id}
+      )
+        ORDER BY event_timestamp DESC
+        LIMIT #{PER_PAGE}
+        OFFSET #{(page.to_i - 1) * PER_PAGE}
+    SQL
+
+    # NOTE: our version of Mysql2::Result is missing the very convenient method: #to_hash ...why?
+    # we should be able to do ActiveRecord::Base.connection.execute(sql).to_hash instead of
+    # populating the array ourselves...
+    result = []
+    ActiveRecord::Base.connection.execute(sql).each(:as => :hash) { |h| result << h }
+    result
   end
 
-  # [ Hash ] -> Hash
-  #  example: output:
-  # {
-  #  "Relationship" => { 12 => <Relationship>, 22 => <Relationship> }
-  #  "Entity" => { 123 => <Entity>}
-  #  "List" => { 987 => <List> }
+  # type EditsByClassAndId = {
+  #   "Relationship" => { [id: Integer] => Relationship }
+  #   "Entity"       => { [id: Integer] => Entity }
+  #   "List"         => { [id: Integer] => List }
   # }
-  #
-  def active_record_lookup_for_recent_edits(edits)
-    edits
+  # [EditsIdHash] -> EditsByClassAndId
+  def edits_by_class_and_id_for(edits_id_hash)
+    base = { "Relationship" => {}, "Entity" => {}, "List" => {} }
+    edits_id_hash
       .group_by { |h| h['tagable_class'] }
       .transform_values { |tagable_array| tagable_array.map { |h| h['tagable_id'] }.uniq }
       .to_a
-      .reduce("Relationship" => {}, "Entity" => {}, "List" => {}) do |acc, (klass, tagable_ids)|
+      .reduce(base) do |acc, (klass, tagable_ids)|
         klass.constantize.find(tagable_ids).each { |tagable| acc[klass].store(tagable.id, tagable) }
         acc
       end
+  end
+
+  # type EditorsById = { [id: Integer] => User }
+  # [EditsIdHash] => EditorsById
+  def editors_by_id(id_hashes)
+    ids = id_hashes.map { |h| h['editor_id'] }
+    SfGuardUser.find(ids)
+      .to_a
+      .map(&:user)
+      .zip(ids)
+      .reduce({}) { |acc, (editor, id)| acc.merge!(id => editor) }
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,13 +1,13 @@
 class Tagging < ActiveRecord::Base
-  DEFAULT_LAST_USER_ID = APP_CONFIG.fetch('system_user_id')
   belongs_to :tagable, polymorphic: true, foreign_type: :tagable_class
+  belongs_to :last_user, class_name: "SfGuardUser", foreign_key: "last_user_id"
   validates_presence_of :tag_id, :tagable_class, :tagable_id
 
   belongs_to :tag
 
   after_save :update_tagable_timestamp
 
-  def update_tagable_timestamp(last_user_id = DEFAULT_LAST_USER_ID)
+  def update_tagable_timestamp(last_user_id = APP_CONFIG['system_user_id'])
     if tagable.last_user_id == last_user_id
       tagable.touch
     else

--- a/app/views/tags/edits.html.erb
+++ b/app/views/tags/edits.html.erb
@@ -1,27 +1,29 @@
 <div id="tag-show-container">
-    <%= render partial: 'header', locals: { tag: @tag, active_tab: :edits } %>
+  <%= render partial: 'header', locals: { tag: @tag, active_tab: :edits } %>
 </div>
 
 <div id="tag-homepage-edits-table-container" class="top-1em">
-    <table class="table" id="tag-homepage-edits-table">
-	<thead>
-	    <tr>
-		<th>Tagged Resource</th>
-		<th>Action</th>
-		<th>Time</th>
-	    </tr>
-	</thead>
-	<tbody>
-	    <% @recent_edits.each do |edit_event| %>
-		<tr>
-		    <td><%= tagable_link edit_event['tagable'] %></td>
-		    <td><%= tags_edits_format_action(edit_event) %></td>
-		    <td><%= tags_edits_format_time(edit_event) %></td>
-		</tr>
-	    <% end %>
-	</tbody>
-    </table>
+  <table class="table" id="tag-homepage-edits-table">
+    <thead>
+      <tr>
+	<th>Tagged Resource</th>
+	<th>Action</th>
+	<th>Time</th>
+        <th>Edited by</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @recent_edits.each do |edit_event| %>
+	<tr>
+	  <td><%= tagable_link edit_event['tagable'] %></td>
+	  <td><%= tags_edits_format_action(edit_event) %></td>
+	  <td><%= tags_edits_format_time(edit_event) %></td>
+          <td><%= tags_edits_format_editor(edit_event) %></td>
+	</tr>
+      <% end %>
+    </tbody>
+  </table>
 
-    <%= link_to_previous_page @recent_edits, 'Previous Page' %>
-    <%= link_to_next_page @recent_edits, 'Next Page', class: 'pull-right' %>
+  <%= link_to_previous_page @recent_edits, 'Previous Page' %>
+  <%= link_to_next_page @recent_edits, 'Next Page', class: 'pull-right' %>
 </div>

--- a/db/migrate/20171010214602_add_last_user_id_to_tagging.rb
+++ b/db/migrate/20171010214602_add_last_user_id_to_tagging.rb
@@ -1,0 +1,5 @@
+class AddLastUserIdToTagging < ActiveRecord::Migration
+  def change
+    add_column :taggings, :last_user_id, :int, default: APP_CONFIG['system_user_id'], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170921224247) do
+ActiveRecord::Schema.define(version: 20171010214602) do
 
   create_table "address", force: :cascade do |t|
     t.integer  "entity_id",    limit: 8,                   null: false
@@ -1529,11 +1529,12 @@ ActiveRecord::Schema.define(version: 20170921224247) do
   add_index "tag", ["name"], name: "uniqueness_idx", unique: true, using: :btree
 
   create_table "taggings", force: :cascade do |t|
-    t.integer  "tag_id",        limit: 4,   null: false
-    t.string   "tagable_class", limit: 255, null: false
-    t.integer  "tagable_id",    limit: 4,   null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.integer  "tag_id",        limit: 4,               null: false
+    t.string   "tagable_class", limit: 255,             null: false
+    t.integer  "tagable_id",    limit: 4,               null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.integer  "last_user_id",  limit: 4,   default: 1, null: false
   end
 
   add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,7 @@ CREATE TABLE `alias` (
   KEY `name_idx` (`name`),
   CONSTRAINT `alias_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `alias_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1580 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -166,7 +166,7 @@ CREATE TABLE `api_tokens` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_api_tokens_on_token` (`token`),
   UNIQUE KEY `index_api_tokens_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -346,7 +346,7 @@ CREATE TABLE `business` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `business_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -382,7 +382,7 @@ CREATE TABLE `business_person` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `business_person_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=47 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -529,7 +529,7 @@ CREATE TABLE `delayed_jobs` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=65 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -563,7 +563,7 @@ CREATE TABLE `donation` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `donation_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `donation_ibfk_2` FOREIGN KEY (`bundler_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=81 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -584,7 +584,7 @@ CREATE TABLE `education` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `education_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `education_ibfk_2` FOREIGN KEY (`degree_id`) REFERENCES `degree` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -606,7 +606,7 @@ CREATE TABLE `elected_representative` (
   KEY `entity_id_idx` (`entity_id`),
   KEY `crp_id_idx` (`crp_id`),
   CONSTRAINT `elected_representative_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=19 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -670,7 +670,7 @@ CREATE TABLE `entity` (
   KEY `index_entity_on_delta` (`delta`),
   CONSTRAINT `entity_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `entity_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=20909 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -732,7 +732,7 @@ CREATE TABLE `extension_record` (
   CONSTRAINT `extension_record_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `extension_record_ibfk_2` FOREIGN KEY (`definition_id`) REFERENCES `extension_definition` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `extension_record_ibfk_3` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1306 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -768,7 +768,7 @@ CREATE TABLE `family` (
   PRIMARY KEY (`id`),
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `family_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -884,7 +884,7 @@ CREATE TABLE `government_body` (
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `government_body_ibfk_1` FOREIGN KEY (`state_id`) REFERENCES `address_state` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `government_body_ibfk_2` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -902,7 +902,7 @@ CREATE TABLE `group_lists` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_group_lists_on_group_id_and_list_id` (`group_id`,`list_id`),
   KEY `index_group_lists_on_list_id` (`list_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -954,7 +954,7 @@ CREATE TABLE `groups` (
   UNIQUE KEY `index_groups_on_slug` (`slug`),
   KEY `index_groups_on_delta` (`delta`),
   KEY `index_groups_on_campaign_id` (`campaign_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1004,7 +1004,7 @@ CREATE TABLE `image` (
   KEY `index_image_on_address_id` (`address_id`),
   CONSTRAINT `image_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `image_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1067,7 +1067,7 @@ CREATE TABLE `link` (
   CONSTRAINT `link_ibfk_2` FOREIGN KEY (`entity2_id`) REFERENCES `entity` (`id`),
   CONSTRAINT `link_ibfk_3` FOREIGN KEY (`entity1_id`) REFERENCES `entity` (`id`),
   CONSTRAINT `link_ibfk_4` FOREIGN KEY (`category_id`) REFERENCES `relationship_category` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1145 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1229,7 +1229,7 @@ CREATE TABLE `ls_list` (
   KEY `index_ls_list_on_name` (`name`),
   CONSTRAINT `ls_list_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `ls_list_ibfk_2` FOREIGN KEY (`featured_list_id`) REFERENCES `ls_list` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1203 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1830 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1259,7 +1259,7 @@ CREATE TABLE `ls_list_entity` (
   CONSTRAINT `ls_list_entity_ibfk_1` FOREIGN KEY (`list_id`) REFERENCES `ls_list` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `ls_list_entity_ibfk_2` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `ls_list_entity_ibfk_3` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1564 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1297,7 +1297,7 @@ CREATE TABLE `membership` (
   PRIMARY KEY (`id`),
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `membership_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1385,7 +1385,7 @@ CREATE TABLE `network_map` (
   PRIMARY KEY (`id`),
   KEY `user_id_idx` (`user_id`),
   KEY `index_network_map_on_delta` (`delta`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1581,7 +1581,7 @@ CREATE TABLE `ny_disclosures` (
   KEY `index_ny_disclosures_on_original_date` (`original_date`),
   KEY `index_ny_disclosures_on_delta` (`delta`),
   KEY `index_filer_report_trans_date_e_year` (`filer_id`,`report_id`,`transaction_id`,`schedule_transaction_date`,`e_year`)
-) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1653,7 +1653,7 @@ CREATE TABLE `ny_filer_entities` (
   KEY `index_ny_filer_entities_on_is_committee` (`is_committee`),
   KEY `index_ny_filer_entities_on_cmte_entity_id` (`cmte_entity_id`),
   KEY `index_ny_filer_entities_on_filer_id` (`filer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1683,7 +1683,7 @@ CREATE TABLE `ny_filers` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_ny_filers_on_filer_id` (`filer_id`),
   KEY `index_ny_filers_on_filer_type` (`filer_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=23 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1707,7 +1707,7 @@ CREATE TABLE `ny_matches` (
   KEY `index_ny_matches_on_donor_id` (`donor_id`),
   KEY `index_ny_matches_on_recip_id` (`recip_id`),
   KEY `index_ny_matches_on_relationship_id` (`relationship_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=23 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1754,7 +1754,7 @@ CREATE TABLE `org` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `org_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=625 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1836,7 +1836,7 @@ CREATE TABLE `os_committees` (
   KEY `index_os_committees_on_cmte_id` (`cmte_id`),
   KEY `index_os_committees_on_recipid` (`recipid`),
   KEY `index_os_committees_on_cmte_id_and_cycle` (`cmte_id`,`cycle`)
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1895,7 +1895,7 @@ CREATE TABLE `os_donations` (
   KEY `index_os_donations_on_recipid` (`recipid`),
   KEY `index_os_donations_on_recipid_and_amount` (`recipid`,`amount`),
   KEY `index_os_donations_on_zip` (`zip`)
-) ENGINE=InnoDB AUTO_INCREMENT=165 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2021,7 +2021,7 @@ CREATE TABLE `os_matches` (
   KEY `index_os_matches_on_cmte_id` (`cmte_id`),
   KEY `index_os_matches_on_relationship_id` (`relationship_id`),
   KEY `index_os_matches_on_reference_id` (`reference_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=69 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2039,7 +2039,7 @@ CREATE TABLE `ownership` (
   PRIMARY KEY (`id`),
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `ownership_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2059,7 +2059,7 @@ CREATE TABLE `pages` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_pages_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2092,7 +2092,7 @@ CREATE TABLE `person` (
   CONSTRAINT `person_ibfk_1` FOREIGN KEY (`party_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `person_ibfk_2` FOREIGN KEY (`gender_id`) REFERENCES `gender` (`id`),
   CONSTRAINT `person_ibfk_3` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=506 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2143,7 +2143,7 @@ CREATE TABLE `political_candidate` (
   KEY `house_fec_id_idx` (`house_fec_id`),
   KEY `crp_id_idx` (`crp_id`),
   CONSTRAINT `political_candidate_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2186,7 +2186,7 @@ CREATE TABLE `political_fundraising` (
   CONSTRAINT `political_fundraising_ibfk_1` FOREIGN KEY (`type_id`) REFERENCES `political_fundraising_type` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `political_fundraising_ibfk_2` FOREIGN KEY (`state_id`) REFERENCES `address_state` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `political_fundraising_ibfk_3` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2223,7 +2223,7 @@ CREATE TABLE `position` (
   KEY `relationship_id_idx` (`relationship_id`),
   CONSTRAINT `position_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `position_ibfk_2` FOREIGN KEY (`boss_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=89 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2257,7 +2257,7 @@ CREATE TABLE `public_company` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `public_company_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2308,7 +2308,7 @@ CREATE TABLE `reference` (
   KEY `object_idx` (`object_model`,`object_id`,`updated_at`),
   KEY `index_reference_on_object_model_and_object_id_and_ref_type` (`object_model`,`object_id`,`ref_type`),
   CONSTRAINT `reference_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=191 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=736 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2330,7 +2330,7 @@ CREATE TABLE `reference_excerpt` (
   KEY `last_user_id_idx` (`last_user_id`),
   CONSTRAINT `reference_excerpt_ibfk_1` FOREIGN KEY (`reference_id`) REFERENCES `reference` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `reference_excerpt_ibfk_2` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2372,7 +2372,7 @@ CREATE TABLE `relationship` (
   CONSTRAINT `relationship_ibfk_2` FOREIGN KEY (`entity1_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `relationship_ibfk_3` FOREIGN KEY (`category_id`) REFERENCES `relationship_category` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `relationship_ibfk_4` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=350 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=103 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2490,7 +2490,7 @@ CREATE TABLE `school` (
   PRIMARY KEY (`id`),
   KEY `entity_id_idx` (`entity_id`),
   CONSTRAINT `school_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=23 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2529,7 +2529,7 @@ CREATE TABLE `sessions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sessions_on_session_id` (`session_id`),
   KEY `index_sessions_on_updated_at` (`updated_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=79 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2654,7 +2654,7 @@ CREATE TABLE `sf_guard_user` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   KEY `is_active_idx_idx` (`is_active`)
-) ENGINE=InnoDB AUTO_INCREMENT=978 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=4091 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2740,7 +2740,7 @@ CREATE TABLE `sf_guard_user_profile` (
   UNIQUE KEY `unique_public_name_idx` (`public_name`),
   KEY `user_id_public_name_idx` (`user_id`,`public_name`),
   CONSTRAINT `sf_guard_user_profile_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `sf_guard_user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=93 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2808,11 +2808,12 @@ CREATE TABLE `taggings` (
   `tagable_id` int(11) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `last_user_id` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `index_taggings_on_tag_id` (`tag_id`),
   KEY `index_taggings_on_tagable_class` (`tagable_class`),
   KEY `index_taggings_on_tagable_id` (`tagable_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1447 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2831,7 +2832,7 @@ CREATE TABLE `tags` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_tags_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=143 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2887,7 +2888,7 @@ CREATE TABLE `toolkit_pages` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_toolkit_pages_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2911,7 +2912,7 @@ CREATE TABLE `transaction` (
   CONSTRAINT `transaction_ibfk_1` FOREIGN KEY (`relationship_id`) REFERENCES `relationship` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `transaction_ibfk_2` FOREIGN KEY (`contact2_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `transaction_ibfk_3` FOREIGN KEY (`contact1_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2930,7 +2931,7 @@ CREATE TABLE `user_permissions` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_user_permissions_on_user_id_and_resource_type` (`user_id`,`resource_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2970,7 +2971,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_username` (`username`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
   UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=885 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3712 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2997,7 +2998,7 @@ CREATE TABLE `versions` (
   KEY `index_versions_on_entity1_id` (`entity1_id`),
   KEY `index_versions_on_entity2_id` (`entity2_id`),
   KEY `index_versions_on_whodunnit` (`whodunnit`)
-) ENGINE=InnoDB AUTO_INCREMENT=285 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=291 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -3009,7 +3010,7 @@ CREATE TABLE `versions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-09-21 22:49:18
+-- Dump completed on 2017-10-10 21:49:39
 INSERT INTO schema_migrations (version) VALUES ('20131031182415');
 
 INSERT INTO schema_migrations (version) VALUES ('20131031182500');
@@ -3233,4 +3234,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170829213118');
 INSERT INTO schema_migrations (version) VALUES ('20170905204324');
 
 INSERT INTO schema_migrations (version) VALUES ('20170921224247');
+
+INSERT INTO schema_migrations (version) VALUES ('20171010214602');
 

--- a/lib/task-helpers/bulk_tagger.rb
+++ b/lib/task-helpers/bulk_tagger.rb
@@ -20,14 +20,14 @@ class BulkTagger
     entity = Entity.find(model_id_from(row.field('entity_url')))
     tags = row_tags(row)
 
-    tags.each { |tag_name| entity.tag(tag_name) }
+    tags.each { |tag_name| entity.add_tag(tag_name) }
     tag_related_entities(entity, tags) if row.field('tag_all_related').present?
   end
 
   def tag_related_entities(entity, tags)
     entity.links.map(&:entity2_id).uniq.each do |id|
       other_entity = Entity.find(id)
-      tags.each { |t| other_entity.tag(t) }
+      tags.each { |t| other_entity.add_tag(t) }
     end
   end
 
@@ -37,13 +37,13 @@ class BulkTagger
     list = List.find(model_id_from(row.field('list_url')))
     tags = row_tags(row)
 
-    tags.each { |t| list.tag(t) }
+    tags.each { |t| list.add_tag(t) }
     tag_all_in_list(list, tags) if row.field('tag_all_in_list').present?
   end
 
   def tag_all_in_list(list, tags)
     list.entities.each do |entity|
-      tags.each { |t| entity.tag(t) }
+      tags.each { |t| entity.add_tag(t) }
     end
   end
 

--- a/spec/features/entity_page_spec.rb
+++ b/spec/features/entity_page_spec.rb
@@ -121,7 +121,7 @@ describe "Entity Page", :network_analysis_helper, :pagination_helper, type: :fea
 
         context "when person has tags" do
           before do
-            tags.each{ |t| person.tag(t.id) }
+            tags.each{ |t| person.add_tag(t.id) }
             refresh_page
           end
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -210,8 +210,11 @@ describe 'Tags', :tagging_helper, type: :feature do
         let(:person) { create(:entity_person).tag(tag.id) }
         let(:list) { create(:list).tag(tag.id) }
         let(:relationship) do
-          create(:generic_relationship, entity: create(:entity_org), related: create(:entity_org)).tag(tag.id)
+          create(:generic_relationship,
+                 entity: create(:entity_org),
+                 related: create(:entity_org)).tag(tag.id)
         end
+
         context 'a person was recently tagged' do
           let(:setup) { proc { person } }
           edits_table_has_correct_row_count(1)
@@ -242,6 +245,23 @@ describe 'Tags', :tagging_helper, type: :feature do
               expect(el).to have_link list.name
               expect(el).to have_link relationship.name
             end
+          end
+        end
+
+        context "tags were added by both system and an analyst" do
+          let(:user) { create_basic_user }
+          let(:person) { create(:entity_person).tag(tag.id, APP_CONFIG["system_user_id"]) }
+          let(:list) { create(:list).tag(tag.id, user.sf_guard_user_id) }
+          let(:setup) { proc { list; person;} }
+
+          it "shows `System` next to system edit" do
+            expect(page.all("#tag-homepage-edits-table tbody tr")[0])
+              .to have_text("System")
+          end
+
+          it "shows anaylsist's username next to analyst's edit" do
+            expect(page.all("#tag-homepage-edits-table tbody tr")[1])
+              .to have_text(user.username)
           end
         end
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -143,7 +143,7 @@ describe 'Tags', :tagging_helper, type: :feature do
 
       context "less than 20 tagged tagables" do
         let(:tagables) do
-          n_tagables(2, tagable_category).map { |t| t.tag(tag.id) }
+          n_tagables(2, tagable_category).map { |t| t.add_tag(tag.id) }
         end
 
         it "shows the tag title and description" do
@@ -182,7 +182,7 @@ describe 'Tags', :tagging_helper, type: :feature do
       end
 
       context "more than 20 tagables" do
-        let(:tagables) { n_tagables(21, tagable_category).map { |t| t.tag(tag.id) } }
+        let(:tagables) { n_tagables(21, tagable_category).map { |t| t.add_tag(tag.id) } }
         it "only shows 10 entities with pagination bar" do
           expect(page.find("#tagable-lists"))
             .to have_selector '.tagable-list-item', count: 20
@@ -207,12 +207,12 @@ describe 'Tags', :tagging_helper, type: :feature do
       end
 
       describe 'list of edits' do
-        let(:person) { create(:entity_person).tag(tag.id) }
-        let(:list) { create(:list).tag(tag.id) }
+        let(:person) { create(:entity_person).add_tag(tag.id) }
+        let(:list) { create(:list).add_tag(tag.id) }
         let(:relationship) do
           create(:generic_relationship,
                  entity: create(:entity_org),
-                 related: create(:entity_org)).tag(tag.id)
+                 related: create(:entity_org)).add_tag(tag.id)
         end
 
         context 'a person was recently tagged' do
@@ -250,8 +250,8 @@ describe 'Tags', :tagging_helper, type: :feature do
 
         context "tags were added by both system and an analyst" do
           let(:user) { create_basic_user }
-          let(:person) { create(:entity_person).tag(tag.id, APP_CONFIG["system_user_id"]) }
-          let(:list) { create(:list).tag(tag.id, user.sf_guard_user_id) }
+          let(:person) { create(:entity_person).add_tag(tag.id, APP_CONFIG["system_user_id"]) }
+          let(:list) { create(:list).add_tag(tag.id, user.sf_guard_user_id) }
           let(:setup) { proc { list; person;} }
 
           it "shows `System` next to system edit" do

--- a/spec/helpers/tags_helper_spec.rb
+++ b/spec/helpers/tags_helper_spec.rb
@@ -1,40 +1,11 @@
+
 require 'rails_helper'
 
 describe TagsHelper, type: :helper do
-
-  describe '#tags_edits_format_time' do
-    subject { helper.tags_edits_format_time(edit_event) }
-
-    let(:username) { Faker::Internet.user_name }
-    let(:mock_entity) do
-      user = build(:user, username: username)
-      build(:org).tap do |org|
-        allow(org).to receive(:last_user).and_return(double(:user => user))
-      end
-    end
-
-    context 'event is tag_added' do
-      let(:edit_event) { { 'event' => 'tag_added', 'event_timestamp' => 1.day.ago } }
-      it { is_expected.to eql "Edited 1 day ago" }
-    end
-
-    context 'tagable is a list' do
-      let(:edit_event) do
-        { 'event' => 'tagable_updated', 'event_timestamp' => 1.day.ago, 'tagable_class' => 'List' }
-      end
-      it { is_expected.to eql "Edited 1 day ago" }
-    end
-
-    context 'event is not tag_added and is an entity' do
-      let(:edit_event) do
-        {
-          'event' => 'tagable_updated',
-          'tagable_class' => 'Entity',
-          'event_timestamp' => 1.day.ago,
-          'tagable' => mock_entity
-        }
-      end
-      it { is_expected.to eql "Edited 1 day ago by #{username}" }
+  describe "#tags_edits_format_time" do
+    it "displays the edit time in English" do
+      edit_event = { 'event_timestamp' => 1.day.ago }
+      expect(tags_edits_format_time(edit_event)).to eql "1 day ago"
     end
   end
 
@@ -48,6 +19,24 @@ describe TagsHelper, type: :helper do
     context 'update event' do
       let(:edit_event) { { 'event' => 'tagable_updated', 'tagable_class' => 'List' } }
       it { is_expected.to eql 'List updated' }
+    end
+  end
+
+  describe '#tags_edits_format_editor' do
+    subject { tags_edits_format_editor(edit_event) }
+
+    context "when edited by a user" do
+      let(:kropotkin){ build(:user, username: "Kropotkin") }
+      let(:edit_event) { { "editor" => kropotkin } }
+
+      it { is_expected.to eql link_to("Kropotkin", "/user/Kropotkin") }
+    end
+
+    context "when edited by The System" do
+      let(:system) { User.find(APP_CONFIG["system_user_id"]) }
+      let(:edit_event) { { "editor" => system } }
+
+      it { is_expected.to eql "System" }
     end
   end
 end

--- a/spec/lib/bulk_tagging_spec.rb
+++ b/spec/lib/bulk_tagging_spec.rb
@@ -10,7 +10,7 @@ describe 'BulkTagging' do
 
   def tagable_mock(tags)
     double('tagable').tap do |double|
-      tags.each { |t| expect(double).to receive(:tag).with(t) }
+      tags.each { |t| expect(double).to receive(:add_tag).with(t) }
     end
   end
 
@@ -47,7 +47,7 @@ describe 'BulkTagging' do
       mock_links.each do |link|
         other_entity = build(:org)
         expect(Entity).to receive(:find).with(link.entity2_id).and_return(other_entity)
-        tags.each { |t| expect(other_entity).to receive(:tag).with(t) }
+        tags.each { |t| expect(other_entity).to receive(:add_tag).with(t) }
       end
       entity
     end
@@ -86,12 +86,12 @@ describe 'BulkTagging' do
     it 'can tag all entities in list' do
       list = build(:list)
       entities_in_list = [build(:org), build(:person)]
-      expect(list).to receive(:tag).with('georgia')
-      expect(list).to receive(:tag).with('oil')
+      expect(list).to receive(:add_tag).with('georgia')
+      expect(list).to receive(:add_tag).with('oil')
       expect(list).to receive(:entities).and_return(entities_in_list)
       entities_in_list.each do |e|
-        expect(e).to receive(:tag).with('georgia')
-        expect(e).to receive(:tag).with('oil')
+        expect(e).to receive(:add_tag).with('georgia')
+        expect(e).to receive(:add_tag).with('oil')
       end
 
       expect(List).to receive(:find).with('1232').and_return(tagable_mock(['nyc']))

--- a/spec/models/concerns/tagable_spec.rb
+++ b/spec/models/concerns/tagable_spec.rb
@@ -129,6 +129,12 @@ describe Tagable, type: :model do
       }.to change { Tagging.count }.by(1)
     end
 
+    it 'only allows one user per tagging' do
+      test_tagable.tag(tag_id, 1)
+      test_tagable.tag(tag_id, 2)
+      expect(Tagging.last.last_user_id).to eq 1
+    end
+
     it "creates a tagging with correct attributes" do
       test_tagable.tag(tag_id)
 

--- a/spec/models/concerns/tagable_spec.rb
+++ b/spec/models/concerns/tagable_spec.rb
@@ -40,15 +40,19 @@ describe Tagable, type: :model do
   end
 
   describe "the Tagable interface" do
-    before { entity.tag(tag_id) }
+    before { entity.add_tag(tag_id) }
 
     it "responds to interface methods" do
       Tagable.classes.each do |tagable_class|
         tagable = tagable_class.new
-        expect(tagable).to respond_to(:tag)
+        expect(tagable).to respond_to(:add_tag)
+        expect(tagable).to respond_to(:remove_tag)
+        expect(tagable).to respond_to(:update_tags)
         expect(tagable).to respond_to(:tags)
-        expect(tagable).to respond_to(:last_user_id)
+        expect(tagable).to respond_to(:taggings)
+        expect(tagable).to respond_to(:tags_for)
         expect(tagable).to respond_to(:description)
+        expect(tagable).to respond_to(:last_user_id)
       end
     end
 
@@ -107,36 +111,36 @@ describe Tagable, type: :model do
     let(:system_user) { SfGuardUser.find(APP_CONFIG['system_user_id']) }
 
     it "creates a new tagging" do
-      expect { test_tagable.tag(tag_id) }.to change { Tagging.count }.by(1)
+      expect { test_tagable.add_tag(tag_id) }.to change { Tagging.count }.by(1)
     end
 
     it "tracks user who created tag" do
-      test_tagable.tag(tag_id, user.id)
+      test_tagable.add_tag(tag_id, user.id)
       expect(Tagging.last.last_user_id).to eql user.id
       expect(Tagging.last.last_user).to eql user
     end
 
     it "provides sysem user as default user" do
-      test_tagable.tag(tag_id)
+      test_tagable.add_tag(tag_id)
       expect(Tagging.last.last_user_id).to eq APP_CONFIG['system_user_id']
       expect(Tagging.last.last_user).to eq system_user
     end
 
     it 'only creates one tagging per tag' do
       expect {
-        test_tagable.tag(tag_id)
-        test_tagable.tag(tag_id)
+        test_tagable.add_tag(tag_id)
+        test_tagable.add_tag(tag_id)
       }.to change { Tagging.count }.by(1)
     end
 
     it 'only allows one user per tagging' do
-      test_tagable.tag(tag_id, 1)
-      test_tagable.tag(tag_id, 2)
+      test_tagable.add_tag(tag_id, 1)
+      test_tagable.add_tag(tag_id, 2)
       expect(Tagging.last.last_user_id).to eq 1
     end
 
     it "creates a tagging with correct attributes" do
-      test_tagable.tag(tag_id)
+      test_tagable.add_tag(tag_id)
 
       attrs = Tagging.last.attributes
       expect(attrs['tag_id']).to eq tag_id
@@ -147,17 +151,17 @@ describe Tagable, type: :model do
 
   describe 'adding tags' do
     it "can be tagged with an existing tag's id" do
-      expect { test_tagable.tag(tag_id) }.to change { Tagging.count }.by(1)
+      expect { test_tagable.add_tag(tag_id) }.to change { Tagging.count }.by(1)
     end
 
     it "can be tagged with an existing tag's name" do
-      expect { test_tagable.tag(tag_name) }.to change { Tagging.count }.by(1)
+      expect { test_tagable.add_tag(tag_name) }.to change { Tagging.count }.by(1)
     end
 
     it "cannot be tagged with a non-existent tag id or name" do
       not_found = ActiveRecord::RecordNotFound
-      expect { test_tagable.tag("THIS IS NOT A REAL TAG!!!!") }.to raise_error(not_found)
-      expect { test_tagable.tag(1_000_000) }.to raise_error(not_found)
+      expect { test_tagable.add_tag("THIS IS NOT A REAL TAG!!!!") }.to raise_error(not_found)
+      expect { test_tagable.add_tag(1_000_000) }.to raise_error(not_found)
     end
   end
 
@@ -168,16 +172,17 @@ describe Tagable, type: :model do
       tagable = test_tagable
       expect(Tagging).to receive(:skip_callback).with(:save, :after, :update_tagable_timestamp).once
       expect(Tagging).to receive(:set_callback).with(:save, :after, :update_tagable_timestamp).once
-      expect(tagable).to receive(:tag).with('tagname', sys_id)
-      tagable.tag_without_callbacks('tagname')
+      expect(tagable).to receive(:add_tag).with('tagname', sys_id)
+      tagable.add_tag_without_callbacks('tagname')
     end
 
     it 're-enables callbacks even if the tag raises an error' do
       tagable = test_tagable
       expect(Tagging).to receive(:skip_callback).with(:save, :after, :update_tagable_timestamp).once
       expect(Tagging).to receive(:set_callback).with(:save, :after, :update_tagable_timestamp).once
-      expect(tagable).to receive(:tag).with('tagname', sys_id).and_raise(ActiveRecord::RecordNotFound)
-      expect { tagable.tag_without_callbacks('tagname') }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(tagable).to receive(:add_tag).with('tagname', sys_id).and_raise(ActiveRecord::RecordNotFound)
+      expect { tagable.add_tag_without_callbacks('tagname') }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -224,7 +229,7 @@ describe Tagable, type: :model do
 
       it 'adds and removes tags in a batch' do
         expect(test_tagable).to receive(:remove_tag).once.with(tags[1].id)
-        expect(test_tagable).to receive(:tag).once.with(tags[2].id)
+        expect(test_tagable).to receive(:add_tag).once.with(tags[2].id)
         test_tagable.update_tags([tags[0].id, tags[2].id])
       end
     end
@@ -241,7 +246,7 @@ describe Tagable, type: :model do
     let(:view_only_access) { { viewable: true, editable: false } }
 
     before(:each) do
-      test_tagable.tag(restricted_tag.id)
+      test_tagable.add_tag(restricted_tag.id)
       owner.permissions.add_permission(Tag, tag_ids: [restricted_tag.id])
       allow(test_tagable).to receive(:tags).and_return([restricted_tag])
     end

--- a/spec/models/entity_deleting_spec.rb
+++ b/spec/models/entity_deleting_spec.rb
@@ -6,8 +6,8 @@ describe 'Deleting an Entity', type: :model do
   describe 'Deleting an entity with tags' do
     let(:entity) do
       entity = create(:entity_org)
-      entity.tag('oil')
-      entity.tag('nyc')
+      entity.add_tag('oil')
+      entity.add_tag('nyc')
       entity
     end
 
@@ -37,8 +37,8 @@ describe 'Deleting an Entity', type: :model do
         person.aliases.create!(name: Faker::TwinPeaks.character)
         person.add_extension('BusinessPerson')
         person.add_extension('Academic')
-        person.tag('oil')
-        person.tag('nyc')
+        person.add_tag('oil')
+        person.add_tag('nyc')
         person.images.create!(filename: Faker::File.file_name(nil, nil,'png'), title: 'image')
         person
       end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -161,8 +161,8 @@ describe Entity, :tag_helper  do
   describe 'get_association_data' do
     let(:company) do
       org = create(:entity_org)
-      org.tag('oil')
-      org.tag('nyc')
+      org.add_tag('oil')
+      org.add_tag('nyc')
       org.aliases.create!(name: 'another name')
       Relationship.create!(entity: org, related: create(:entity_person), category_id: 12)
       org.add_extension('PublicCompany')
@@ -728,7 +728,7 @@ describe Entity, :tag_helper  do
   describe 'Tagging' do
     it 'can tag a person with oil' do
       person = create(:entity_person)
-      expect { person.tag('oil') }.to change { Tagging.count }.by(1)
+      expect { person.add_tag('oil') }.to change { Tagging.count }.by(1)
       expect(person.taggings).to eq [Tagging.last]
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -42,8 +42,8 @@ describe Tag do
 
         let(:entities_by_type) do
           {
-            'Person' => Array.new(5) { create(:entity_person).tag(tag.id) },
-            'Org' => Array.new(5) { create(:entity_org).tag(tag.id) }
+            'Person' => Array.new(5) { create(:entity_person).add_tag(tag.id) },
+            'Org' => Array.new(5) { create(:entity_org).add_tag(tag.id) }
           }
         end
 
@@ -76,7 +76,7 @@ describe Tag do
 
         describe "sorting" do
 
-          let(:lists) { Array.new(2) { create(:list).tag(tag.id) } }
+          let(:lists) { Array.new(2) { create(:list).add_tag(tag.id) } }
           let(:tagables) { tag.tagables_for_homepage('lists') }          
 
           before do
@@ -95,7 +95,7 @@ describe Tag do
         describe "pagination" do
 
           let(:page_limit){ Tag::PER_PAGE }
-          let(:lists) { Array.new(page_limit + 1) { create(:list).tag(tag.id) } }
+          let(:lists) { Array.new(page_limit + 1) { create(:list).add_tag(tag.id) } }
           before { lists }
           
           it "shows records corresponding to a given page" do
@@ -115,7 +115,7 @@ describe Tag do
               :generic_relationship,
               entity: create(:entity_person),
               related: create(:entity_org)
-            ).tag(tag.id)
+            ).add_tag(tag.id)
           end
         end
 
@@ -145,7 +145,7 @@ describe Tag do
       let(:tagables){ entities + relationships + lists }
 
       before do
-        tagables.each { |t| t.tag(tag.id, user.sf_guard_user_id) }
+        tagables.each { |t| t.add_tag(tag.id, user.sf_guard_user_id) }
         # offset tagging updated_at timestamps to yield
         # reverse chronological ordering equivalent to tagable ordering
         tagables.reverse.each_with_index do |t, i|

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -128,62 +128,57 @@ describe Tag do
       end
     end
 
-    describe '#recent_edits' do
+    describe 'recent edits' do
+      let(:user) { create_basic_user }
+      let(:system_user) { SfGuardUser.find(APP_CONFIG["system_user_id"]).user }
       let(:tag) { create(:tag) }
+
+      let(:entities) { Array.new(2) { create(:entity_org) } }
+      let(:lists) { Array.new(2) { create(:list) } }
       let(:untagged_person) { create(:entity_person) }
       let(:untagged_org) { create(:entity_org) }
-
-      let(:entities) do
-        Array.new(2) { create(:entity_org).tag(tag.id) }
-      end
-
       let(:relationships) do
         Array.new(2) do
-          create(:generic_relationship, entity: untagged_person, related: untagged_org).tag(tag.id)
+          create(:generic_relationship, entity: untagged_person, related: untagged_org)
+        end
+      end
+      let(:tagables){ entities + relationships + lists }
+
+      before do
+        tagables.each { |t| t.tag(tag.id, user.sf_guard_user_id) }
+        # offset tagging updated_at timestamps to yield
+        # reverse chronological ordering equivalent to tagable ordering
+        tagables.reverse.each_with_index do |t, i|
+          t.taggings.first.update_column(:created_at, Time.now + i.seconds)
         end
       end
 
-      let(:lists) do
-        Array.new(2) { create(:list).tag(tag.id) }
-      end
+      describe 'listing `tag_added` events' do
 
-      context 'all recent edits to tagables are tag updated event' do
-        before { entities; relationships; lists; }
-
-        def it_contains_all_tagables
-          expect(Set.new(tag.send(:recent_edits_query).map { |x| x['tagable_id'] }))
-            .to eql Set.new( (entities + lists + relationships).map(&:id) )
-        end
-
-        it 'contains a list of tag_added events' do
-          expect(tag.send(:recent_edits_query).length).to eql 6
-          it_contains_all_tagables
-        end
-
-        it 'also contains a tagable_updated event' do
-          relationships[0].update_column(:updated_at, Date.tomorrow)
-          expect(tag.send(:recent_edits_query).length).to eql 7
-          it_contains_all_tagables
-          expect(tag.send(:recent_edits_query)[0])
-            .to eq(
-                  "tagging_id" => relationships[0].taggings.first.id,
-                  "tagable_id" => relationships[0].id,
-                  "tagable_class" => "Relationship",
-                  "tagging_created_at" => relationships[0].taggings.first.created_at,
-                  "event_timestamp" => relationships[0].updated_at,
-                  "event" => "tagable_updated"
-                )
-        end
-
-        it 'recent_edits returns an array of active record objects' do
-          relationships[0].update_column(:updated_at, Date.tomorrow)
-
-          tag.send(:recent_edits).each do |edit|
-            expect(Tagable.classes).to include edit['tagable'].class
+        it 'shows all `tag_added` events' do
+          tag.recent_edits.each_with_index do |edit, idx|
+            expect(edit)
+              .to eq("tagable"         => tagables[idx],
+                     "tagable_class"   => tagables[idx].class.name,
+                     "event"           => "tag_added",
+                     "event_timestamp" => tagables[idx].taggings.last.created_at,
+                     "editor"          => user)
           end
+        end
+      end
 
-          expect(tag.send(:recent_edits).first['tagable']).to eq relationships[0]
-          
+      describe 'listing `tagable_updated` events' do
+        let(:tomorrow) { Date.tomorrow }
+        let(:relationship) { relationships.first }
+        before { relationship.update_column(:updated_at, tomorrow) }
+
+        it 'shows a `tagable_updated` event' do
+          expect(tag.recent_edits.first)
+            .to eq("tagable"            => relationships.first,
+                   "tagable_class"      => "Relationship",
+                   "event"              => "tagable_updated",
+                   "event_timestamp"    => tomorrow,
+                   "editor"             => system_user)
         end
       end
     end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -24,12 +24,12 @@ describe Tagging, type: :model do
 
     it 'updates entity timestamp after creating a tagging' do
       org.update_column(:updated_at, 1.day.ago)
-      expect { org.tag(tag.id) }.to change { org.reload.updated_at }
+      expect { org.add_tag(tag.id) }.to change { org.reload.updated_at }
     end
 
     it 'sets last_user_id to be the system\'s default user' do
       org.update_columns(updated_at: 1.day.ago, last_user_id: @sf_user.id)
-      expect { org.tag(tag.id) }
+      expect { org.add_tag(tag.id) }
         .to change { org.reload.last_user_id }.to(APP_CONFIG['system_user_id'])
     end
   end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -5,11 +5,14 @@ describe Tagging, type: :model do
   it { should have_db_column(:tag_id) }
   it { should have_db_column(:tagable_class) }
   it { should have_db_column(:tagable_id) }
+  it { should have_db_column(:last_user_id) }
+
   it { should validate_presence_of(:tag_id) }
   it { should validate_presence_of(:tagable_class) }
   it { should validate_presence_of(:tagable_id) }
 
   it { should belong_to(:tag) }
+  it { should belong_to(:last_user) }
 
   before(:all) do
     @sf_user = create(:sf_user)
@@ -27,7 +30,7 @@ describe Tagging, type: :model do
     it 'sets last_user_id to be the system\'s default user' do
       org.update_columns(updated_at: 1.day.ago, last_user_id: @sf_user.id)
       expect { org.tag(tag.id) }
-        .to change { org.reload.last_user_id }.to(Tagging::DEFAULT_LAST_USER_ID)
+        .to change { org.reload.last_user_id }.to(APP_CONFIG['system_user_id'])
     end
   end
 end

--- a/spec/views/entities/sidebar/_sidebar.html.erb_spec.rb
+++ b/spec/views/entities/sidebar/_sidebar.html.erb_spec.rb
@@ -46,8 +46,8 @@ describe "partial: sidebar", :tag_helper do
     end
     context 'entity has tags' do
       before do
-        org.tag('oil')
-        org.tag('nyc')
+        org.add_tag('oil')
+        org.add_tag('nyc')
         assign(:entity, org)
         render partial: 'entities/sidebar.html.erb'
       end


### PR DESCRIPTION
resolves #238 

and supplements #326, which was discovered to be incomplete at last show & tell

--------------

## Screenshot

![tag-edits-with-usernames](https://user-images.githubusercontent.com/6032844/31513175-75468f16-af5b-11e7-8a03-f8079ca7348b.png)

## Implementation Notes

* pass (sf_guard) user id to `Tagable#tag`
* use AR associations to give `Tagging` a `last_user` method
* refactor `#recent_edits` SQL query to find `last_user_id` for both
  `tag_added` and `tagable_updated` events, store as `editor_id`
* use `editor_id` to lookup user in (renamed) `#editors_by_id` helper
* use new `tags_helper` method to format username or `System`
* simplify `Time` column to omit (1) "Edited", (2) omit username

## Side Effects (refactoring)

* rename helper methods to `#recent_edits` to reflect the shape of the data they return, and flesh out descriptions of their return (pseudo)types
* discard intermediary id fields from hash returned by `#recent_edits` (build a new hash that only has values we use in controller/view)
* rewrite specs to deterministically assert equality of expected hash values for `recent_edits` (in context of both `tag_added` and `tagable_updated` edit events)
* re-order helpers in `Tag` to:
  1. expose `<tagable>s_for_homepage` first-class helper methods
  2. expose `recent_edits`
  3. make order of private helpers correspond to order of methods helped
 
