### PR TITLE
Entity merge

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -15,7 +15,6 @@ class Article < ActiveRecord::Base
       driver.navigate.to(url)
       driver.save_screenshot(screenshot_path)
     rescue => e
-      binding.pry
       return false
     end
 

--- a/app/models/ny_filer_entity.rb
+++ b/app/models/ny_filer_entity.rb
@@ -1,16 +1,16 @@
 class NyFilerEntity < ActiveRecord::Base
   belongs_to :ny_filer
   belongs_to :entity
-  
+
   validates_presence_of :ny_filer_id, :entity_id, :filer_id
 
   after_create :rematch_existing_matches
-  
+
   def rematch_existing_matches
-    NyMatch.joins(:ny_filer_entity).where('ny_filer_entities.id = ?', id).find_each do |ny_match| 
+    NyMatch.joins(:ny_filer_entity).where('ny_filer_entities.id = ?', id).find_each do |ny_match|
       ny_match.rematch
     end
   end
-  handle_asynchronously :rematch_existing_matches
 
+  handle_asynchronously :rematch_existing_matches
 end

--- a/app/models/ny_match.rb
+++ b/app/models/ny_match.rb
@@ -53,7 +53,7 @@ class NyMatch < ActiveRecord::Base
   def unmatch!
     destroy!
     if relationship.present?
-      relationship.update_ny_donation_info.save
+      relationship.update_ny_donation_info.save!
       relationship.soft_delete unless relationship.ny_matches.exists?
     end
   end

--- a/app/models/ny_match.rb
+++ b/app/models/ny_match.rb
@@ -36,6 +36,8 @@ class NyMatch < ActiveRecord::Base
   end
 
   # input: int, int, int (optional)
+  # output: NyMatch
+  # Matches the NY disclosure with the donor.
   def self.match(disclosure_id, donor_id, matched_by=APP_CONFIG['system_user_id'])
     m = self.find_or_initialize_by(ny_disclosure_id: disclosure_id, donor_id: donor_id)
     if m.new_record?
@@ -44,6 +46,15 @@ class NyMatch < ActiveRecord::Base
       m.create_or_update_relationship
       m.recipient.try(:touch)
       m.save
+    end
+    return m
+  end
+
+  def unmatch!
+    destroy!
+    if relationship.present?
+      relationship.update_ny_donation_info.save
+      relationship.soft_delete unless relationship.ny_matches.exists?
     end
   end
 

--- a/app/models/os_match.rb
+++ b/app/models/os_match.rb
@@ -109,16 +109,15 @@ class OsMatch < ActiveRecord::Base
     end
   end
 
-  # 1) Updates relationship os donation info
-  # 2) Destroys links and donations
-  # 3) Destroys the reference
+  # Callback for after_destroy:
+  # - Updates relationship os donation info
+  # - soft_deletes relationship if there are no more matches
+  # - remove the reference from the relationship
   def unmatch
     relationship.update_os_donation_info.save!
 
     if relationship.filings.zero?
       relationship.soft_delete
-      relationship.donation.destroy
-      relationship.links.each(&:delete)
     else
 
       doc = Document.find_by_url(os_donation.reference_url)

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -531,6 +531,11 @@ class Relationship < ActiveRecord::Base
     end
   end
 
+  # -> [ entity1_id, entity2_id, category_id ]
+  def triplet
+    [entity1_id, entity2_id, category_id]
+  end
+
   private
 
   def last_user_id_for_entity_update(sf_user_id = nil)

--- a/app/utility/color_printer.rb
+++ b/app/utility/color_printer.rb
@@ -1,48 +1,59 @@
 class ColorPrinter
   NOCOLOR = "\e[0m"
 
+  COLORS = [:black, :red, :green, :brown, :blue, :magenta, :cyan, :gray, :bg_red, :bg_gray]
+
+  COLORS.each do |color|
+    define_singleton_method("print_#{color}") do |text|
+      puts colorize(text, color)
+    end
+
+    define_singleton_method(color) do |text|
+      colorize(text, color)
+    end
+  end
+
+  def self.colorize(text, color)
+    "#{color_code(color)}#{text}#{NOCOLOR}"
+  end
+
   def self.print(text, color = nil)
     if color.nil?
       puts text
     else
-      puts "#{color_code(color)}#{text}#{NOCOLOR}"
+      puts colorize(text, color)
     end
   end
 
   def self.color_code(color)
     case color
+    when :black
+      "\e[30m"
     when :red
       "\e[31m"
     when :green
       "\e[32m"
+    when :brown
+      "\e[33m"
     when :blue
       "\e[34m"
+    when :magenta
+      "\e[35m"
     when :cyan
       "\e[36m"
+    when :gray
+      "\e[37m"
+    when :bg_red
+      "\e[41m"
+    when :bg_gray
+      "\e[47m"
     else
       raise ArgumentError, "invalid color!"
     end
   end
 end
 
