### PR TITLE
Join page improvements

### DIFF
--- a/app/assets/stylesheets/styles/home.scss
+++ b/app/assets/stylesheets/styles/home.scss
@@ -159,3 +159,7 @@ div#donate  {
 .littlesis_carousel a.buttons img {
     cursor: pointer;
 }
+
+#join-page-get-involved p {
+    text-align: justify;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -123,7 +123,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def user_params
-    params.require(:user).permit(:username, :email, :password, :password_confirmation, :default_network_id, :newsletter)
+    params.require(:user).permit(:username, :email, :password, :password_confirmation, :default_network_id, :newsletter, :map_the_power)
   end
 
   def sf_profile_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -127,7 +127,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def sf_profile_params
-    sf_params = params.require(:user).permit(:email, :username, sf_guard_user_profile: [:name_first, :name_last, :reason] )
+    sf_params = params.require(:user).permit(:email, :username, sf_guard_user_profile: [:name_first, :name_last, :reason, :location])
     sf_params[:sf_guard_user_profile].merge(
       "email" => sf_params[:email],
       "public_name" => sf_params[:username],

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -38,38 +38,38 @@
  })
 </script>
 
+<% column_class = 'col-sm-8' %>
+
 <div class="row">
-  <div class="col-sm-7">
+  <div class="<%= column_class %>">
     <div class="thin-grey-bottom-border">
       <h2>Get Involved!</h2>
-    </div>
-  </div>
-  <div class="col-sm-1"></div>
-  <div class="col-sm-4 thin-grey-bottom-border">
-    <h2 class="text-center">Data Summary</h2>
+      </div>
   </div>
 </div>
 <br />
 <div class="row">
-  <div class="col-sm-8">
-    <div class="row">
-      <div class="col-sm-12">
-	<p><strong>LittleSis is bringing together a community of researchers who believe in transparency and accountability in our society and economy.</strong> Our task is to study, document, and expose the social networks that have our democracy in a stranglehold, so that grassroots efforts can more effectively challenge their claim to power.</p>
-	<p><strong>We're looking for researchers, programmers, artists and organizers to be a part of our activist researcher community.</strong> If you want to get involved sign up to become a LittleSis analyst and start adding information to the site. You can check out our instructional videos for information on how to use all the tools on our site.</p>
-	<p>If you’re interested in <strong>connecting with other power researchers in your region</strong> and doing local or regional power mapping of your city or state, check out our <%= link_to 'Map The Power', 'https://littlesis.org/toolkit' %> toolkit and sign up <%= link_to 'here', 'https://docs.google.com/forms/d/e/1FAIpQLSfiJh9AjPmE8l6m-OKQH5-Tde6RjlVrZ-q_pjg8UV62h8dneA/viewform' %> to be part of our national network of researchers for the resistance!</p>
-      </div>
-    </div>
-    <div class="row bottom-1em">
-      <div class="col-sm-8">
-        <div class="thin-grey-bottom-border">
-          <h3>Become an analyst!</h2>
-        </div>
-      </div>
-    </div>
+  <div class="col-sm-8 col-md-7 col-xs-12" id="join-page-get-involved">
+    <p><strong>LittleSis is bringing together a community of researchers who believe in transparency and accountability in our society and economy.</strong> Our task is to study, document, and expose the social networks that have our democracy in a stranglehold, so that grassroots efforts can more effectively challenge their claim to power.</p>
+    <p><strong>We're looking for researchers, programmers, artists and organizers to be a part of our activist researcher community.</strong> If you want to get involved sign up to become a LittleSis analyst and start adding information to the site. You can check out our <%= link_to 'instructional videos', 'https://www.youtube.com/watch?v=aWLnTqQb-BI&list=PLLT8_8t1lsddq42_VmrwIXSkXn0-bLfit' %> for information on how to use all the tools on our site.</p>
+    <p>If you’re interested in <strong>connecting with other power researchers in your region</strong> and doing local or regional power mapping of your city or state, check out our <%= link_to 'Map The Power', 'https://littlesis.org/toolkit' %> toolkit and sign up <%= link_to 'here', 'https://docs.google.com/forms/d/e/1FAIpQLSfiJh9AjPmE8l6m-OKQH5-Tde6RjlVrZ-q_pjg8UV62h8dneA/viewform' %> to be part of our national network of researchers for the resistance!</p>
+  </div>
+  <div class="col-sm-4 col-md-5 hidden-xs">
+    <%= image_tag "map_the_power_RGB.jpg",  class: 'img-responsive center-block' %>
+  </div>
+</div>
 
