### PR TITLE
Redirect merged entities

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,10 +152,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def set_entity(args)
+  def set_entity(args = {})
     base_query = Entity.unscoped.includes(args[:includes])
     @entity = base_query.find_by_id(params[:id])
-    if @entity.merged_id.present?
+    if @entity&.merged_id&.present?
       raise Exceptions::MergedEntityError.new(base_query.find_by_id(@entity.merged_id))
     end
     raise ActiveRecord::RecordNotFound if (@entity.nil? || @entity.is_deleted)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -156,9 +156,6 @@ class ApplicationController < ActionController::Base
 
   def set_entity(skope = :itself)
     @entity = Entity.find_with_merges(id: params[:id], skope: skope)
-    # @entity = Entity.unscoped.send(skope).find_by_id(params[:id])
-    # raise_merged skope if @entity&.has_merges?
-    # raise_if_not_found @entity
   end
 
   def set_cache_control(time = 1.hour)
@@ -171,17 +168,5 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:account_update, keys: [:about_me])
-  end
-
-  private 
-
-  def raise_merged(skope)
-    merged_entity = @entity.resolve_merges(skope)
-    raise_if_not_found(merged_entity)
-    raise Exceptions::MergedEntityError.new(merged_entity)
-  end
-
-  def raise_if_not_found(entity)
-    raise ActiveRecord::RecordNotFound if entity.nil? or entity.is_deleted
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -154,21 +154,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def set_entity(args = {})
-    @skope = Entity.unscoped.includes(args[:includes])
-    @entity = @skope.find_by_id(params[:id])
-    raise_merged if @entity&.has_merges?
-    raise_if_not_found @entity
-  end
-
-  def raise_merged
-    merged_entity = @entity.resolve_merges(@skope)
-    raise_if_not_found(merged_entity)
-    raise Exceptions::MergedEntityError.new(merged_entity)
-  end
-
-  def raise_if_not_found(entity)
-    raise ActiveRecord::RecordNotFound if entity.nil? or entity.is_deleted
+  def set_entity(skope = :itself)
+    @entity = Entity.find_with_merges(id: params[:id], skope: skope)
+    # @entity = Entity.unscoped.send(skope).find_by_id(params[:id])
+    # raise_merged skope if @entity&.has_merges?
+    # raise_if_not_found @entity
   end
 
   def set_cache_control(time = 1.hour)
@@ -181,5 +171,17 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:account_update, keys: [:about_me])
+  end
+
+  private 
+
+  def raise_merged(skope)
+    merged_entity = @entity.resolve_merges(skope)
+    raise_if_not_found(merged_entity)
+    raise Exceptions::MergedEntityError.new(merged_entity)
+  end
+
+  def raise_if_not_found(entity)
+    raise ActiveRecord::RecordNotFound if entity.nil? or entity.is_deleted
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,8 +37,10 @@ class ApplicationController < ActionController::Base
     render json: { errors: ['title' => exception.message] }, status: 401
   end
 
-  rescue_from Exceptions::MergedEntityError do |exception|
-    redirect_to entity_path(exception.merged_entity)
+  rescue_from Exceptions::MergedEntityError do |e|
+    EntitiesController::TABS.include?(action_name) ?
+      redirect_to(send("#{action_name}_entity_path", e.merged_entity)) :
+      redirect_to(entity_path(e.merged_entity))
   end
 
   def admins_only

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -8,6 +8,8 @@ class EntitiesController < ApplicationController
     }
   )
 
+  TABS = %w[interlocks political giving datatable].freeze
+
   before_filter :authenticate_user!, except: [:show, :datatable, :political, :contributions, :references, :interlocks, :giving]
   before_action :set_entity, except: [:new, :create, :search_by_name, :search_field_names, :show, :create_bulk]
   before_action :set_entity_with_eager_loading, only: [:show]

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -413,7 +413,7 @@ class EntitiesController < ApplicationController
   private
 
   def set_entity_with_eager_loading
-    @entity = Entity.includes(:aliases, list_entities: [:list]).find(params[:id])
+    set_entity(includes: :aliases, list_entities: [:list])
   end
 
   def set_entity_references

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -12,7 +12,7 @@ class EntitiesController < ApplicationController
 
   before_filter :authenticate_user!, except: [:show, :datatable, :political, :contributions, :references, :interlocks, :giving]
   before_action :set_entity, except: [:new, :create, :search_by_name, :search_field_names, :show, :create_bulk]
-  before_action :set_entity_with_eager_loading, only: [:show]
+  before_action :set_entity_for_profile_page, only: [:show]
   before_action :importers_only, only: [:match_donation, :match_donations, :review_donations, :match_ny_donations, :review_ny_donations]
   before_action -> { check_permission('contributor') }, only: [:create]
   before_action -> { check_permission('deleter') }, only: [:destroy]
@@ -414,8 +414,8 @@ class EntitiesController < ApplicationController
 
   private
 