-# def black;          "\e[30m#{self}\e[0m" end
-# def red;            "\e[31m#{self}\e[0m" end
-# def green;          "\e[32m#{self}\e[0m" end
-# def brown;          "\e[33m#{self}\e[0m" end
-# def blue;           "\e[34m#{self}\e[0m" end
-# def magenta;        "\e[35m#{self}\e[0m" end
-# def cyan;           "\e[36m#{self}\e[0m" end
-# def gray;           "\e[37m#{self}\e[0m" end
-
-# def bg_black;       "\e[40m#{self}\e[0m" end
-# def bg_red;         "\e[41m#{self}\e[0m" end
-# def bg_green;       "\e[42m#{self}\e[0m" end
-# def bg_brown;       "\e[43m#{self}\e[0m" end
-# def bg_blue;        "\e[44m#{self}\e[0m" end
-# def bg_magenta;     "\e[45m#{self}\e[0m" end
-# def bg_cyan;        "\e[46m#{self}\e[0m" end
-# def bg_gray;        "\e[47m#{self}\e[0m" end
-
+# ADD THESE TOO?
 # def bold;           "\e[1m#{self}\e[22m" end
 # def italic;         "\e[3m#{self}\e[23m" end
 # def underline;      "\e[4m#{self}\e[24m" end

--- a/app/utility/color_printer.rb
+++ b/app/utility/color_printer.rb
@@ -1,0 +1,50 @@
+class ColorPrinter
+  NOCOLOR = "\e[0m"
+
+  def self.print(text, color = nil)
+    if color.nil?
+      puts text
+    else
+      puts "#{color_code(color)}#{text}#{NOCOLOR}"
+    end
+  end
+
+  def self.color_code(color)
+    case color
+    when :red
+      "\e[31m"
+    when :green
+      "\e[32m"
+    when :blue
+      "\e[34m"
+    when :cyan
+      "\e[36m"
+    else
+      raise ArgumentError, "invalid color!"
+    end
+  end
+end
+
+# def black;          "\e[30m#{self}\e[0m" end
+# def red;            "\e[31m#{self}\e[0m" end
+# def green;          "\e[32m#{self}\e[0m" end
+# def brown;          "\e[33m#{self}\e[0m" end
+# def blue;           "\e[34m#{self}\e[0m" end
+# def magenta;        "\e[35m#{self}\e[0m" end
+# def cyan;           "\e[36m#{self}\e[0m" end
+# def gray;           "\e[37m#{self}\e[0m" end
+
+# def bg_black;       "\e[40m#{self}\e[0m" end
+# def bg_red;         "\e[41m#{self}\e[0m" end
+# def bg_green;       "\e[42m#{self}\e[0m" end
+# def bg_brown;       "\e[43m#{self}\e[0m" end
+# def bg_blue;        "\e[44m#{self}\e[0m" end
+# def bg_magenta;     "\e[45m#{self}\e[0m" end
+# def bg_cyan;        "\e[46m#{self}\e[0m" end
+# def bg_gray;        "\e[47m#{self}\e[0m" end
+
+# def bold;           "\e[1m#{self}\e[22m" end
+# def italic;         "\e[3m#{self}\e[23m" end
+# def underline;      "\e[4m#{self}\e[24m" end
+# def blink;          "\e[5m#{self}\e[25m" end
+# def reverse_color;  "\e[7m#{self}\e[27m" end

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -17,7 +17,15 @@ class EntityMerger
     merge
     ActiveRecord::Base.transaction do
       @extensions.each { |e| e.merge!(@dest) }
-      
+      @contact_info.each(&:save!)
+      @lists.each { |list_id| ListEntity.create!(list_id: list_id, entity_id: dest.id) }
+      @images.each(&:save!)
+      @aliases.each(&:save!)
+      @document_ids.each { |doc_id| dest.add_reference_by_document_id(doc_id) }
+      @tag_ids.each { |tag_id| dest.add_tag(tag_id) }
+      @articles.each(&:save!)
+      @os_categories.each(&:save!)
+      @relationships.each(&:save!)
     end
   end
 
@@ -35,9 +43,9 @@ class EntityMerger
     merge_references
     merge_tags
     merge_articles
+    merge_os_categories
     merge_os_donations
     merge_ny_donations
-    merge_os_categories
     merge_relationships
   end
 

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -1,11 +1,12 @@
 class EntityMerger
-  attr_reader :source, :dest, :extensions
+  attr_reader :source, :dest, :extensions, :contact_info
 
   def initialize(source:, dest:)
     @source = source
     @dest = dest
     check_input_validity
     @extensions = []
+    @contact_info = []
   end
 
   # the actual merging
@@ -43,6 +44,28 @@ class EntityMerger
     end
   end
 
+  
+  def merge_contact_info
+    set_dest_entity_id = proc { |x| x.entity_id = dest.id }
+
+    source.addresses.each do |address|
+      unless dest.addresses.present? && dest.addresses.select { |dest_a| dest_a.same_as?(address) }.present?
+        @contact_info << address.dup.tap(&set_dest_entity_id)
+      end
+    end
+
+    source.emails.each do |email|
+      unless dest.emails.present? && dest.emails.map(&:address).include?(email.address)
+        @contact_info << email.dup.tap(&set_dest_entity_id)
+      end
+    end
+
+    source.phones.each do |phone|
+      unless dest.phones.present? && dest.phones.map(&:number).include?(phone.number)
+        @contact_info << phone.dup.tap(&set_dest_entity_id)
+      end
+    end
+  end
 
   ## ERRORS ## 
   

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -3,7 +3,8 @@ class EntityMerger
               :contact_info, :lists, :images,
               :aliases, :document_ids, :tag_ids,
               :articles, :os_categories,
-              :relationships, :potential_duplicate_relationships
+              :relationships, :potential_duplicate_relationships,
+              :os_match_relationships
 
   def initialize(source:, dest:)
     @source = source
@@ -27,6 +28,7 @@ class EntityMerger
       @articles.each(&:save!)
       @os_categories.each(&:save!)
       @relationships.each(&:merge!)