-    <div class="row">
+<div class="row bottom-1em">
+  <div class="<%= column_class %>">
+    <div class="thin-grey-bottom-border">
+      <h3>Become an analyst!</h2>
+    </div>
+  </div>
+</div>
+
+<div class="row">
       
-      <div class="col-sm-12">
+      <div class="col-sm-7">
         <p>LittleSis presents an exciting opportunity: editors (called "analysts" on LittleSis) are developing an unprecedented, authoritative database of key relationships between powerful Americans. Sign up to edit the profile pages of your (least) favorite fatcats.</p>
         <p>To request an account, please provide all of the following information. We promise not to share it with anyone, ever!</p>
 
@@ -201,8 +201,5 @@
 
       </div>
     </div>
-  </div>
-  <div class="col-sm-3 col-sm-offset-1">
-    <%= render partial: 'home/data_summary', locals: {stats: ExtensionRecord.data_summary} %>
   </div>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -55,7 +55,7 @@
     <p>If you’re interested in <strong>connecting with other power researchers in your region</strong> and doing local or regional power mapping of your city or state, check out our <%= link_to 'Map The Power', 'https://littlesis.org/toolkit' %> toolkit and sign up <%= link_to 'here', 'https://docs.google.com/forms/d/e/1FAIpQLSfiJh9AjPmE8l6m-OKQH5-Tde6RjlVrZ-q_pjg8UV62h8dneA/viewform' %> to be part of our national network of researchers for the resistance!</p>
   </div>
   <div class="col-sm-4 col-md-5 hidden-xs">
-    <%= image_tag "map_the_power_RGB.jpg",  class: 'img-responsive center-block' %>
+    <%= image_tag "map_the_power_RGB.jpg",  class: 'img-responsive' %>
   </div>
 </div>
 
@@ -165,6 +165,15 @@
 		<%= f.check_box :newsletter, checked: true %><small style="padding-left: 0.5em;">Send me your newsletter (we send one every 1-2 months)</small>
               </div>
 	    </div>
+
+
+	    <div class="form-group">
+              <%=  label_tag 'map_the_power', "Map the Power", :class => label_class %>
+              <div class="col-sm-9">
+		<%= f.check_box :map_the_power %><small style="padding-left: 0.5em;">Tell me more about Map the Power!</small>
+              </div>
+	    </div>
+
 
 	    <div class="form-group">
               <%=  label_tag 'location', "Location", :class => label_class %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -54,8 +54,9 @@
   <div class="col-sm-8">
     <div class="row">
       <div class="col-sm-12">
