### PR TITLE
User signup notification email

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -15,7 +15,6 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       # send welcome email to user - views/user_mailer/welcome_email
       if user.errors.empty?
         UserMailer.welcome_email(user).deliver_later
-        NotificationMailer.signup_email(user).deliver_later
         user.create_default_permissions
 
         # If the user's request is from a spamy ip address then automatically restrict the user
@@ -24,6 +23,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
           user.update(is_restricted: true)
         else
           user.delay.create_chat_account
+          NotificationMailer.signup_email(user).deliver_later                    
         end
 
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit_permissions, :add_permission, :delete_permission, :destroy, :restrict, :edits]
+  before_action :prevent_restricted, only: [:show, :edits]
   before_action :authenticate_user!, except: [:success]
   before_action :admins_only, except: [:show, :restrict, :success, :edits]
   before_action :user_or_admins_only, only: [:edits]
@@ -55,7 +56,7 @@ class UsersController < ApplicationController
       render action: 'image'
     end
   end
-  
+
   # GET /users/:id/edit_permissions
   def edit_permissions
 
@@ -133,6 +134,9 @@ class UsersController < ApplicationController
     else
       raise Exceptions::NotFoundError
     end
+  end
+
+  def prevent_restricted
     raise Exceptions::NotFoundError if @user.is_restricted?
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,6 +133,7 @@ class UsersController < ApplicationController
     else
       raise Exceptions::NotFoundError
     end
+    raise Exceptions::NotFoundError if @user.is_restricted?
   end
 
   # Only allow a trusted parameter "white list" through.

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,4 +1,5 @@
 class NotificationMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
   default from: APP_CONFIG['notification_email']
 
   SMTP_OPTIONS = { user_name: APP_CONFIG['notification_user_name'], password: APP_CONFIG['notification_password'] }

--- a/app/views/notification_mailer/signup_email.html.erb
+++ b/app/views/notification_mailer/signup_email.html.erb
@@ -1,4 +1,8 @@
 <p><strong>New User Signup:</strong> <%= @user.username %> (<%= @user.id %>)</p>
 
 <p><strong>Name:</strong> <%= @profile.name_first + ' ' +  @profile.name_last%></p>
-<p><strong>Why they joined:</strong><br><%= @profile.reason %></p>    
+<p><strong>Email:</strong> <%= @user.email %></p>
+<p><strong>Location:</strong> <%= @profile.location %></p>
+<p><strong>Interested in Map the Power:</strong> <%= yes_or_no @user.map_the_power %></p>
+
+<p><strong>Why they joined:</strong><br><%= @profile.reason %></p>

--- a/spec/controllers/users_confirmations_controllers_spec.rb
+++ b/spec/controllers/users_confirmations_controllers_spec.rb
@@ -7,14 +7,14 @@ describe Users::ConfirmationsController, type: :controller do
     expect(User).to receive(:confirm_by_token).and_return(@user)
     expect(UserMailer).to receive(:welcome_email)
                             .with(@user).and_return(double(:deliver_later => nil))
-    expect(NotificationMailer).to receive(:signup_email)
-                            .with(@user).and_return(double(:deliver_later => nil))
     expect(@user).to receive(:create_default_permissions).once
   end
 
   context 'request is not from a restricted ip' do
     before do
       expect(@user).not_to receive(:update)
+      expect(NotificationMailer).to receive(:signup_email)
+                            .with(@user).and_return(double(:deliver_later => nil))
       expect(@user).to receive(:delay).once.and_return(double(:create_chat_account => nil))
       get :show
     end
@@ -24,6 +24,7 @@ describe Users::ConfirmationsController, type: :controller do
   context 'request is from a restricted ip' do
     before do
       expect(IpBlocker).to receive(:restricted?).with('0.0.0.0').and_return(true)
+      expect(NotificationMailer).not_to receive(:signup_email)
       expect(@user).to receive(:update).with(is_restricted: true)
       expect(@user).not_to receive(:delay)
       get :show

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -39,7 +39,7 @@ describe UsersController, type: :controller do
     context 'as an admin' do
       login_admin
       before do
-        expect(User).to receive(:find).with('1')
+        expect(User).to receive(:find).with('1').and_return(build(:user))
         get :edit_permissions, params: { :id => '1' }
       end
       it { should render_template 'edit_permissions' }