+      merge_os_donations!
       set_merged_id_and_delete
     end
   end
@@ -187,7 +189,8 @@ class EntityMerger
   def merge_os_donations!
     @os_match_relationships.each do |rel|
       if rel.entity1_id == source.id
-        os_donation_ids = rel.os_matches(&:os_donation_id)
+       # binding.pry
+        os_donation_ids = rel.os_matches.map(&:os_donation_id)
         rel.os_matches.each(&:destroy!)
         os_donation_ids.each { |i| OsMatch.create!(os_donation_id: i, donor_id: dest.id) }
       elsif rel.entity2_id == source.id

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -65,6 +65,18 @@ class EntityMerger
     unless @potential_duplicate_relationships.length.zero?
       puts cp.red("NOTICE: ") + cp.cyan("found ") + cp.blue(@potential_duplicate_relationships.count.to_s) + cp.cyan(' potential duplicate relationships')
     end
+
+    unless @aliases.length.zero?
+      puts cp.cyan("adding ") + cp.red(@aliases.length.to_s) + cp.cyan(" aliases: ") + cp.blue(@aliases.map(&:name).join(', '))
+    end
+
+    unless @document_ids.length.zero?
+      puts cp.cyan("Transfering ") + cp.red(@document_ids.count.to_s) + cp.cyan(" documents")
+    end
+
+    unless @tag_ids.length.zero?
+      puts cp.cyan("Transfering ") + cp.red(@tag_ids.count.to_s) + cp.cyan(" tags: ") + cp.blue(@tag_ids.map { |t| Tag.find(t).name }.join(', '))
+    end
   end
 
   def merge

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -29,6 +29,7 @@ class EntityMerger
       @os_categories.each(&:save!)
       @relationships.each(&:merge!)
       merge_os_donations!
+      replace_os_match_cmte_id!
       set_merged_id_and_delete
     end
   end
@@ -48,7 +49,6 @@ class EntityMerger
     merge_tags
     merge_articles
     merge_os_categories
-    
     merge_relationships
     # merge_os_donations
     # merge_ny_donations
@@ -204,6 +204,7 @@ class EntityMerger
   end
 
   def replace_os_match_cmte_id!
+    OsMatch.where(cmte_id: source.id).update_all(cmte_id: dest.id)
     # ActiveRecord::Base.connection.execute()
   end
 

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -42,8 +42,30 @@ class EntityMerger
 
   # trial run
   def report
+    merge
+    cp = ColorPrinter
+    puts "Merging #{cp.colorize(source.name, :red)} (#{cp.colorize(source.id, :bg_red) }) into #{cp.colorize(dest.name, :red)} (#{cp.colorize(dest.id, :bg_red)})"
+
+    unless @extensions.length.zero?
+      puts cp.cyan("Adding or updating ") + cp.red(@extensions.count.to_s) + cp.cyan(" extensions")
+    end
+
+    unless @contact_info.length.zero?
+      puts cp.cyan("Transferring ") + cp.red(@contact_info.count.to_s) + cp.cyan(" contact info models")
+    end
+
+    unless @lists.length.zero?
+      puts cp.cyan("Putting the merged entity on ") + cp.red(@lists.count.to_s) + cp.cyan(" new lists")
+    end
+
+    unless @relationships.length.zero?
+      puts cp.cyan("Transfering ") + cp.red(@relationships.count.to_s) + cp.cyan(" Relationships")
+    end
+
+    unless @potential_duplicate_relationships.length.zero?
+      puts cp.red("NOTICE: ") + cp.cyan("found ") + cp.blue(@potential_duplicate_relationships.count.to_s) + cp.cyan(' potential duplicate relationships')
+    end
   end
-  
 
   def merge
     merge_extensions

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -189,13 +189,14 @@ class EntityMerger
   def merge_os_donations!
     @os_match_relationships.each do |rel|
       if rel.entity1_id == source.id
-       # binding.pry
         os_donation_ids = rel.os_matches.map(&:os_donation_id)
         rel.os_matches.each(&:destroy!)
         os_donation_ids.each { |i| OsMatch.create!(os_donation_id: i, donor_id: dest.id) }
       elsif rel.entity2_id == source.id
         rel.os_matches.each { |m| m.update!(recip_id: dest.id) }
         rel.update!(entity2_id: dest.id)
+        rel.links.where(is_reverse: false).update_all(entity2_id: dest.id)
+        rel.links.where(is_reverse: true).update_all(entity1_id: dest.id)
       else
         raise Exceptions::ThatsWeirdError
       end

--- a/app/utility/entity_merger.rb
+++ b/app/utility/entity_merger.rb
@@ -3,8 +3,9 @@ class EntityMerger
               :contact_info, :lists, :images,
               :aliases, :document_ids, :tag_ids,
               :articles, :os_categories,
+              :child_entities, :party_members,
               :relationships, :potential_duplicate_relationships,
-              :os_match_relationships
+              :os_match_relationships, :ny_match_relationships
 
   def initialize(source:, dest:)
     @source = source
@@ -20,15 +21,20 @@ class EntityMerger
     ActiveRecord::Base.transaction do
       @extensions.each { |e| e.merge!(@dest) }
       @contact_info.each(&:save!)
+      @contact_info_to_delete.each(&:destroy!)
       @lists.each { |list_id| ListEntity.create!(list_id: list_id, entity_id: dest.id) }
       @images.each(&:save!)
       @aliases.each(&:save!)
       @document_ids.each { |doc_id| dest.add_reference_by_document_id(doc_id) }
       @tag_ids.each { |tag_id| dest.add_tag(tag_id) }
       @articles.each(&:save!)