-  def set_entity_with_eager_loading
-    set_entity(includes: :aliases, list_entities: [:list])
+  def set_entity_for_profile_page
+    set_entity(:profile_scope)
   end
 
   def set_entity_references

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -814,6 +814,16 @@ class Entity < ActiveRecord::Base
     "/#{primary_ext.downcase}/#{to_param}"
   end
 
+  # ActiveRecordScope -> Entity
+  def resolve_merges(skope = Entity.unscoped)
+    return skope.find_by_id(merged_id).resolve_merges(skope) if has_merges?
+    self
+  end
+
+  def has_merges?
+    merged_id.present?
+  end
+
   # A type checker for definition id and names
   # input: String or Integer
   # output: String or throws ArgumentError

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -38,4 +38,17 @@ module Exceptions
       "Well, that's weird."
     end
   end
+
+  class MergedEntityError < StandardError
+    attr_reader :merged_entity
+
+    def initialize(merged_entity)
+      super
+      @merged_entity = merged_entity
+    end
+
+    def message
+      "Tried to retrieve entity that has been merged into entity w/ id #{merged_entity.id}"
+    end
+  end
 end

--- a/spec/controllers/edits_controller_spec.rb
+++ b/spec/controllers/edits_controller_spec.rb
@@ -20,7 +20,7 @@ describe EditsController, type: :controller do
     login_user
 
     before do
-      expect(Entity).to receive(:find).and_return(build(:person))
+      expect(Entity).to receive(:find_by_id).and_return(build(:person))
       get :entity, id: '123'
     end
     it { should respond_with 200 }

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -491,16 +491,11 @@ describe EntitiesController, type: :controller do
       login_user
 
       before do
-        # NOTE: @aguestuser twists himself into contortions to write
-        # these mocks to fix controller specs that fail for functionality that works
-        # *and* has passing feature specs and wonders...
-        # ... why are we writing tests that are as brittle as this anyway?
-        # ... why are we writing tests that break when an implementation changes but the result does not?
-        # ... do they *really* give us a lot of value we could not get from a less brittle approach?
-        @entity = double('entity', :name        => 'my awesome name',
+        @entity = double('entity',
+                         :name        => 'Lew Basnight',
                          :merged_id   => nil,
                          :has_merges? => false,
-                         :is_deleted  => false)
+                         :is_deleted? => false)
         expect(Entity).to receive(:find_by_id).and_return(@entity)
       end
 

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -497,9 +497,10 @@ describe EntitiesController, type: :controller do
         # ... why are we writing tests that are as brittle as this anyway?
         # ... why are we writing tests that break when an implementation changes but the result does not?
         # ... do they *really* give us a lot of value we could not get from a less brittle approach?
-        @entity = double('entity', :name => 'my awesome name',
-                                   :merged_id => nil,
-                                   :is_deleted => false)
+        @entity = double('entity', :name        => 'my awesome name',
+                         :merged_id   => nil,
+                         :has_merges? => false,
+                         :is_deleted  => false)
         expect(Entity).to receive(:find_by_id).and_return(@entity)
       end
 

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -48,7 +48,7 @@ describe EntitiesController, type: :controller do
     describe 'entity/id/contributions' do
       before do
         @e = build(:mega_corp_inc, updated_at: Time.now)
-        expect(Entity).to receive(:find).and_return(@e)
+        expect(Entity).to receive(:find_by_id).and_return(@e)
         expect(@e).to receive(:contribution_info).and_return([build(:os_donation)])
         get :contributions, id: @e.id
       end
@@ -66,7 +66,8 @@ describe EntitiesController, type: :controller do
 
     describe '#match_donations and reivew donations' do
       before do
-        expect(Entity).to receive(:find).once
+        # expect(Entity).to receive(:find_by_id).once
+        expect(Entity).to receive(:find_by_id).and_return(build(:entity_org))
         expect(controller).to receive(:check_permission).with('importer').and_call_original
       end
 
@@ -286,7 +287,7 @@ describe EntitiesController, type: :controller do
   describe '#add_relationship' do
     login_user
     before do
-      expect(Entity).to receive(:find)
+      expect(Entity).to receive(:find_by_id).and_return(build(:entity_org))
       get :add_relationship, id: rand(100)
     end
     it { should render_template(:add_relationship) }
@@ -297,7 +298,7 @@ describe EntitiesController, type: :controller do
     login_user
 
     before do
-      expect(Entity).to receive(:find).and_return(build(:org))
+      expect(Entity).to receive(:find_by_id).and_return(build(:org))
       get :edit, id: rand(100)
     end
     it { should render_template(:edit) }
@@ -490,8 +491,16 @@ describe EntitiesController, type: :controller do
       login_user
 
       before do