-	<p><strong>LittleSis is bringing together a community of citizens who believe in transparency and accountability where it matters most.</strong> Our task is to study, document, and expose the social networks that have our democracy in a stranglehold, so that grassroots efforts can more effectively challenge their claim to power.</p>
-	<p><strong>We're looking for researchers, programmers, artists and organizers to lend a hand.</strong> If you want to get involved, <%= link_to "send us a note", "/contact" %> join our email list, sign up to become a LittleSis analyst and start adding information to the site, or check out our <%= link_to "help pages", '/help' %> for information on how to use the site.</p>
+	<p><strong>LittleSis is bringing together a community of researchers who believe in transparency and accountability in our society and economy.</strong> Our task is to study, document, and expose the social networks that have our democracy in a stranglehold, so that grassroots efforts can more effectively challenge their claim to power.</p>
+	<p><strong>We're looking for researchers, programmers, artists and organizers to be a part of our activist researcher community.</strong> If you want to get involved sign up to become a LittleSis analyst and start adding information to the site. You can check out our instructional videos for information on how to use all the tools on our site.</p>
+	<p>If you’re interested in <strong>connecting with other power researchers in your region</strong> and doing local or regional power mapping of your city or state, check out our <%= link_to 'Map The Power', 'https://littlesis.org/toolkit' %> toolkit and sign up <%= link_to 'here', 'https://docs.google.com/forms/d/e/1FAIpQLSfiJh9AjPmE8l6m-OKQH5-Tde6RjlVrZ-q_pjg8UV62h8dneA/viewform' %> to be part of our national network of researchers for the resistance!</p>
       </div>
     </div>
     <div class="row bottom-1em">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,14 +4,14 @@
    aboutYouInput.setCustomValidity("Don't forget to fill out this field");
    
    aboutYouInput.addEventListener("input", function(e){
-	     if (this.value === '') {
-	       this.setCustomValidity("Don't forget to fill out this field");
-	     } else if (this.value.split(' ').length <= 2) {
-	       this.setCustomValidity("Please include more details")
-	     } else {
-	       this.setCustomValidity("")
-	     }
-	   });
+     if (this.value === '') {
+       this.setCustomValidity("Don't forget to fill out this field");
+     } else if (this.value.split(' ').length <= 2) {
+       this.setCustomValidity("Please include more details")
+     } else {
+       this.setCustomValidity("")
+     }
+   });
  });
  
  function validateForm(){
@@ -39,175 +39,169 @@
 </script>
 
 <div class="row">
-    <div class="col-sm-7">
-        <div class="thin-grey-bottom-border">
-            <h2>Get Involved!</h2>
-        </div>
+  <div class="col-sm-7">
+    <div class="thin-grey-bottom-border">
+      <h2>Get Involved!</h2>
     </div>
-    <div class="col-sm-1"></div>
-    <div class="col-sm-4 thin-grey-bottom-border">
-        <h2 class="text-center">Data Summary</h2>
-    </div>
+  </div>
+  <div class="col-sm-1"></div>
+  <div class="col-sm-4 thin-grey-bottom-border">
+    <h2 class="text-center">Data Summary</h2>
+  </div>
 </div>
 <br />
 <div class="row">
-    <div class="col-sm-8">
-        <div class="row">
-            <div class="col-sm-12">
-		<p><strong>LittleSis is bringing together a community of citizens who believe in transparency and accountability where it matters most.</strong> Our task is to study, document, and expose the social networks that have our democracy in a stranglehold, so that grassroots efforts can more effectively challenge their claim to power.</p>
-		<p><strong>We're looking for researchers, programmers, artists and organizers to lend a hand.</strong> If you want to get involved, <%= link_to "send us a note", "/contact" %> join our email list, sign up to become a LittleSis analyst and start adding information to the site, or check out our <%= link_to "help pages", '/help' %> for information on how to use the site.</p>
-            </div>
-        </div>
-        <div class="row bottom-1em">
-            <div class="col-sm-8">
-                <div class="thin-grey-bottom-border">
-                    <h3>Become an analyst!</h2>
-                </div>
-            </div>
-        </div>
-
-        <div class="row">
-            
-            <div class="col-sm-12">
-                <p>LittleSis presents an exciting opportunity: editors (called "analysts" on LittleSis) are developing an unprecedented, authoritative database of key relationships between powerful Americans. Sign up to edit the profile pages of your (least) favorite fatcats.</p>
-                <p>To request an account, please provide all of the following information. We promise not to share it with anyone, ever!</p>
-
-                <% label_class = 'col-sm-2 control-label' %>
-                <% field_class = 'col-sm-6' %>
-                <br />
-
-                <%= form_for(resource, as: resource_name,  url: registration_path(resource_name), html: {:onsubmit => 'return validateForm();', :class => 'form-horizontal', }) do |f| %>
-                    <%= devise_error_messages! %>
-                    <%= f.fields_for :sf_guard_user_profile do |profile_fields| %>
-
-		      <% if @signup_errors.present? %>
-			<div class="form-group">
-			  <div class="col-sm-10">
-			    <div class="alert alert-danger" role="alert" id="signup-errors-alert">
-			      <h5><strong>Sorry!</strong> We could not create your account for the following reasons:</h5>
-			      <% @signup_errors.each do |msg| %>
-				<p><%= msg %></p>
-			      <% end %>
-			    </div>
-			  </div>
-			</div>
-		      <% end %>
-		      
-
-			<div class="form-group">
-                            <%= profile_fields.label :name_first, "First Name", :class => label_class   %>
-                            <div class="<%= field_class %>">
-				<%= profile_fields.text_field :name_first, :required => true %>
-                            </div>
-			</div>
-			
-			<div class="form-group">
-                            <%= profile_fields.label :name_last, "Last Name", :class => label_class %>
-                            <div class="<%= field_class %>">
-				<%= profile_fields.text_field :name_last %><br />
-				<small><em>(your name and email will not be public)</em> </small>
-                            </div>
-                            
-			</div>
-			<div class="row">
-                            <div class="col-sm-2"></div>
-                            <div class="col-sm-10">
-				
-                            </div>
-
-			</div>
-			<div class="form-group">
-                            <%= f.label :email,
-			    "Email",
-			    :class => label_class,
-			    :title => 'We do not share your email with anyone. Email verification is required to use LittleSis, and a confirmation will be sent out after you submit this form',
-			    :data => {toggle: 'tooltip', placement: 'left' } %>
-                            <div class="<%= field_class %>">
-				<%= f.email_field :email, autofocus: true, :required => true %>
-                            </div>
-			</div>
-			
-			<div class="form-group">
-                            <%= f.label :username, "Username",
-			    :class => label_class,
-			    :title => 'This is your public username. Any edits you do will be recorded with this name and visible to other LittleSis users',
-			    :data => {toggle: 'tooltip', placement: 'left' } %>
-                            <div class="<%= field_class %>">
-				<%= f.text_field :username, autofocus: true,
-				:required => true,
-				:pattern => '[^@ ]{3,}',
-				:oninvalid => "this.setCustomValidity(\"Usernames must be at least 3 letters and cannot include '@' or spaces\")",
-				:oninput => "this.setCustomValidity('')"
-				%>
-                            </div>
-			</div>
-
-
-			<div class="form-group">
-                            <%= f.label :password, "Password (Minimum 8 letters)", :class => label_class %>
-                            <div class="<%= field_class %>">
-				<%= f.password_field :password, autocomplete: "off", :required => true  %>
-                            </div>
-			</div>
-
-			<div class="form-group">
-                            <%= f.label :password_confirmation, :class => label_class  %>
-                            <div class="<%= field_class %>">
-				<%= f.password_field :password_confirmation, autocomplete: "off", :required => true  %>
-                            </div>
-			</div>
-
-			
-
-
-			<div class="form-group">
-                            <%=  label_tag 'terms_of_use', "Terms of use", :class => label_class %>
-                            <div class="col-sm-9 bg-info bottom-1em top-1em">
-				<p>I understand that LittleSis's mission is to track people and groups with inordinate wealth, influence on public policy, and access to government officials. As a LittleSis analyst it is my responsibility to ensure that information I contribute is relevant to the site's mission, accurate, and documented by publicly available original sources on the internet. The LittleSis staff can revoke my editing privileges or disable my account if they believe I am not following these guidelines in good faith.</p>
-				<%= check_box_tag 'terms_of_use' %><small> I accept the above terms of use </small>
-                            </div>
-			</div>
-
-			<div class="form-group">
-                            <%=  label_tag 'newsletter', "Newsletter?", :class => label_class %>
-                            <div class="col-sm-10">
-				<%= f.check_box :newsletter, checked: true %><small style="padding-left: 0.5em;">Send me your newsletter (we send one every 1-2 months)</small>
-                            </div>
-			</div>
-
-			<div class="form-group">
-                            <%= profile_fields.label :reason, "A little about you and why you're signing up*", :class => label_class  %>
-                            <div class="col-sm-9">
-				<%= profile_fields.text_area :reason, :class => 'form-control', :rows => 5, :id => 'about-you-input' %>
-                            </div>
-			</div>
-			
-			<div class="form-group">
-			    <%=  label_tag 'spam_test', "", :class => label_class %>
-                            <div class="col-sm-10">
-				<%= flash[:recaptcha_error] %>
-				<%= recaptcha_tags %>
-			    </div>
-			</div>
-
-			<div class="actions form-group">
-                            <div class="col-sm-2"></div>
-                            <div class="col-sm-2">
-				<%= f.submit "Sign up" %>
-				<p class="text-center"><small><%= render "users/shared/links" %></small></p>
-                            </div>
-			</div>
-			
-                    <% end %>
-		<% end %>
-
-            </div>
-        </div>
+  <div class="col-sm-8">
+    <div class="row">
+      <div class="col-sm-12">
+	<p><strong>LittleSis is bringing together a community of citizens who believe in transparency and accountability where it matters most.</strong> Our task is to study, document, and expose the social networks that have our democracy in a stranglehold, so that grassroots efforts can more effectively challenge their claim to power.</p>
+	<p><strong>We're looking for researchers, programmers, artists and organizers to lend a hand.</strong> If you want to get involved, <%= link_to "send us a note", "/contact" %> join our email list, sign up to become a LittleSis analyst and start adding information to the site, or check out our <%= link_to "help pages", '/help' %> for information on how to use the site.</p>
+      </div>
     </div>
-    <div class="col-sm-1"></div>
-    <div class="col-sm-3">
-        <%= render partial: 'home/data_summary', locals: {stats: ExtensionRecord.data_summary} %>
+    <div class="row bottom-1em">
+      <div class="col-sm-8">
+        <div class="thin-grey-bottom-border">
+          <h3>Become an analyst!</h2>
+        </div>
+      </div>
     </div>
+
+    <div class="row">
+      
+      <div class="col-sm-12">
+        <p>LittleSis presents an exciting opportunity: editors (called "analysts" on LittleSis) are developing an unprecedented, authoritative database of key relationships between powerful Americans. Sign up to edit the profile pages of your (least) favorite fatcats.</p>
+        <p>To request an account, please provide all of the following information. We promise not to share it with anyone, ever!</p>
+
+        <% label_class = 'col-sm-3 control-label' %>
+        <% field_class = 'col-sm-6' %>
+        <br />
+
+        <%= form_for(resource, as: resource_name,  url: registration_path(resource_name), html: {:onsubmit => 'return validateForm();', :class => 'form-horizontal', }) do |f| %>
+          <%= devise_error_messages! %>
+          <%= f.fields_for :sf_guard_user_profile do |profile_fields| %>
+
+	    <% if @signup_errors.present? %>
+	      <div class="form-group">
+		<div class="col-sm-10">
+		  <div class="alert alert-danger" role="alert" id="signup-errors-alert">
+		    <h5><strong>Sorry!</strong> We could not create your account for the following reasons:</h5>
+		    <% @signup_errors.each do |msg| %>
+		      <p><%= msg %></p>
+		    <% end %>
+		  </div>
+		</div>
+	      </div>
+	    <% end %>
+	    
+
+	    <div class="form-group">
+              <%= profile_fields.label :name_first, "First Name", :class => label_class   %>
+              <div class="<%= field_class %>">
+		<%= profile_fields.text_field :name_first, :required => true %>
+              </div>
+	    </div>
+	    
+	    <div class="form-group">
+              <%= profile_fields.label :name_last, "Last Name", :class => label_class %>
+              <div class="<%= field_class %>">
+		<%= profile_fields.text_field :name_last %><br />
+		<small><em>(your name and email will not be public)</em> </small>
+              </div>
+              
+	    </div>
+	    
+	    <div class="form-group">
+              <%= f.label :email,
+	      "Email",
+	      :class => label_class,
+	      :title => 'We do not share your email with anyone. Email verification is required to use LittleSis, and a confirmation will be sent out after you submit this form',
+	      :data => {toggle: 'tooltip', placement: 'left' } %>
+              <div class="<%= field_class %>">
+		<%= f.email_field :email, autofocus: true, :required => true %>
+              </div>
+	    </div>
+	    
+	    <div class="form-group">
+              <%= f.label :username, "Username",
+	      :class => label_class,
+	      :title => 'This is your public username. Any edits you do will be recorded with this name and visible to other LittleSis users',
+	      :data => {toggle: 'tooltip', placement: 'left' } %>
+              <div class="<%= field_class %>">
+		<%= f.text_field :username, autofocus: true,
+		:required => true,
+		:pattern => '[^@ ]{3,}',
+		:oninvalid => "this.setCustomValidity(\"Usernames must be at least 3 letters and cannot include '@' or spaces\")",
+		:oninput => "this.setCustomValidity('')"
+		%>
+              </div>
+	    </div>
+
+	    <div class="form-group">
+              <%= f.label :password, "Password (Minimum 8 letters)", :class => label_class %>
+              <div class="<%= field_class %>">
+		<%= f.password_field :password, autocomplete: "off", :required => true  %>
+              </div>
+	    </div>
+
+	    <div class="form-group">
+              <%= f.label :password_confirmation, :class => label_class  %>
+              <div class="<%= field_class %>">
+		<%= f.password_field :password_confirmation, autocomplete: "off", :required => true  %>
+              </div>
+	    </div>
+
+	    <div class="form-group">
+              <%=  label_tag 'terms_of_use', "Terms of use", :class => label_class %>
+              <div class="col-sm-9 bg-info bottom-1em top-1em">
+		<p>I understand that LittleSis's mission is to track people and groups with inordinate wealth, influence on public policy, and access to government officials. As a LittleSis analyst it is my responsibility to ensure that information I contribute is relevant to the site's mission, accurate, and documented by publicly available original sources on the internet. The LittleSis staff can revoke my editing privileges or disable my account if they believe I am not following these guidelines in good faith.</p>
+		<%= check_box_tag 'terms_of_use' %><small> I accept the above terms of use </small>
+              </div>
+	    </div>
+
+	    <div class="form-group">
+              <%=  label_tag 'newsletter', "Newsletter?", :class => label_class %>
+              <div class="col-sm-9">
+		<%= f.check_box :newsletter, checked: true %><small style="padding-left: 0.5em;">Send me your newsletter (we send one every 1-2 months)</small>
+              </div>
+	    </div>
+
+	    <div class="form-group">
+              <%=  label_tag 'location', "Location", :class => label_class %>
+	      <div class="<%= field_class %>">
+		<%= profile_fields.text_field :location %>
+              </div>
+	    </div>
+
+	    <div class="form-group">
+              <%= profile_fields.label :reason, raw("What are <br> your research interests? <br> What are you hoping to use LittleSis for?*"), :class => label_class  %>
+              <div class="col-sm-9">
+		<%= profile_fields.text_area :reason, :class => 'form-control', :rows => 5, :id => 'about-you-input' %>
+              </div>
+	    </div>
+	    
+	    <div class="form-group">
+	      <%=  label_tag 'spam_test', "", :class => label_class %>
+              <div class="col-sm-9">
+		<%= flash[:recaptcha_error] %>
+		<%= recaptcha_tags %>
+	      </div>
+	    </div>
+
+	    <div class="actions form-group">
+              <div class="col-sm-3"></div>
+              <div class="col-sm-8">
+		<%= f.submit "Sign up" %>
+		<p><small><%= render "users/shared/links" %></small></p>
+              </div>
+	    </div>
+	    
+          <% end %>
+	<% end %>
+
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-3 col-sm-offset-1">
+    <%= render partial: 'home/data_summary', locals: {stats: ExtensionRecord.data_summary} %>
+  </div>
 </div>
-
-

--- a/db/migrate/20171109155832_add_location_to_sf_guard_user_profile.rb
+++ b/db/migrate/20171109155832_add_location_to_sf_guard_user_profile.rb
@@ -1,0 +1,5 @@
+class AddLocationToSfGuardUserProfile < ActiveRecord::Migration
+  def change
+    add_column :sf_guard_user_profile, :location, :string
+  end
+end

--- a/db/migrate/20171109174122_add_map_the_power_to_user.rb
+++ b/db/migrate/20171109174122_add_map_the_power_to_user.rb
@@ -1,0 +1,5 @@
+class AddMapThePowerToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :map_the_power, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109155832) do
+ActiveRecord::Schema.define(version: 20171109174122) do
 
   create_table "address", force: :cascade do |t|
     t.integer  "entity_id",    limit: 8,                   null: false