+      @child_entities.each(&:merge!)
+      @party_members.each(&:merge!)
       @os_categories.each(&:save!)
       @relationships.each(&:merge!)
       merge_os_donations!
+      merge_ny_donations!
+      transfer_ny_filer_entity!
       replace_os_match_cmte_id!
       set_merged_id_and_delete
     end
@@ -49,9 +55,9 @@ class EntityMerger
     merge_tags
     merge_articles
     merge_os_categories
+    merge_child_entities
+    merge_party_members
     merge_relationships
-    # merge_os_donations
-    # merge_ny_donations
   end
 
   ## Merge Functions ##
@@ -94,18 +100,21 @@ class EntityMerger
     source.addresses.each do |address|
       unless dest.addresses.present? && dest.addresses.select { |dest_a| dest_a.same_as?(address) }.present?
         @contact_info << address.dup.tap(&set_dest_entity_id)
+        @contact_info_to_delete << address
       end
     end
 
     source.emails.each do |email|
       unless dest.emails.present? && dest.emails.map(&:address).include?(email.address)
         @contact_info << email.dup.tap(&set_dest_entity_id)
+        @contact_info_to_delete << email
       end
     end
 
     source.phones.each do |phone|
       unless dest.phones.present? && dest.phones.map(&:number).include?(phone.number)
         @contact_info << phone.dup.tap(&set_dest_entity_id)
+        @contact_info_to_delete << phone
       end
     end
   end
@@ -164,6 +173,11 @@ class EntityMerger
         next
       end
 
+      if relationship.ny_matches.exists?
+        @ny_match_relationships << relationship
+        next
+      end
+
       attributes = relationship.attributes.except('id', 'entity1_id', 'entity2_id', 'updated_at', 'created_at')
       
       if relationship.entity1_id == source.id
@@ -205,15 +219,52 @@ class EntityMerger
 
   def replace_os_match_cmte_id!
     OsMatch.where(cmte_id: source.id).update_all(cmte_id: dest.id)
-    # ActiveRecord::Base.connection.execute()
+  end
+
+  def transfer_ny_filer_entity!
+    NyFilerEntity.where(entity_id: source.id).update_all(entity_id: dest.id)
   end
 
   def merge_ny_donations!
+    @ny_match_relationships.each do |rel|
+      if rel.entity1_id == source.id
+        ny_disclosure_ids = rel.ny_matches.map(&:ny_disclosure_id)
+        rel.ny_matches.each(&:unmatch!)
+        ny_disclosure_ids.each { |i| NyMatch.match(i, dest.id) }
+      elsif rel.entity2_id == source.id
+        rel.ny_matches.each { |m| m.update!(recip_id: dest.id) }
+        rel.update!(entity2_id: dest.id)
+        rel.links.where(is_reverse: false).update_all(entity2_id: dest.id)
+        rel.links.where(is_reverse: true).update_all(entity1_id: dest.id)
+      else
+        raise Exceptions::ThatsWeirdError
+      end
+    end
   end
 
   def set_merged_id_and_delete
     source.update!(merged_id: dest.id)
     source.reload.soft_delete
+  end
+
+  ChildEntity = Struct.new(:child, :dest_id) do
+    def merge!
+      child.update_columns(:parent_id => dest_id)
+    end
+  end
+  
+  def merge_child_entities
+    @child_entities = @source.children.map { |e| ChildEntity.new(e, @dest.id) }
+  end
+
+  PartyMember = Struct.new(:party_member, :dest_id) do
+    def merge!
+      party_member.person.update_columns(party_id: dest_id)
+    end
+  end
+
+  def merge_party_members
+    @party_members = @source.party_members.map { |e| PartyMember.new(e, @dest.id) }
   end
 
   ## ERRORS ##
@@ -231,15 +282,19 @@ class EntityMerger
   def reset_instance_vars
     @extensions = []
     @contact_info = []
+    @contact_info_to_delete = []
     @lists = []
     @images = []
     @aliases = []
     @document_ids = []
     @tag_ids = []
     @os_categories = []
+    @child_entities = []
+    @party_members = []
     @relationships = []
     @potential_duplicate_relationships = []
     @os_match_relationships = []
+    @ny_match_relationships = []
   end
 
   def check_input_validity
@@ -256,198 +311,3 @@ class EntityMerger
     @dest_relationship_lookup ||= Set.new(dest.relationships.map(&:triplet))
   end
 end
