### PR TITLE
Bulk list tool: show spinners during upload and submission

### DIFF
--- a/app/assets/javascripts/utility.js
+++ b/app/assets/javascripts/utility.js
@@ -297,6 +297,33 @@ utility.isEmpty = function (obj){
 
 // Browser/DOM Utilities
 
+// JQueryNode -> JQueryNode
+utility.appendSpinner = function(element){
+  // leverage `sk-circle` classes in `assets/stylesheets/base/spin.css`
+  return $(element).append(
+    $('<div>', { class: 'sk-circle' })
+      .append($('<div>', { class: 'sk-circle1 sk-child' }))
+      .append($('<div>', { class: 'sk-circle2 sk-child' }))
+      .append($('<div>', { class: 'sk-circle3 sk-child' }))
+      .append($('<div>', { class: 'sk-circle4 sk-child' }))
+      .append($('<div>', { class: 'sk-circle5 sk-child' }))
+      .append($('<div>', { class: 'sk-circle6 sk-child' }))
+      .append($('<div>', { class: 'sk-circle7 sk-child' }))
+      .append($('<div>', { class: 'sk-circle8 sk-child' }))
+      .append($('<div>', { class: 'sk-circle9 sk-child' }))
+      .append($('<div>', { class: 'sk-circle10 sk-child' }))
+      .append($('<div>', { class: 'sk-circle11 sk-child' }))
+      .append($('<div>', { class: 'sk-circle12 sk-child' }))
+  );
+};
+
+// JQueryNode -> JQueryNode
+utility.removeSpinner = function(element){
+  // leverage `sk-circle` classes in `assets/stylesheets/base/spin.css`
+  $(element).find('.sk-circle').remove();
+  return $(element);
+};
+
 // String -> Void
 utility.redirectTo = function(path){
   document.location.replace(path);

--- a/app/assets/javascripts/utility.js
+++ b/app/assets/javascripts/utility.js
@@ -300,6 +300,7 @@ utility.isEmpty = function (obj){
 // JQueryNode -> JQueryNode
 utility.appendSpinner = function(element){
   // leverage `sk-circle` classes in `assets/stylesheets/base/spin.css`
+  // IMPORTANT: THIS MUST RETURN A VALUE OR CALLING CODE WILL BREAK!!!
   return $(element).append(
     $('<div>', { class: 'sk-circle' })
       .append($('<div>', { class: 'sk-circle1 sk-child' }))

--- a/spec/javascripts/common/bulkTable.spec.js
+++ b/spec/javascripts/common/bulkTable.spec.js
@@ -25,7 +25,9 @@ describe('Bulk Table module', () => {
       addEntitiesToListSpy,
       hasFileSpy,
       getFileSpy,
-      redirectSpy;
+      redirectSpy,
+      appendSpinnerSpy,
+      removeSpinnerSpy;
 
   // STUB VALUES
   let file, errorMsg;
@@ -207,7 +209,11 @@ describe('Bulk Table module', () => {
 
     describe("with well-formed csv", () => {
 
-      beforeEach(done => setupWithCsv(csvValid).then(done));
+      beforeEach(done => {
+        appendSpinnerSpy = spyOn(utility, 'appendSpinner');
+        removeSpinnerSpy = spyOn(utility, 'removeSpinner');
+        setupWithCsv(csvValid).then(done);
+      });
 
       it('stores entity data', () => {
         expect(bulkTable.getIn(['entities', 'byId'])).toEqual({
@@ -222,6 +228,11 @@ describe('Bulk Table module', () => {
 
       it('hides upload button', () => {
         expect($('#upload-button')).not.toExist();
+      });
+
+      it('shows and hides a spinner', () => {
+        expect(appendSpinnerSpy).toHaveBeenCalled();
+        expect($("#top-spinner")).not.toExist();
       });
     });
 
@@ -1019,12 +1030,21 @@ describe('Bulk Table module', () => {
         describe('on submit', () => {
 
           beforeEach(done =>  {
+            appendSpinnerSpy = spyOn(utility, 'appendSpinner');
             setupSubmit(entities, emptyPromise, emptyPromise)
               .then(done);
           });
 
           it('attempts to create new entities', () => {
             expect(createEntitiesSpy).toHaveBeenCalledWith(Object.values(fxt.newEntities));
+          });
+
+          it('replaces the submit button with a spinner during API call', () => {
+            expect(appendSpinnerSpy).toHaveBeenCalled();
+          });
+
+          it('restores the submit button after API call', () => {
+            expect($("#bulk-submit-button")).toExist();
           });
         });
 

--- a/spec/javascripts/common/utility.spec.js
+++ b/spec/javascripts/common/utility.spec.js
@@ -270,4 +270,28 @@ describe('utility', function(){
       });
     });
   });
+
+  describe('DOM utilities', () => {
+
+    const testDom ='<div id="test-dom"></div>';
+    beforeEach(() => $('body').append(testDom));
+    afterEach(() => $('#test-dom').remove());
+
+    describe('#appendSpinner', () => {
+
+      it('appends a spinner to a DOM node', () => {
+        utility.appendSpinner($('#test-dom'));
+        expect($('#test-dom .sk-circle')).toExist();
+      });
+    });
+
+    describe('#removeSpinner', () => {
+
+      it('removes a spinner from a DOM node', () => {
+        utility.appendSpinner($('#test-dom'));
+        utility.removeSpinner($('#test-dom'));
+        expect($('#test-dom .sk-circle')).not.toExist();
+      });
+    });
+  });
 });


### PR DESCRIPTION
resolves #417
_______

## Upload Spinner:

![spinner-ingest](https://user-images.githubusercontent.com/6032844/33576820-126ee7fc-d90f-11e7-8445-c1f8ac7edc44.png)

## Submit Spinner:

![spinner-submit](https://user-images.githubusercontent.com/6032844/33576833-19cbbbec-d90f-11e7-9830-cad3b36e4625.png)

## Implementation Notes:

* create and use `utility#appendSpinner` (which leveraged nice spinner styles in `assets/stylesheets/base/spin.css`
* in `bulkTable`: 
  * set spinner state in state tree, only show spinners during `render` calls if corresponding boolen flag is set 
  * no need to call #remove, since if there is no spinner it will not be rendered
  * do not toggle spinner state directly on DOM (only indirectly through Flux-type unidirectional data flow: event handler -> state -> render -> DOM)