@@ -1661,6 +1661,7 @@ ActiveRecord::Schema.define(version: 20171109155832) do
     t.boolean  "newsletter"
     t.string   "chatid",                 limit: 255
     t.boolean  "is_restricted",                      default: false
+    t.boolean  "map_the_power"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031152314) do
+ActiveRecord::Schema.define(version: 20171109155832) do
 
   create_table "address", force: :cascade do |t|
     t.integer  "entity_id",    limit: 8,                   null: false
@@ -1541,6 +1541,7 @@ ActiveRecord::Schema.define(version: 20171031152314) do
     t.integer  "home_network_id",            limit: 4,                          null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "location",                   limit: 255
   end
 
   add_index "sf_guard_user_profile", ["email"], name: "unique_email_idx", unique: true, using: :btree

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -529,7 +529,7 @@ CREATE TABLE `delayed_jobs` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=41 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1251,7 +1251,7 @@ CREATE TABLE `ls_list` (
   KEY `index_ls_list_on_name` (`name`),
   CONSTRAINT `ls_list_ibfk_1` FOREIGN KEY (`last_user_id`) REFERENCES `sf_guard_user` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `ls_list_ibfk_2` FOREIGN KEY (`featured_list_id`) REFERENCES `ls_list` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1879 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1884 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2693,7 +2693,7 @@ CREATE TABLE `sf_guard_user` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   KEY `is_active_idx_idx` (`is_active`)
-) ENGINE=InnoDB AUTO_INCREMENT=7995 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=8027 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2779,7 +2779,7 @@ CREATE TABLE `sf_guard_user_profile` (
   UNIQUE KEY `unique_email_idx` (`email`),
   UNIQUE KEY `unique_public_name_idx` (`public_name`),
   KEY `user_id_public_name_idx` (`user_id`,`public_name`)
-) ENGINE=InnoDB AUTO_INCREMENT=51 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=88 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3004,13 +3004,14 @@ CREATE TABLE `users` (
   `newsletter` tinyint(1) DEFAULT NULL,
   `chatid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `is_restricted` tinyint(1) DEFAULT '0',
+  `map_the_power` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_sf_guard_user_id` (`sf_guard_user_id`),
   UNIQUE KEY `index_users_on_username` (`username`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
   UNIQUE KEY `index_users_on_confirmation_token` (`confirmation_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=9683 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9710 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3037,7 +3038,7 @@ CREATE TABLE `versions` (
   KEY `index_versions_on_entity1_id` (`entity1_id`),
   KEY `index_versions_on_entity2_id` (`entity2_id`),
   KEY `index_versions_on_whodunnit` (`whodunnit`)
-) ENGINE=InnoDB AUTO_INCREMENT=164 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=170 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -3049,7 +3050,7 @@ CREATE TABLE `versions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-11-09 16:09:47
+-- Dump completed on 2017-11-09 17:42:33
 INSERT INTO schema_migrations (version) VALUES ('20131031182415');
 
 INSERT INTO schema_migrations (version) VALUES ('20131031182500');
@@ -3285,4 +3286,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171018151914');
 INSERT INTO schema_migrations (version) VALUES ('20171031152314');
 
 INSERT INTO schema_migrations (version) VALUES ('20171109155832');
+
+INSERT INTO schema_migrations (version) VALUES ('20171109174122');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.7.19, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.20, for Linux (x86_64)
 --
 -- Host: mysql    Database: littlesis_test
 -- ------------------------------------------------------
@@ -2773,6 +2773,7 @@ CREATE TABLE `sf_guard_user_profile` (
   `home_network_id` int(11) NOT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
+  `location` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_user_idx` (`user_id`),
   UNIQUE KEY `unique_email_idx` (`email`),
@@ -3048,7 +3049,7 @@ CREATE TABLE `versions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-10-31 15:24:44
+-- Dump completed on 2017-11-09 16:09:47
 INSERT INTO schema_migrations (version) VALUES ('20131031182415');
 
 INSERT INTO schema_migrations (version) VALUES ('20131031182500');
@@ -3282,4 +3283,6 @@ INSERT INTO schema_migrations (version) VALUES ('20171012181822');
 INSERT INTO schema_migrations (version) VALUES ('20171018151914');
 
 INSERT INTO schema_migrations (version) VALUES ('20171031152314');
+
+INSERT INTO schema_migrations (version) VALUES ('20171109155832');
 

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -16,7 +16,7 @@ feature "Signing up for an account", type: :feature do
     expect(page).to have_current_path new_user_registration_path
 
     page_has_selector 'h2', text: 'Get Involved!'
-    page_has_selector 'h2', text: 'Data Summary'
+    page_has_selector 'h3', text: 'Become an analyst!'
 
     expect(page).to have_text "What are your research interests? What are you hoping to use LittleSis for?"
   end

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -17,6 +17,8 @@ feature "Signing up for an account", type: :feature do
 
     page_has_selector 'h2', text: 'Get Involved!'
     page_has_selector 'h2', text: 'Data Summary'
+
+    expect(page).to have_text "What are your research interests? What are you hoping to use LittleSis for?"
   end
 
   scenario 'Fills out form and signs up' do
@@ -40,6 +42,24 @@ feature "Signing up for an account", type: :feature do
     expect(page).not_to have_selector "#signup-errors-alert"
   end
 
+  scenario 'Fills out form and signs up with location field' do
+    location = 'the center of the earth'
+
+    fill_in 'user_sf_guard_user_profile_name_first', :with => user_info.first_name
+    fill_in 'user_sf_guard_user_profile_name_last', :with => user_info.last_name
+    fill_in 'user_email', :with => user_info.email
+    fill_in 'user_username', :with => user_info.username
+    fill_in 'user_password', :with => user_info.password
+    fill_in 'user_password_confirmation', :with => user_info.password
+    find(:css, "#terms_of_use").set(true)
+    fill_in 'about-you-input', :with => user_info.about_you
+    fill_in 'user_sf_guard_user_profile_location', :with => location
+
+    click_button 'Sign up'
+
+    expect(SfGuardUserProfile.last.location).to eql location
+  end
+
   context 'Attempting to signup with a username that is already taken' do
     let(:username) { Faker::Internet.user_name }
     let!(:user) do
@@ -50,7 +70,7 @@ feature "Signing up for an account", type: :feature do
 
     scenario 'Shows error message regarding the username' do
       counts = [User.count, SfGuardUser.count, SfGuardUserProfile.count]
-      
+
       fill_in 'user_sf_guard_user_profile_name_first', :with => user_info.first_name
       fill_in 'user_sf_guard_user_profile_name_last', :with => user_info.last_name
       fill_in 'user_email', :with => user_info.email
@@ -63,7 +83,7 @@ feature "Signing up for an account", type: :feature do
       click_button 'Sign up'
 
       expect(counts).to eql [User.count, SfGuardUser.count, SfGuardUserProfile.count]
-      
+
       expect(page.status_code).to eq 200
       page_has_selector 'h2', text: 'Get Involved!'
       page_has_selector "#signup-errors-alert"
@@ -71,5 +91,4 @@ feature "Signing up for an account", type: :feature do
 
     end
   end
-  
 end

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -17,7 +17,7 @@ feature "Signing up for an account", type: :feature do
 
     page_has_selector 'h2', text: 'Get Involved!'
     page_has_selector 'h3', text: 'Become an analyst!'
-
+    expect(page).to have_text "Tell me more about Map the Power!"
     expect(page).to have_text "What are your research interests? What are you hoping to use LittleSis for?"
   end
 
@@ -38,11 +38,14 @@ feature "Signing up for an account", type: :feature do
     expect(counts.map { |x| x + 1 }).to eql [User.count, SfGuardUser.count, SfGuardUserProfile.count]
     expect(page.status_code).to eq 200
     expect(page).to have_current_path join_success_path
-
     expect(page).not_to have_selector "#signup-errors-alert"
+
+    last_user = User.last
+    expect(last_user.newsletter).to be true
+    expect(last_user.map_the_power).to be false
   end
 
-  scenario 'Fills out form and signs up with location field' do
+  scenario 'Fills out form and signs up with location field and checks map the power' do
     location = 'the center of the earth'
 
     fill_in 'user_sf_guard_user_profile_name_first', :with => user_info.first_name
@@ -55,9 +58,15 @@ feature "Signing up for an account", type: :feature do
     fill_in 'about-you-input', :with => user_info.about_you
     fill_in 'user_sf_guard_user_profile_location', :with => location
 
+    find(:css, "#user_map_the_power").set(true)
+
     click_button 'Sign up'
 
     expect(SfGuardUserProfile.last.location).to eql location
+
+    last_user = User.last
+    expect(last_user.email).to eql user_info.email
+    expect(last_user.map_the_power).to be true
   end
 
   context 'Attempting to signup with a username that is already taken' do

--- a/spec/models/sf_guard_user_profile_spec.rb
+++ b/spec/models/sf_guard_user_profile_spec.rb
@@ -4,6 +4,8 @@ describe SfGuardUserProfile do
   before(:all) { DatabaseCleaner.start }
   after(:all) { DatabaseCleaner.clean }
 
+  it { should have_db_column(:location) }
+
   describe 'validations' do
     before(:all) { @sf_guard_user = create(:sf_guard_user) }
     subject { build(:sf_guard_user_profile, user_id: @sf_guard_user.id) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,7 @@ describe User do
   before(:all) { DatabaseCleaner.start }
   after(:all) { DatabaseCleaner.clean }
 
+  it { should have_db_column(:map_the_power) }
   it { should have_one(:api_token) }
   it { should have_many(:lists) }
   it { should have_many(:user_permissions) }


### PR DESCRIPTION
Resolves #377 

Makes the following changes to the join page:

- Removes the data summary and replaces it with the map the power logo
- changes the 'get involved' text
- adds location field
- adds interested in map the power check box
- other minor style changes

two changes to our models:
- add string field 'location' to sf_guard_user_profile
- add boolean field 'map_the_power' to user

![get_involved_join](https://user-images.githubusercontent.com/8505044/32621459-d2566d4a-c54d-11e7-9a95-6a6a81406f6d.png)

____________________________________________

![join_new_fields](https://user-images.githubusercontent.com/8505044/32621464-d6dc5230-c54d-11e7-920d-664e60a5147a.png)