-
-=begin
-
-def self.merge_basic(e1, e2, excludes = [])
-    ActiveRecord::Base.transaction do
-      # have to have the same primary extension
-      raise "can't merge entities with different primary extensions" unless e1.primary_ext == e2.primary_ext
-
-      # add new extensions, if any, to e1, with attributes
-      exts1 = e1.extension_names
-      exts2 = e2.extension_names
-
-      (exts1 - exts2).each do |ext|
-        e1.add_extension(ext)
-      end
-
-      # set values based on merge rules defined in merge_field
-      excludes = (excludes + ['id', 'created_at', 'updated_at']).uniq
-      attrs1 = e1.all_attributes
-      attrs2 = e2.all_attributes
-      attrs2.each do |key, value|
-        next if excludes.include?(key)
-        e1.set_attribute(key, merge_attribute(key, attrs1[key], attrs2[key]))
-      end
-    end
-
-    e1
-  end
-
-  def self.merge_attribute(key, old, nu)
-    return nu if old.nil?
-    return old if nu.nil?
-    return old if old == nu
-
-    append_with_new_line_fields = ['summary', 'notes']
-    append_with_space_fields = ['name_suffix', 'name_prefix']
-    date_fields = ['start_date', 'end_date']
-    name_fields = ['name_first', 'name_middle']
-    number_fields = ['employees', 'revenue', 'endowment', 'net_worth']
-
-    return old + "\n\n" + nu if append_with_new_line_fields.include?(key)
-    return old + " " + nu if append_with_space_fields.include?(key)
-
-    if date_fields.include?(key)
-      old_date = Date.new(old)
-      nu_date = Date.new(nu)
-
-      return old_date.format if old_date.how_specific > nu_date.how_specific
-      return nu_date.format if old_date_how_specific < nu_date.how_specific
-
-      return (Date.less_or_equal(old_date, nu_date) ? old_date : nu_date) if old_date.how_specific == Date::YEAR_SPECIFIC
-      return old_date
-    end
-
-    return ((old.length >= nu.length or old.length != 1) ? old : nu) if name_fields.include?(key)
-    return (old == 0 ? nu : old) if number_fields.include?(key)
-
-    old
-  end
-
-  def self.merge_all(e1, e2)
-    ActiveRecord::Base.transaction do
-      e1 = merge_basic(e1, e2)
-
-      # CONTACT INFO
-      e2.phones.each do |phone|
-        phone.update(entity_id: e1.id) unless e1.phones.where(number: phone.number).exists?        
-      end
-      e2.emails.each do |email|
-        email.update(entity_id: e1.id) unless e1.emails.where(address: email.address).exists?
-      end
-      e2.addresses.each do |address|
-        address.update(entity_id: e1.id) unless e1.addresses.find { |a| a.same_as?(address) }
-      end
-      
-      # RELATIONSHIPS
-      e2.relationships.each do |rel|
-        if rel.entity1_id == e2.id
-          rel.update(entity1_id: e1.id)
-          rel.links.where(is_reverse: false).update_all(entity1_id: e1.id)
-          rel.links.where(is_reverse: true).update_all(entity2_id: e1.id)
-        elsif rel.entity2_id = e2.id
-          rel.update(entity2_id: e1.id)
-          rel.links.where(is_reverse: false).update_all(entity2_id: e1.id)
-          rel.links.where(is_reverse: true).update_all(entity1_id: e1.id)
-        end
-      end
-
-      # LISTS
-      e2.list_entities.active.each do |le|
-        le.update(entity_id: e1.id) unless e1.list_entities.active.map(&:list_id).include?(le.list_id)        
-      end
-
-      # IMAGES
-      e2.images.update_all(entity_id: e1.id)
-
-      # ALIASES
-      e2.aliases.each do |a|
-        next if e1.aliases.where(name: a.name, context: a.context).exists?
-        a.update(entity_id: e1.id, is_primary: false)
-      end
-
-      # IGNORE CUSTOM FIELDS B/C THEY'RE NOT USED
-
-      # IGNORE MODIFICATIONS IN RAILS
-
-      # IGNORE TAGS B/C THEY'RE NOT USED
-
-      # REFERENCES
-      e2.references.each do |ref|
-        ref.update(object_id: e1.id) unless e1.references.find { |r| r.source == ref.source }
-      end
-
-      e2.update(merged_id: e1.id)
-
-      # CHILD ENTITIES
-      e2.children.update_all(parent_id: e1.id)
-
-      # PARTY MEMBERS
-      e2.party_members.each do |pm|
-        pm.person.update(party_id: e1.id)
-      end
-
-      # IGNORE BUSINESS INDUSTRIES B/C THEY'RE NOT USED
-
-      # IGNORE BUNDLERS B/C THEY'RE NOT USED
-
-      # LOBBY FILING LOBBYISTS    
-      ActiveRecord::Base.connection.execute("UPDATE lobby_filing_lobbyist SET lobbyist_id = #{e1.id} WHERE lobbyist_id = #{e2.id}")
-
-      # TRANSACTION CONTACTS
-      ActiveRecord::Base.connection.execute("UPDATE transaction SET contact1_id = #{e1.id} WHERE contact1_id = #{e2.id}")
-      ActiveRecord::Base.connection.execute("UPDATE transaction SET contact2_id = #{e1.id} WHERE contact2_id = #{e2.id}")
-
-      # NOTES
-      e2.note_entities.each do |ne|
-        ne.update(entity_id: e1.id) unless e1.note_entities.where(note_id: ne.note_id).exists?
-      end
-
-      # DONATION MATCHES
-      e2.os_entity_transactions.each do |et2|
-        if et1 = e1.os_entity_transactions.where(cycle: et2.cycle, transaction_id: et2.transaction_id).first
-          # only merge in verified matches
-          if et2.is_verified
-            et1.update(is_verified: true, is_processed: false, is_synced: false)
-          end
-
-          et2.destroy
-        else
-          et2.update(entity_id: e1.id, is_processed: false, is_synced: false)
-        end
-      end
-      # remove and rebuild relationships with fec filings based on donation matches
-      e1.relationships.joins(:fec_filings).where(category_id: 5).each { |r| r.soft_delete }
-      e1.os_entity_transactions.where(is_verified: true).update_all(is_processed: false, is_synced: false)
-
-      # DONATION MATCHING PREPROCESS LOG
-      e2.os_entity_preprocesses.each do |ep2|
-        if e1.os_entity_preprocesses.find { |ep1| ep1.cycle == ep2.cycle }
-          ep2.destroy
-        else
-          ep2.update(entity_id: e1.id)
-        end
-      end
-
-      # EXTERNAL KEYS
-      e2.external_keys.each do |key|
-        key.update(entity_id: e1.id) unless e1.external_keys.find { |k| k.domain_id == key.domain_id }
-      end
-
-      # OPENSECRETS CATEGORIES
-      e2.os_entity_categories.each do |ec2|
-        ec2.update(entity_id: e1.id) unless e1.os_entity_categories.where(category_id: ec2.category_id).exists?
-      end
-
-      # FIELDS
-      e2.entity_fields.each do |ef2|
-        ef2.update(entity_id: e1.id) unless e1.entity_fields.where(field_id: ef2.field_id).exists?
-      end
-
-      # ARTICLES
-      e2.article_entities.each do |ae2|
-        ae2.update(entity_id: e1.id) unless e1.article_entities.where(article_id: ae2.article_id).exists?
-      end
-
-      # QUEUES
-      e2.queue_entities.each do |qe2|
-        qe2.update(entity_id: e1.id) unless e1.queue_entities.where(queue: ae2.queue).exists?
-      end
-
-      e1
-    end
-  end
-
-=end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -26,4 +26,10 @@ module Exceptions
       "The model has been deleted"
     end
   end
