### PR TITLE
Make tags publically visible

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -11,7 +11,6 @@ class EntitiesController < ApplicationController
   ## Profile Page Tabs:
   # (consider moving these all to #show route)
   def show
-    @similar_entities = @entity.similar_entities
     @active_tab = :relationships
   end
 

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -12,8 +12,10 @@ module TagsHelper
   end
 
   def tags_controls
-    content_tag(:span, id: 'tags-controls') do
-      content_tag(:span, nil, id: 'tags-edit-button', class: 'tags-edit-glyph')
+    if user_signed_in?
+      content_tag(:span, id: 'tags-controls') do
+        content_tag(:span, nil, id: 'tags-edit-button', class: 'tags-edit-glyph')
+      end
     end
   end
 

--- a/app/models/concerns/similar_entities.rb
+++ b/app/models/concerns/similar_entities.rb
@@ -5,8 +5,11 @@ module SimilarEntities
 
   SIMILAR_ENTITY_FIELD_WEIGHTS = { name: 15, aliases: 10, blurb: 3 }.freeze
 
-  # -> [ <Entity> ]
   def similar_entities(per_page = 5)
+    @similar_entities ||= _similar_entities(per_page)
+  end
+  # -> [ <Entity> ]
+  def _similar_entities(per_page)
     Entity.search("@!summary #{generate_search_terms}",
                   :with => { primary_ext: "'#{primary_ext}'", is_deleted: false },
                   :without => { sphinx_internal_id: id },

--- a/app/views/entities/_sidebar.html.erb
+++ b/app/views/entities/_sidebar.html.erb
@@ -23,8 +23,8 @@
 
     <!-- TAGS -->
 
-    <% if user_signed_in? && current_user.admin? %>
-      
+
+    <% if @entity.tags.present? || user_signed_in? %>
       <div class="row" id="sidebar-tags-container">
 	<div class="col-sm-12">            
           <%= sidebar_header 'Tags', addon: capture { tags_controls } %>
@@ -33,13 +33,15 @@
           <%= display_tags(@entity.tags) %>
 	</div>
       </div>
-	
-	<script>
-	 tags.init(
-	   <%= raw(@entity.tags_for(current_user).to_json) %>,
-           "<%= raw(tags_entity_path(@entity)) %>",
-	 );
-	</script>
+    <% end %>
+
+    <% if user_signed_in? %>
+      <script id="edit-tags-javascript">
+       tags.init(
+	 <%= raw(@entity.tags_for(current_user).to_json) %>,
+         "<%= raw(tags_entity_path(@entity)) %>",
+       );
+      </script>
     <% end %>
 
     <!-- SOURCE LINKS -->
@@ -96,18 +98,18 @@
     <% end %>
 
     <!-- Similar Entities -->
-    <% unless @similar_entities.blank? %>
-	<div class="row" id="sidbar-similar-entities-container">
+    <% unless @entity.similar_entities.blank? %>
+	<div class="row" id="sidebar-similar-entities-container">
 	    <div class="col-sm-12">
 		<%= sidebar_header('Similar Entities') %>
 	    </div>
 	    <div class="col-sm-12">
 		<ul class="list-unstyled">
-		    <%= sidebar_similar_entities(@similar_entities) %>
+		    <%= sidebar_similar_entities(@entity.similar_entities) %>
 		</ul>
 		
 		<% if user_signed_in? && (current_user.admin? || current_user.has_legacy_permission('merger') )%>
-		    <%= link_to 'Begin merging process »', @entity.legacy_url('merge') %>
+		    <%= link_to 'Begin merging process »', @entity.legacy_url('merge'), id: 'begin-merging-process-link' %>
 		<% end %>
 	    </div>
 	</div>

--- a/app/views/lists/_header.html.erb
+++ b/app/views/lists/_header.html.erb
@@ -12,9 +12,7 @@
 
 	<% if list.tags.count.positive? %>
 	    <div class="col-sm-4 col-md-3">
-		<% if user_admin?  %>
-		    <%= render partial: 'lists/tags', locals: { tags: list.tags, include_title: true } %>
-		<% end %>
+	      <%= render partial: 'lists/tags', locals: { tags: list.tags, include_title: true } %>
 	    </div>
 	<% end %>
 

--- a/app/views/relationships/show.html.erb
+++ b/app/views/relationships/show.html.erb
@@ -20,29 +20,26 @@
 		<%= render partial: 'sources', locals: {relationship: @relationship } %>
 	    </div>
 
-	    <% if user_admin? %>
+	    <% if @relationship.tags.present? || user_signed_in? %>
+	      
+	      <div class="row">		    
+		<h4 class="relationship-sidebar-title">Tags</h4>
 
-		<% if @relationship.tags.present? || user_signed_in? %>
-		    
-		    <div class="row">		    
-			<h4 class="relationship-sidebar-title">Tags</h4>
+		<%= tags_controls if user_signed_in? %>
+		<%= display_tags(@relationship.tags) %>
 
-			<%= tags_controls if user_signed_in? %>
-			<%= display_tags(@relationship.tags) %>
+		<% if user_signed_in?  %>
+		  <script id="tags-init-js">
+		   $(function(){
+		     tags.init(
+		       <%= raw(@relationship.tags_for(current_user).to_json) %>,
+		       "<%= raw(tags_relationship_path(@relationship)) %>",
+		     );
+		   });
+		  </script>
+		<%  end %>
+	      </div>
 
-			<% if user_signed_in?  %>
-			    <script id="tags-init-js">
-			     $(function(){
-			       tags.init(
-				 <%= raw(@relationship.tags_for(current_user).to_json) %>,
-				 "<%= raw(tags_relationship_path(@relationship)) %>",
-			       );
-			     });
-			    </script>
-			<%  end %>
-		    </div>
-
-		<% end %>
 	    <% end %> 
         </div>
     </div>

--- a/app/views/shared/_bootstrap_nav_menu.html.erb
+++ b/app/views/shared/_bootstrap_nav_menu.html.erb
@@ -39,8 +39,8 @@ items['Explore'] = {
   items: {
     Maps: "/maps",
     Lists: "/lists",
+    Tags: "/tags",
     Groups: "/groups",
-    Users: users_path,
     Edits:"/edits"
   }
 }

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -34,10 +34,7 @@ describe EntitiesController, type: :controller do
     let(:entity) { create(:entity_org, updated_at: Time.now) }
 
     describe "/entity/id" do
-      before do
-        expect(Entity).to receive(:search)
-        get(:show, id: entity.id)
-      end
+      before { get(:show, id: entity.id) }
       it { should render_template(:show) }
     end
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -14,6 +14,7 @@ describe 'home/dashboard', type: :feature do
       expect(page).to have_current_path home_dashboard_path
 
       expect(page).to have_selector 'ul.nav li a', text: current_user.username
+      expect(page).to have_selector 'ul.nav li a', text: 'Tags'
       # verifing that networks have been removed:
       expect(page).not_to have_selector 'ul.nav li a', text: 'United States'
     end

--- a/spec/features/list_spec.rb
+++ b/spec/features/list_spec.rb
@@ -9,18 +9,29 @@ feature 'list page', type: :feature do
     list
   end
 
-  before { visit list_path(list) }
-
   scenario 'visiting the list page' do
+    visit list_path(list)
     successfully_visits_page(list_path(List.last) + '/members')
     expect(page.find('#list-name')).to have_text list.name
+    expect(page).not_to have_selector '#list-tags-container'
   end
 
   scenario 'navigating to the sources tab' do
+    visit list_path(list)
     click_on 'Sources'
     successfully_visits_page(list_path(List.last) + '/references')
     page_has_selector '#list-sources'
     expect(page).to have_link document_attributes[:name], href: document_attributes[:url]
   end
-  
+
+  feature 'list page with tags' do
+    let(:tag) { create(:tag) }
+    let!(:tags) { list.add_tag(tag.id) }
+
+    scenario 'tags are visable on the page' do
+      visit list_path(list)
+      expect(page).to have_selector '#list-tags-container'
+      expect(page).to have_selector '#tags-list li', text: tag.name
+    end
+  end
 end

--- a/spec/features/viewing_relationship_page_spec.rb
+++ b/spec/features/viewing_relationship_page_spec.rb
@@ -5,6 +5,7 @@ describe "Relationship Page", :type => :feature do
   let(:org) { create(:entity_org) }
   let(:person) { create(:entity_person) }
   let(:url) { 'http://example.com' }
+  let(:tag) { create(:tag) }
 
   let(:relationship) do
     rel = Relationship.create!(category_id: 12, entity: org, related: person, last_user_id: user.sf_guard_user.id)
@@ -12,24 +13,43 @@ describe "Relationship Page", :type => :feature do
   end
 
   context "Anonymous user" do
-    before(:each) do
-      visit "/relationships/#{relationship.id}"
-    end
+    subject { page }
 
-    it 'has relationship title' do
-      expect(page).to have_selector 'h1.relationship-title-link a', text: relationship.name
-    end
-
-    context 'source links' do
-      it 'has one source link' do
-        expect(page).to have_selector '#source-links-table tbody tr', count: 1, text: url
-      end
-
+    context 'layout' do
+      before { visit "/relationships/#{relationship.id}" }
+      it { is_expected.to have_selector 'h1.relationship-title-link a', text: relationship.name }
+      it { is_expected.to have_selector '#source-links-table tbody tr', count: 1, text: url }
+      it { is_expected.not_to have_selector '#tags-container' }
       it 'opens the source links in a new tab' do
-        page.all('#source-links-table tbody tr a').each do |element|
+        page.all('#source-links-table tbody tr a').each do |element| 
           expect(element[:target]).to eql '_blank'
         end
       end
     end
+
+    context 'with tags' do
+      let!(:tags) { relationship.add_tag(tag.id) }
+      before { visit "/relationships/#{relationship.id}" }
+      it { is_expected.to have_selector '#tags-container' }
+      it { is_expected.not_to have_selector '#tags-edit-button' }
+      it { is_expected.not_to have_selector '#tags-init-js' }
+    end
+  end
+
+  context 'signed in user' do
+    subject { page }
+    let(:user) { create_basic_user }
+    let!(:tags) { relationship.add_tag(tag.id) }
+
+    before do
+      login_as(user, scope: :user)
+      visit "/relationships/#{relationship.id}"
+    end
+    after { logout(user) }
+
+    it { is_expected.to have_selector '#tags-container' }
+    it { is_expected.to have_selector '#tags-edit-button' }
+    it { is_expected.to have_selector '#tags-list li', text: tag.name }
+    it { is_expected.to have_selector '#tags-init-js' }
   end
 end

--- a/spec/views/entities/show.html.erb_spec.rb
+++ b/spec/views/entities/show.html.erb_spec.rb
@@ -16,7 +16,9 @@ describe 'entities/show.html.erb' do
   context 'switching tabs' do
     before do
       assign(:active_tab, active_tab)
-      assign(:entity, build(:org, last_user_id: @sf_user.id, updated_at: 1.day.ago, org: build(:organization)))
+      entity = build(:org, last_user_id: @sf_user.id, updated_at: 1.day.ago, org: build(:organization))
+      expect(entity).to receive(:similar_entities).and_return([])
+      assign(:entity, entity)
       render
     end
 

--- a/spec/views/entities/sidebar/_sidebar.html.erb_spec.rb
+++ b/spec/views/entities/sidebar/_sidebar.html.erb_spec.rb
@@ -164,19 +164,4 @@ describe "partial: sidebar", :tag_helper do
       end
     end
   end
-
-  describe 'similar entities' do
-    before { assign(:entity, org) }
-    it 'has merging process link' do
-      allow(view).to receive(:user_signed_in?).and_return(true)
-      assign(:similar_entities, ['some', 'similar', 'entities'])
-      expect(view).to receive(:sidebar_similar_entities)
-      current_user = build(:user)
-      expect(current_user).to receive(:admin?).at_least(:twice).and_return(false)
-      allow(current_user).to receive(:importer?).and_return(false)
-      expect(current_user).to receive(:has_legacy_permission).at_least(:once).with('merger').and_return(true)
-      expect(view).to receive(:current_user).at_least(:twice).and_return(current_user)
-      render partial: 'entities/sidebar.html.erb' 
-    end
-  end
 end


### PR DESCRIPTION
resolves #345 

This pull request makes tags visible for all. It also adds 'tags' to the 'explore' section of the nav bar.