-        @entity = double('entity', :name => 'my awesome name')
-        expect(Entity).to receive(:find).and_return(@entity)
+        # NOTE: @aguestuser twists himself into contortions to write
+        # these mocks to fix controller specs that fail for functionality that works
+        # *and* has passing feature specs and wonders...
+        # ... why are we writing tests that are as brittle as this anyway?
+        # ... why are we writing tests that break when an implementation changes but the result does not?
+        # ... do they *really* give us a lot of value we could not get from a less brittle approach?
+        @entity = double('entity', :name => 'my awesome name',
+                                   :merged_id => nil,
+                                   :is_deleted => false)
+        expect(Entity).to receive(:find_by_id).and_return(@entity)
       end
 
       it 'calls soft delete on entity' do

--- a/spec/features/entity_page_spec.rb
+++ b/spec/features/entity_page_spec.rb
@@ -39,20 +39,25 @@ describe "Entity Page", :network_analysis_helper, :pagination_helper, type: :fea
       visit src_url
       expect(page.status_code).to eq 200
       expect(page).to have_current_path dst_url
-      expect(page).to have_selector '#entity-page-container'
+      expect(page).to have_selector '#entity-header'
     end
 
-    %i[alice bob cassie].each do |sym|
-      let(sym) { create(:entity_person) }
-      let("#{sym}_url".to_sym){ entity_path(send(sym)) }
+    %i[alice bob cassie].each do |person|
+      let!(person) { create(:entity_person) }
     end
 
     context "when alice has been merged into bob" do
-
       before { EntityMerger.new(source: alice, dest: bob).merge! }
 
       it "redirects from alice's profile page to bob's profile page" do
-        should_redirect(alice_url, bob_url)
+        should_redirect(entity_path(alice), entity_path(bob))
+      end
+
+      EntitiesController::TABS.each do |tab| 
+        it "redirects from alice's #{tab} tab to bob's #{tab} tab" do
+          should_redirect(send("#{tab}_entity_path", alice),
+                          send("#{tab}_entity_path", bob))
+        end
       end
     end
   end

--- a/spec/features/entity_page_spec.rb
+++ b/spec/features/entity_page_spec.rb
@@ -33,6 +33,30 @@ describe "Entity Page", :network_analysis_helper, :pagination_helper, type: :fea
     end
   end
 
+  describe'redirecting merged entities' do
+
+    def should_redirect(src_url, dst_url)
+      visit src_url
+      expect(page.status_code).to eq 200
+      expect(page).to have_current_path dst_url
+      expect(page).to have_selector '#entity-page-container'
+    end
+
+    %i[alice bob cassie].each do |sym|
+      let(sym) { create(:entity_person) }
+      let("#{sym}_url".to_sym){ entity_path(send(sym)) }
+    end
+
+    context "when alice has been merged into bob" do
+
+      before { EntityMerger.new(source: alice, dest: bob).merge! }
+
+      it "redirects from alice's profile page to bob's profile page" do
+        should_redirect(alice_url, bob_url)
+      end
+    end
+  end
+
   describe "header" do
     before { visit_page.call }
 

--- a/spec/features/entity_page_spec.rb
+++ b/spec/features/entity_page_spec.rb
@@ -33,7 +33,7 @@ describe "Entity Page", :network_analysis_helper, :pagination_helper, type: :fea
     end
   end
 
-  describe'redirecting merged entities' do
+  describe 'redirecting merged entities' do
 
     def should_redirect(src_url, dst_url)
       visit src_url

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -840,4 +840,37 @@ describe Entity, :tag_helper  do
       end
     end
   end
+
+  describe "resolving merges" do
+
+    %i[alice bob cassie].each do |person|
+      let!(person) { create(:entity_person) }
+    end
+
+    context "when alice has not been merged" do
+
+      it "resolves alice to herself" do
+        expect(alice.resolve_merges).to eql alice
+      end
+    end
+
+    context "when alice has been merged into bob" do
+      before { EntityMerger.new(source: alice, dest: bob).merge! }
+
+      it "resolves alice to bob" do
+        expect(alice.resolve_merges).to eql bob
+      end
+    end
+
+    context "when alice has been merged into bob, bob into cassie" do
+      before do
+        EntityMerger.new(source: alice, dest: bob).merge!
+        EntityMerger.new(source: bob,   dest: cassie).merge!
+      end
+
+      it "resolves alice to cassie" do
+        expect(alice.resolve_merges).to eql cassie
+      end
+    end
+  end
 end


### PR DESCRIPTION
resolves #420 

___

## Demo

[see video here](https://vimeo.com/246551860)

## Notes

* introduce `Entity#resolve_entities`, use to recursively resolve an entity from chain of merged entities (or return itself)
* introduce `MergedEntityError` exception
* use the combination of these to recursively redirect merged entities or return a 404 if entity or merged enity has been deleted
* additionally. refactor `EntityController#set_entity_with_eager_loading` to delegate to `ApplicationController#set_entity` for DRY-ness and single-point-of-truth re: merges, etc...