+
+  class ThatsWeirdError < StandardError
+    def message
+      "Well, that's weird."
+    end
+  end
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :address do
+    street1 { Faker::Address.street_name  }
+    city { Faker::Address.city }
+    country_name { Faker::Address.country }
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :article do
+    url { Faker::Internet.unique.url }
+    title { Faker::Lorem.sentence }
+    created_by_user_id '1'
+  end
+end

--- a/spec/factories/emails.rb
+++ b/spec/factories/emails.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :email do
+    address { Faker::Internet.email }
+  end
+end

--- a/spec/factories/entities.rb
+++ b/spec/factories/entities.rb
@@ -66,4 +66,12 @@ FactoryBot.define do
   trait :with_last_user_id do
     last_user_id APP_CONFIG['system_user_id']
   end
+
+  trait :with_person_name do
+    name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+  end
+
+  trait :with_org_name do
+    name { Faker::Company.name }
+  end
 end

--- a/spec/factories/ny_disclosures.rb
+++ b/spec/factories/ny_disclosures.rb
@@ -1,11 +1,12 @@
 FactoryBot.define do
   factory :ny_disclosure, class: NyDisclosure do
-    filer_id 'A1'
+    filer_id { SecureRandom.hex(2) }
     report_id "A"
     transaction_code 'A'
     e_year '2014'
     transaction_id '123'
     schedule_transaction_date '1999-01-14'
+    amount1 { rand(5000) }
     sequence(:id)
   end
 

--- a/spec/factories/os_categories.rb
+++ b/spec/factories/os_categories.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :os_category_private_equity, class: OsCategory do
+    category_id "F2600"
+    category_name "Private Equity & Investment Firms"
+    industry_id "F07"
+    industry_name "Securities & Investment"
+    sector_name "Finance, Insurance & Real Estate"
+  end
+end
+
+FactoryBot.define do
+  factory :os_category_defence, class: OsCategory do
+    category_id "D6000"
+    category_name "Homeland Security contractors"
+    industry_id "D03"
+    industry_name "Misc Defense"
+    sector_name "Defense"
+  end
+end

--- a/spec/factories/phones.rb
+++ b/spec/factories/phones.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :phone do
-    number { Faker::PhoneNumber.phone_number }
+    number { Faker::PhoneNumber.phone_number.slice(0,16) }
     type 'phone'
   end
 end

--- a/spec/factories/phones.rb
+++ b/spec/factories/phones.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :phone do
+    number { Faker::PhoneNumber.phone_number }
+    type 'phone'
+  end
+end

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -526,6 +526,35 @@ describe Entity, :tag_helper  do
         expect { @org.remove_extensions_by_def_ids([7, 10, 9]) }.to change { ExtensionRecord.count }.by(-2)
       end
     end
+
+
+    describe '#merge_extension' do
+      let(:business) do
+        create(:entity_org).tap { |e| e.add_extension('Business') }
+      end
+
+      let(:law_firm) do
+        create(:entity_org).tap { |e| e.add_extension('LawFirm') }
+      end
+
+      it 'throws unless called with an extension that has attributes' do
+        expect { business.merge_extension('Business', {}) }.not_to raise_error
+        expect { business.merge_extension('LawFirm', {}) }.to raise_error(ArgumentError)
+      end
+
+      it 'merges attributes that are nil on the source and not-nil on the dest' do
+        expect(business.business.annual_profit).to be nil
+        business.merge_extension('Business', 'annual_profit' => 100)
+        expect(business.reload.business.annual_profit).to eql 100
+      end
+
+      it 'does not merge attributes that are not nil on the source' do
+        business.business.update('annual_profit' => 10)
+        expect(business.business.annual_profit).to be 10
+        business.merge_extension('Business', 'annual_profit' => 100 )
+        expect(business.reload.business.annual_profit).to eql 10
+      end
+    end
   end # end Extension Attributes Functions
 
   describe 'basic_info' do

