### PR TITLE
BUGFIX: eliminate arrow function in `bulkTable.js`

### DIFF
--- a/app/assets/javascripts/pages/bulkTable.js
+++ b/app/assets/javascripts/pages/bulkTable.js
@@ -1032,7 +1032,7 @@
     return state
       .setIn(['entities', 'byId', entity.id], newEntity)
       .maybeReidentifyEntity(newEntity, attr)
-      .then(s => s.validateAndRender());
+      .then(state.validateAndRender);
   };
 
   // String -> String -> State


### PR DESCRIPTION
(caused rails precompile to fail, b/c not parseable in ES5)