### PR TITLE
[#357] Validate username and wrap user models in a transaction

### DIFF
--- a/app/models/sf_guard_user_profile.rb
+++ b/app/models/sf_guard_user_profile.rb
@@ -4,6 +4,7 @@ class SfGuardUserProfile < ActiveRecord::Base
   validates :name_first, presence: true
   validates :home_network_id, presence: true
   validates :reason, signup_reason: true
+  validates_uniqueness_of :public_name
 
   belongs_to :sf_guard_user, inverse_of: :sf_guard_user_profile, foreign_key: "user_id"
   belongs_to :user, foreign_key: "user_id", primary_key: "sf_guard_user_id", inverse_of: :sf_guard_user_profile

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -80,6 +80,20 @@
                     <%= devise_error_messages! %>
                     <%= f.fields_for :sf_guard_user_profile do |profile_fields| %>
 
+		      <% if @signup_errors.present? %>
+			<div class="form-group">
+			  <div class="col-sm-10">
+			    <div class="alert alert-danger" role="alert" id="signup-errors-alert">
+			      <h5><strong>Sorry!</strong> We could not create your account for the following reasons:</h5>
+			      <% @signup_errors.each do |msg| %>
+				<p><%= msg %></p>
+			      <% end %>
+			    </div>
+			  </div>
+			</div>
+		      <% end %>
+		      
+
 			<div class="form-group">
                             <%= profile_fields.label :name_first, "First Name", :class => label_class   %>
                             <div class="<%= field_class %>">

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+feature "Signing up for an account", type: :feature do
+  let(:user_info) do
+    Struct
+      .new(:first_name, :last_name, :email, :password, :username, :about_you)
+      .new(Faker::Name.first_name, Faker::Name.last_name, Faker::Internet.email, Faker::Internet.password(8), Faker::Internet.user_name, Faker::Lovecraft.sentence)
+  end
+
+  before do
+    visit new_user_registration_path
+  end
+
+  scenario 'User visits join page' do
+    expect(page.status_code).to eq 200
+    expect(page).to have_current_path new_user_registration_path
+
+    page_has_selector 'h2', text: 'Get Involved!'
+    page_has_selector 'h2', text: 'Data Summary'
+  end
+
+  scenario 'Fills out form and signs up' do
+    counts = [User.count, SfGuardUser.count, SfGuardUserProfile.count]
+
+    fill_in 'user_sf_guard_user_profile_name_first', :with => user_info.first_name
+    fill_in 'user_sf_guard_user_profile_name_last', :with => user_info.last_name
+    fill_in 'user_email', :with => user_info.email
+    fill_in 'user_username', :with => user_info.username
+    fill_in 'user_password', :with => user_info.password
+    fill_in 'user_password_confirmation', :with => user_info.password
+    find(:css, "#terms_of_use").set(true)
+    fill_in 'about-you-input', :with => user_info.about_you
+
+    click_button 'Sign up'
+
+    expect(counts.map { |x| x + 1 }).to eql [User.count, SfGuardUser.count, SfGuardUserProfile.count]
+    expect(page.status_code).to eq 200
+    expect(page).to have_current_path join_success_path
+
+    expect(page).not_to have_selector "#signup-errors-alert"
+  end
+
+  context 'Attempting to signup with a username that is already taken' do
+    let(:username) { Faker::Internet.user_name }
+    let!(:user) do
+      sf_user = create(:sf_guard_user)
+      create(:sf_guard_user_profile, public_name: username, user_id: sf_user.id)
+      create(:user, sf_guard_user_id: sf_user.id, username: username)
+    end
+
+    scenario 'Shows error message regarding the username' do
+      counts = [User.count, SfGuardUser.count, SfGuardUserProfile.count]
+      
+      fill_in 'user_sf_guard_user_profile_name_first', :with => user_info.first_name
+      fill_in 'user_sf_guard_user_profile_name_last', :with => user_info.last_name
+      fill_in 'user_email', :with => user_info.email
+      fill_in 'user_username', :with => username # dfiferent than the above example
+      fill_in 'user_password', :with => user_info.password
+      fill_in 'user_password_confirmation', :with => user_info.password
+      find(:css, "#terms_of_use").set(true)
+      fill_in 'about-you-input', :with => user_info.about_you
+
+      click_button 'Sign up'
+
+      expect(counts).to eql [User.count, SfGuardUser.count, SfGuardUserProfile.count]
+      
+      expect(page.status_code).to eq 200
+      page_has_selector 'h2', text: 'Get Involved!'
+      page_has_selector "#signup-errors-alert"
+      expect(page.find("#signup-errors-alert")).to have_text "The username -- #{username} -- has already been taken"
+
+    end
+  end
+  
+end


### PR DESCRIPTION
resolves #357 

If the SfGuardUserProfile had an invalid field, the error message
wouldn't appear in devise user messages, causing the account
sign up to fail without providing any visual indication to the user.

Errors message are now handled in the controller, and the models are saved in a
transaction to ensure that SfGuardUserProfiles are never persisted
without the user model also being saved.