@@ -49,7 +49,8 @@ describe UsersController, type: :controller do
   describe 'POST #add_permission' do
     login_admin
     before do
-      expect(User).to receive(:find).with('1').and_return(double(:sf_guard_user_id => 2, :id => 1))
+      expect(User).to receive(:find).with('1')
+                        .and_return(build(:user, sf_guard_user_id: 2, id: 1))
       expect(SfGuardUserPermission).to receive(:create!).with(permission_id: 5, user_id: 2)
       post :add_permission, params: { :id => '1', :permission => '5' }
     end
@@ -59,7 +60,8 @@ describe UsersController, type: :controller do
   describe 'DELETE #delete_permission' do
     login_admin
     before do
-      expect(User).to receive(:find).with('1').and_return(double(:sf_guard_user_id => 2, :id => 1))
+      expect(User).to receive(:find).with('1')
+                        .and_return(build(:user, sf_guard_user_id: 2, id: 1))
       expect(SfGuardUserPermission).to receive(:remove_permission).with(permission_id: 5, user_id: 2)
       delete :delete_permission, params: { :id => '1', :permission => '5' }
     end
@@ -67,12 +69,6 @@ describe UsersController, type: :controller do
   end
 
   describe 'DELETE #destory' do
-    # describe 'logged in as regular user' do 
-    #   login_user
-    #   before { delete :destroy, :id => '1234' }
-    #   it { should respond_with(403) }
-    # end
-    
     describe 'logged in as admin' do
       login_admin
 
@@ -113,7 +109,7 @@ describe UsersController, type: :controller do
         end
 
         context 'afterwards' do
-          before { delete :destroy, params: { :id => @user.id  } }
+          before { delete :destroy, params: { :id => @user.id } }
           it { should redirect_to(admin_users_path) }
         end
       end

--- a/spec/features/user_page_spec.rb
+++ b/spec/features/user_page_spec.rb
@@ -45,6 +45,17 @@ feature 'User Pages' do
         expect(page).to have_selector 'h3 small a', text: 'view all edits'
       end
     end
+
+    context 'user is restricted' do
+      before do
+        user_for_page.update!(is_restricted: true)
+        visit "/users/#{user_for_page.username}"
+      end
+
+      scenario 'does not show user pages for restircted users' do
+        expect(page.status_code).to eq 404
+      end
+    end
   end
 
   feature 'User Edits Page' do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -45,10 +45,11 @@ describe NotificationMailer, type: :mailer do
   end
 
   describe '#signup_email' do
+    let(:map_the_power) { false }
     before(:each) do
       @sf_user = create(:sf_guard_user)
-      @user = create(:user, sf_guard_user: @sf_user)
-      @profile = create(:sf_guard_user_profile, user_id: @sf_user.id)
+      @user = create(:user, map_the_power: map_the_power, sf_guard_user: @sf_user)
+      @profile = create(:sf_guard_user_profile, user_id: @sf_user.id, location: 'vienna')
       @mail = NotificationMailer.signup_email(@user)
     end
 
@@ -66,6 +67,28 @@ describe NotificationMailer, type: :mailer do
 
     it 'has name' do
       expect(@mail.encoded).to include 'first last'
+    end
+
+    it 'has location' do
+      expect(@mail.encoded).to include '<strong>Location:</strong> vienna'
+    end
+
+    it 'has email' do
+      expect(@mail.encoded).to include "<strong>Email:</strong> #{@user.email}"
+    end
+
+    context 'is interested in map the power' do
+      let(:map_the_power) { true }
+      it 'interested in map the power' do
+        expect(@mail.encoded).to include "<strong>Interested in Map the Power:</strong> yes"
+      end
+    end
+
+    context 'is not interested in map the power' do
+      let(:map_the_power) { false }
+      it 'interested in map the power' do
+        expect(@mail.encoded).to include "<strong>Interested in Map the Power:</strong> no"
+      end
     end
 
     it 'has reason' do


### PR DESCRIPTION
resolves #376 and resolves #394 

add information -- Email, Location, and if they are interested to map the power -- to the notification email sent to admins.  It also skips sending those email if the user signed up from a restricted IP.

It also prevents user pages from being visible for restricted users (which will hopefully reduce the incentive for spammy signups) 