--- a/spec/models/ny_filer_entity_spec.rb
+++ b/spec/models/ny_filer_entity_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 describe NyFilerEntity, type: :model do
-  before(:all) do 
-    Entity.skip_callback(:create, :after, :create_primary_ext)
-    #DatabaseCleaner.start
-  end
-  after(:all) do 
-    Entity.set_callback(:create, :after, :create_primary_ext)
-    #DatabaseCleaner.clean
-  end
-
   it { should belong_to(:ny_filer) }
   it { should belong_to(:entity) }
   it { should validate_presence_of(:ny_filer_id) }
@@ -18,32 +9,29 @@ describe NyFilerEntity, type: :model do
   it { should callback(:rematch_existing_matches).after(:create) }
 
   describe "associations" do
-    before do
-      @elected = create(:entity_person, name: 'Elected Representative')
-      @ny_filer = create(:ny_filer, filer_id: 'A1')
-      @filer_entity = NyFilerEntity.create!(entity: @elected, ny_filer: @ny_filer, filer_id: 'A1')
-    end
+    let(:elected) { create(:entity_person, name: 'Elected Representative') }
+    let(:ny_filer) { create(:ny_filer, filer_id: 'A1') }
+    let(:filer_entity) { NyFilerEntity.create!(entity: elected, ny_filer: ny_filer, filer_id: 'A1') }
 
     it "belongs to entity" do
-      expect(@filer_entity.entity).to eql @elected
-      expect(@elected.ny_filer_entities.length).to eql 1
-      expect(@elected.ny_filer_entities[0].id).to eq @filer_entity.id
+      expect(filer_entity.entity).to eql elected
+      expect(elected.ny_filer_entities.length).to eql 1
+      expect(elected.ny_filer_entities[0].id).to eq filer_entity.id
     end
 
-    it "belongs to ny_filer" do 
-      expect(@filer_entity.ny_filer).to eql @ny_filer
-      expect(@ny_filer.entities.length).to eql 1
-      expect(@ny_filer.ny_filer_entity.present?).to be true
-      expect(@ny_filer.entities[0].id).to eql @elected.id
-      expect(@ny_filer.ny_filer_entity.id).to eql @filer_entity.id
+    it "belongs to ny_filer" do
+      expect(filer_entity.ny_filer).to eql ny_filer
+      expect(ny_filer.entities.length).to eql 1
+      expect(ny_filer.ny_filer_entity.present?).to be true
+      expect(ny_filer.entities[0].id).to eql elected.id
+      expect(ny_filer.ny_filer_entity.id).to eql filer_entity.id
     end
-
   end
 
-  describe 'rematch_existing_matches' do 
-    it 'calls rematch on NyMatch for models' do 
+  describe 'rematch_existing_matches' do
+    it 'calls rematch on NyMatch for models' do
       elected = create(:elected)
-      donor = create(:person)
+      donor = create(:entity_person)
       ny_filer = create(:ny_filer, filer_id: 'A2')
       NyFilerEntity.create!(entity: elected, ny_filer: ny_filer, filer_id: 'A2')
       ny_disclosure = create(:ny_disclosure, ny_filer: ny_filer)
@@ -53,5 +41,4 @@ describe NyFilerEntity, type: :model do
       expect(NyMatch.last.recip_id).to eql elected.id
     end
   end
-  
 end

--- a/spec/models/os_match_spec.rb
+++ b/spec/models/os_match_spec.rb
@@ -3,13 +3,10 @@ require 'rails_helper'
 describe OsMatch, type: :model do
   before(:all) do
     Entity.skip_callback(:create, :after, :create_primary_ext)
-
-    
   end
 
   after(:all) do
     Entity.set_callback(:create, :after, :create_primary_ext)
-    #
   end
 
   it { should validate_presence_of(:os_donation_id) }

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -666,6 +666,16 @@ describe Relationship, type: :model do
     end
   end
 
+  describe 'triplet' do
+    let(:person) { create(:entity_person) }
+    let(:person_two) { create(:entity_person) }
+    let(:rel) { create(:generic_relationship, entity: person, related: person_two) }
+
+    it 'returns array with entity ids and category id' do
+      expect(rel.triplet).to eql([ person.id, person_two.id, 12 ])
+    end
+  end
+
   context 'Using paper_trail for versioning' do
     let(:human) { create(:entity_person) }
     let(:corp) { create(:entity_org) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
   config.include FeatureExampleMacros, :type => :feature
   config.include RequestExampleMacros, :type => :request
   config.include NetworkAnalysisExampleHelper, :network_analysis_helper
+  config.include MergingExampleMacros, :merging_helper
 
   # these run inside example groups (ie: describe blocks)
   config.extend ControllerMacros, :type => :controller
@@ -52,6 +53,7 @@ RSpec.configure do |config|
   config.extend TaggingHelpers, :tagging_helper
   config.extend TagSpecHelper, :tag_helper
   config.extend PaginationExampleGroupHelper, :pagination_helper
+  config.extend MergingGroupMacros, :merging_helper
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/support/merging_group_macros.rb
+++ b/spec/support/merging_group_macros.rb
@@ -7,10 +7,7 @@ module MergingExampleMacros
 end
 
 module MergingGroupMacros
-  def merge!
-    context 'merge!' do
-      before { subject.send(:reset_instance_vars) }
-      yield
-    end
+  def reset_merger
+    before { subject.send(:reset_instance_vars) }
   end
 end

--- a/spec/support/merging_group_macros.rb
+++ b/spec/support/merging_group_macros.rb
@@ -1,0 +1,16 @@
+module MergingExampleMacros
+  def verify_contact_info_length_type_and_entity_id(type, entity_id)
+    expect(subject.contact_info.length).to eql 1
+    expect(subject.contact_info.first).to be_a type
+    expect(subject.contact_info.first.entity_id).to eql entity_id
+  end
+end
+
+module MergingGroupMacros
+  def merge!
+    context 'merge!' do
+      before { subject.send(:reset_instance_vars) }
+      yield
+    end
+  end
+end

--- a/spec/utility/entity_merger_spec.rb
+++ b/spec/utility/entity_merger_spec.rb
@@ -1,16 +1,88 @@
 require 'rails_helper'
 
 describe 'Merging Entities' do
- 
-  # def entity_merge(source:, dest:)
-  # end
+  describe 'initializing' do
+    let(:source) { build(:org) }
+    let(:dest) { build(:org) }
 
-  it 'can only merge entities that have the same primary extension'
+    it 'requires both source and dest entities' do
+      expect { EntityMerger.new(source: source) }.to raise_error(ArgumentError)
+      expect { EntityMerger.new(dest: dest) }.to raise_error(ArgumentError)
+      expect { EntityMerger.new }.to raise_error(ArgumentError)
+      expect { EntityMerger.new(source: source, dest: build(:document)) }.to raise_error(ArgumentError)
+    end
+
+    it 'sets source and dest attributes' do
+      em = EntityMerger.new(source: source, dest: dest)
+      expect(em.source).to eql source
+      expect(em.dest).to eql dest
+    end
+  end
+
+  it 'can only merge entities that have the same primary extension' do
+    expect { EntityMerger.new source: build(:person), dest: build(:org) }.to raise_error(EntityMerger::ExtensionMismatchError)
+  end
+  
+  
   it 'sets the "merged_id" fields of the merged entity to be the id of the merged entity'
   it 'marks the merged entity as deleted'
 
+
   context 'extensions' do
-    it 'adds new extensions to the destination entity'
+    let(:source_person) { create(:entity_person, :with_person_name) }
+    let(:dest_person) { create(:entity_person, :with_person_name) }
+    let(:source_org) { create(:entity_org, :with_org_name) }
+    let(:dest_org) { create(:entity_org, :with_org_name) }
+    subject { EntityMerger.new(source: source_person, dest: dest_person) } 
+
+    context 'With no new extensions on the source' do
+      it '@extensions contains non-new extension' do
+        subject.merge_extensions
+        expect(subject.extensions.length).to eql 1
+        extension = subject.extensions.first
+        expect(extension).to be_a EntityMerger::Extension
+        expect(extension.new).to be false
+        expect(extension.ext_id).to eql 1
+        expect(extension.fields).to eql source_person.person.attributes.except('id', 'entity_id')
+      end
+    end
+
+    context 'when the source has a new extension with fields' do
+      before do
+        source_person.add_extension('PoliticalCandidate') # ext_id = 3
+        subject.merge_extensions
+      end
+
+      it 'has 2 extensions' do
+        expect(subject.extensions.length).to eql 2
+      end
+
+      it 'has new extension' do
+        new_ext = subject.extensions.select { |e| e.new == true }.first
+        expect(new_ext.new).to be true
+        expect(new_ext.ext_id).to eql 3
+        expect(new_ext.fields.keys).to contain_exactly('is_federal', 'is_state', 'is_local', 'pres_fec_id', 'senate_fec_id', 'house_fec_id', 'crp_id') 
+      end
+    end
+
+
+    context 'when the source has a new extension without fields' do
+      subject { EntityMerger.new(source: source_org, dest: dest_org) }
+      before do
+        source_org.add_extension('Philanthropy') # ext_id = 9
+        subject.merge_extensions
+      end
+
+      it { expect(subject.extensions.length).to eql 2 }
+
+      it 'contains new philanthroy extension' do
+        new_ext = subject.extensions.select { |e| e.new == true }.first
+        expect(new_ext.ext_id).to eql 9
+        expect(new_ext.fields).to eql({})
+      end
+    end
+
+    it 'adds new extensions to the source' 
     it 'updates fields on the destination entity if they are nil'
   end
 

--- a/spec/utility/entity_merger_spec.rb
+++ b/spec/utility/entity_merger_spec.rb
@@ -113,7 +113,6 @@ describe 'Merging Entities', :merging_helper do
   context 'contact info' do
     subject { EntityMerger.new(source: source_org, dest: dest_org) }
 
-    
     context 'addresses' do
       let!(:address) { create(:address, entity_id: source_org.id) }
 
@@ -273,8 +272,9 @@ describe 'Merging Entities', :merging_helper do
       reset_merger
 
       it 'transfers images to new entity' do
-        expect { subject.merge! }.to change { Image.find(image.id).entity_id }
-                                       .from(source_org.id).to(dest_org.id)
+        expect(Image.find(image.id).entity_id).to eql source_org.id
+        subject.merge!
+        expect(Image.find(image.id).entity_id).to eql dest_org.id
       end
     end
   end


### PR DESCRIPTION
This resolves #381 

It adds a new class ` EntityMerger ` which handles all the merging.

calling EntityMerger#merge! does the actual merging. Right now there's a command line version of a trial-run which will report on what will happen. We can adapt it later, if we want, to create a report page on the front-end to let users see what will happen if they merge two entities.

for instance, if you try to merge walmart into exxon mobile (not a good idea) you get this:

![entity_merge_report](https://user-images.githubusercontent.com/8505044/33342635-c026b24e-d450-11e7-95ef-d16f5e40d570.png)
