### PR TITLE
Add Elite Consensus + CMP importer work in progress

### DIFF
--- a/app/models/cmp_entity.rb
+++ b/app/models/cmp_entity.rb
@@ -1,0 +1,4 @@
+class CmpEntity < ApplicationRecord
+  belongs_to :entity
+  enum entity_type: [:org, :person]
+end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -314,7 +314,10 @@ class Entity < ApplicationRecord
       'PublicIntellectual',
       'PublicOfficial',
       'Lawyer',
-      'Couple'
+      'Couple',
+      'ResearchInstitute',
+      'GovernmentAdvisoryBody',
+      'EliteConsensus'
     ]
   end
 

--- a/app/utility/ls_hash.rb
+++ b/app/utility/ls_hash.rb
@@ -1,0 +1,5 @@
+class LsHash < ActiveSupport::HashWithIndifferentAccess
+  def with_last_user(user_id)
+    merge(last_user_id: user_id.to_i)
+  end
+end

--- a/db/migrate/20180123192048_create_cmp_entities.rb
+++ b/db/migrate/20180123192048_create_cmp_entities.rb
@@ -1,0 +1,14 @@
+class CreateCmpEntities < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cmp_entities do |t|
+      t.bigint :entity_id
+      t.integer :cmp_id
+      t.integer :entity_type, limit: 1, unsigned: true, null: false
+
+      t.timestamps
+    end
+    add_index :cmp_entities, :cmp_id, unique: true
+    add_index :cmp_entities, :entity_id, unique: true
+    add_foreign_key :cmp_entities, :entity, column: 'entity_id'
+  end
+end

--- a/db/migrate/20180124213412_add_entity_extension_elite_consensus.rb
+++ b/db/migrate/20180124213412_add_entity_extension_elite_consensus.rb
@@ -1,0 +1,12 @@
+class AddEntityExtensionEliteConsensus < ActiveRecord::Migration[5.0]
+  def up
+    ExtensionDefinition.create!([
+                                  {name: "EliteConsensus", display_name: "Elite Consensus Group", has_fields: false, parent_id: 2, tier: 3, id: 40}
+                                ])
+  end
+
+  def down
+    ExtensionDefinition.find(40).delete
+  end
+  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123192048) do
+ActiveRecord::Schema.define(version: 20180124213412) do
 
   create_table "address", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint   "entity_id",                                null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123184642) do
+ActiveRecord::Schema.define(version: 20180123192048) do
 
   create_table "address", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint   "entity_id",                                null: false
@@ -195,6 +195,16 @@ ActiveRecord::Schema.define(version: 20180123184642) do
     t.index ["room", "updated_at", "user_id"], name: "room_updated_at_user_id_idx", using: :btree
     t.index ["room", "user_id"], name: "room_user_id_idx", unique: true, using: :btree
     t.index ["user_id"], name: "user_id_idx", using: :btree
+  end
+
+  create_table "cmp_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint   "entity_id"
+    t.integer  "cmp_id"
+    t.integer  "entity_type", limit: 1, null: false, unsigned: true
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.index ["cmp_id"], name: "index_cmp_entities_on_cmp_id", unique: true, using: :btree
+    t.index ["entity_id"], name: "index_cmp_entities_on_entity_id", unique: true, using: :btree
   end
 
   create_table "couple", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -1583,6 +1593,7 @@ ActiveRecord::Schema.define(version: 20180123184642) do
   add_foreign_key "business_industry", "industry", name: "business_industry_ibfk_1", on_update: :cascade, on_delete: :cascade
   add_foreign_key "business_person", "entity", name: "business_person_ibfk_1", on_update: :cascade, on_delete: :cascade
   add_foreign_key "candidate_district", "political_district", column: "district_id", name: "candidate_district_ibfk_1"
+  add_foreign_key "cmp_entities", "entity"
   add_foreign_key "donation", "entity", column: "bundler_id", name: "donation_ibfk_2", on_update: :cascade, on_delete: :nullify
   add_foreign_key "donation", "relationship", name: "donation_ibfk_1", on_update: :cascade, on_delete: :cascade
   add_foreign_key "education", "degree", name: "education_ibfk_2", on_update: :cascade, on_delete: :nullify

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,8 @@ ExtensionDefinition.create!([
   {name: "Lawyer", display_name: "Lawyer", has_fields: false, parent_id: 1, tier: 2, id: 36},
   {name: "Couple", display_name: "Couple", has_fields: true, parent_id: nil, tier: 1, id: 37},
   {name: "ResearchInstitute", display_name: "Academic Research Institute", has_fields: false, parent_id: 2, tier: 3, id: 38},
-  {name: "GovernmentAdvisoryBody", display_name: "Government Advisory Body", has_fields: false, parent_id: 2, tier: 3, id: 39}
+  {name: "GovernmentAdvisoryBody", display_name: "Government Advisory Body", has_fields: false, parent_id: 2, tier: 3, id: 39},
+  {name: "EliteConsensus", display_name: "Elite Consensus Group", has_fields: false, parent_id: 2, tier: 3, id: 40}
 ])
 
 SfGuardUser.create!({id: 1, username: "system@littlesis.org", password: 'password', salt:''})

--- a/lib/cmp.rb
+++ b/lib/cmp.rb
@@ -1,6 +1,8 @@
 require 'csv'
 
 module Cmp
+  CMP_USER_ID = 1
+  
   ORG_FILE_PATH = Rails.root.join('data', 'CMPDatabase2_Organizations_2015-2016.xlsx').to_s
   ORG_OUT_CSV_PATH = Rails.root.join('data', "cmp-orgs-#{Time.current.strftime('%F')}.csv").to_s
 
@@ -10,7 +12,7 @@ module Cmp
   def self.save_org_csv
     Query.save_hash_array_to_csv ORG_OUT_CSV_PATH, orgs.map(&:to_h)
   end
-    
+
   def self.save_person_csv
     Query.save_hash_array_to_csv PERSON_OUT_CSV_PATH, people.map(&:to_h)
   end

--- a/lib/cmp/cmp_entity.rb
+++ b/lib/cmp/cmp_entity.rb
@@ -3,7 +3,11 @@ module Cmp
     attr_reader :attributes
 
     def initialize(attrs)
-      @attributes = attrs
+      @attributes = ActiveSupport::HashWithIndifferentAccess.new(attrs)
+    end
+
+    def cmpid
+      attributes['cmpid']
     end
 
     # join table between CMP IDS and LittleSis Entity

--- a/lib/cmp/cmp_entity_importer.rb
+++ b/lib/cmp/cmp_entity_importer.rb
@@ -1,9 +1,9 @@
 module Cmp
-  class CmpEntity
+  class CmpEntityImporter
     attr_reader :attributes
 
     def initialize(attrs)
-      @attributes = ActiveSupport::HashWithIndifferentAccess.new(attrs)
+      @attributes = LsHash.new(attrs)
     end
 
     def cmpid

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -1,5 +1,5 @@
 module Cmp
-  class CmpOrg < Cmp::CmpEntity
+  class CmpOrg < Cmp::CmpEntityImporter
     # Mapping between cmp fields and Model/Attribute for entities
     ATTRIBUTE_MAP = {
       # :cmpname => [:entity, :name],
@@ -24,11 +24,14 @@ module Cmp
       )
     end
 
-    def import
+    def import!
       ApplicationRecord.transaction do
         entity = find_or_create_entity
         cmp_entity.create!(entity: entity, entity_type: :org)
-        entity.org.update!(name_nick: attributes[:cmpmnemonic], revenue: attributes[:revenue])
+        entity.org.update! attrs_for(:org)
+        entity.addresses.find_or_create_by attrs_for(:addresses).with_last_user(CMP_USER_ID)
+        import_ticker(entity)
+        create_cmp_entity(entity)
       end
     end
 
@@ -36,13 +39,22 @@ module Cmp
       if CmpEntity.find_by(cmp_id: cmpid)
         CmpEntity.find_by(cmp_id: cmpid).entity
       elsif !entity_match.empty?
-        entity_match.first
+        entity_match.match
       else
         create_new_entity!
       end
     end
 
+    def create_cmp_entity(entity)
+      CmpEntity.find_or_create_by!(entity: entity, cmp_id: cmpid)
+    end
+
     private
+
+    def import_ticker(entity)
+      return nil unless attributes[:ticker].present?
+      entity.add_extension('PublicCompany').public_company.update!(ticker: attributes[:ticker])
+    end
 
     def attrs_for(model)
       ATTRIBUTE_MAP

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -9,6 +9,7 @@ module Cmp
       :cmpmnemonic => [:org, :name_nick],
       :revenue => [:org, :revenue],
       :website => [:entity, :website],
+      :is_current => [:entity, :is_current],
       :city => [:address, :city],
       :country => [:address, :country_name],
       :latitude => [:address, :latitude],
@@ -20,8 +21,7 @@ module Cmp
     def initialize(attrs)
       @attributes = LsHash.new(attrs)
       @org_type = OrgType.new fetch(:orgtype_code)
-      attributes
-        .store :assets, attributes.values_at(:assets_2016, :assets_2015, :assets_2014).compact.first
+      parse_fields
     end
 
     def cmpid
@@ -63,6 +63,15 @@ module Cmp
     end
 
     private
+
+    # Modifies fields as needed from CMP
+    # - adds 'assets' as latest provided value from 2014-2016
+    # - adds 'is_current' based if status is active
+    def parse_fields
+      attributes
+        .store(:assets, attributes.values_at(:assets_2016, :assets_2015, :assets_2014).compact.first)
+      attributes.store(:is_current, fetch(:status, nil) == 'active' ? true : nil)
+    end
 
     def create_cmp_entity(entity)
       CmpEntity.find_or_create_by!(entity: entity, cmp_id: cmpid, entity_type: :org)

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -2,13 +2,14 @@ module Cmp
   class CmpOrg < Cmp::CmpEntity
     # Mapping between cmp fields and Model/Attribute for entities
     ATTRIBUTE_MAP = {
-      :cmpname => [:entity, :name],
+      # :cmpname => [:entity, :name],
       :cmpmnemonic => [:org, :name_nick],
       :revenue => [:org, :revenue],
       :website => [:entity, :website],
       :city => [:address, :city],
       :latitude => [:address, :latitude],
-      :longitude => [:address, :longitude]
+      :longitude => [:address, :longitude],
+      :ticker => [:public_company, :ticker]
     }.freeze
 
     def entity_match
@@ -22,5 +23,47 @@ module Cmp
         url: entity_match.empty? ? "" : entity_url(entity_match.first)
       )
     end
+
+    def import
+      ApplicationRecord.transaction do
+        entity = find_or_create_entity
+        cmp_entity.create!(entity: entity, entity_type: :org)
+        entity.org.update!(name_nick: attributes[:cmpmnemonic], revenue: attributes[:revenue])
+      end
+    end
+
+    def find_or_create_entity
+      if CmpEntity.find_by(cmp_id: cmpid)
+        CmpEntity.find_by(cmp_id: cmpid).entity
+      elsif !entity_match.empty?
+        entity_match.first
+      else
+        create_new_entity!
+      end
+    end
+
+    private
+
+    def attrs_for(model)
+      ATTRIBUTE_MAP
+        .select { |_k, (m, _f)| m == model }
+        .map { |k, (_m, f)| [f, attributes[k]] }
+        .to_h
+    end
+
+    def merge_unless_blank(hash, key, val)
+      return hash if val.blank?
+      hash.merge(key.to_sym => val)
+    end
+
+    # -> <Entity>
+    def create_new_entity!
+      Entity.create!(
+        primary_ext: 'Org',
+        name: attributes[:cmpname],
+        last_user_id: Cmp::CMP_USER_ID
+      )
+    end
+
   end
 end

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -29,6 +29,7 @@ module Cmp
       ApplicationRecord.transaction do
         entity = find_or_create_entity
         create_cmp_entity(entity)
+        entity.update! attrs_for(:entity).with_last_user(CMP_USER_ID)
         entity.org.update! attrs_for(:org)
         entity.addresses.find_or_create_by! attrs_for(:address).with_last_user(CMP_USER_ID)
         import_ticker(entity)

--- a/lib/cmp/cmp_person.rb
+++ b/lib/cmp/cmp_person.rb
@@ -1,5 +1,5 @@
 module Cmp
-  class CmpPerson < Cmp::CmpEntity
+  class CmpPerson < Cmp::CmpEntityImporter
     def name
       "#{@attributes.fetch(:firstname)} #{@attributes.fetch(:middlename)} #{@attributes.fetch(:lastname)}"
     end

--- a/lib/cmp/entity_match.rb
+++ b/lib/cmp/entity_match.rb
@@ -9,6 +9,10 @@ module Cmp
       search_results
     end
 
+    def match
+      first
+    end
+
     def first
       search_results.first unless empty?
     end

--- a/lib/cmp/org_sheet.rb
+++ b/lib/cmp/org_sheet.rb
@@ -7,6 +7,7 @@ module Cmp
       orgtype: 'OrgType_a',
       orgtype_code: 'OrgType_n',
       city: 'City',
+      country: 'Country',
       province: 'Province-State_US-Can',
       latitude: 'Latitude',
       longitude: 'Longitude',

--- a/lib/cmp/org_sheet.rb
+++ b/lib/cmp/org_sheet.rb
@@ -12,7 +12,10 @@ module Cmp
       longitude: 'Longitude',
       revenue: 'Revenue2015_CombinedEstimates',
       website: 'Websiteaddress_2016',
-      status: 'Status_2016'
+      status: 'Status_2016',
+      ticker: 'Tickersymbol_2016',
+      industry_name: 'Industry7cat_a',
+      industry_number: 'Industry7cat_n'
     }.freeze
   end
 end

--- a/lib/cmp/org_sheet.rb
+++ b/lib/cmp/org_sheet.rb
@@ -16,7 +16,10 @@ module Cmp
       status: 'Status_2016',
       ticker: 'Tickersymbol_2016',
       industry_name: 'Industry7cat_a',
-      industry_number: 'Industry7cat_n'
+      industry_number: 'Industry7cat_n',
+      assets_2016: 'TotalassetsthUSD2016',
+      assets_2015: 'TotalassetsthUSD2015',
+      assets_2014: 'TotalassetsthUSD2014'
     }.freeze
   end
 end

--- a/lib/cmp/org_type.rb
+++ b/lib/cmp/org_type.rb
@@ -4,7 +4,7 @@ module Cmp
     TYPES = {
       1 => {
         name: 'Policy-Planning',
-        extension: nil #  ?
+        extension: 'ThinkTank'
       },
       2 => {
         name: 'Industry Association',
@@ -12,7 +12,7 @@ module Cmp
       },
       3 => {
         name: 'Advocacy and Consensus',
-        extension: 'ThinkTank'
+        extension: 'EliteConsensus'
       },
       4 => {
         name: 'University',
@@ -20,7 +20,7 @@ module Cmp
       },
       5 => {
         name: 'Research Institute',
-        extension: 'ThinkTank'
+        extension: 'ResearchInstitute'
       },
       6 => {
         name: 'Foundation',
@@ -28,11 +28,11 @@ module Cmp
       },
       7 => {
         name: 'Climate Advisory',
-        extension: nil #  ?
+        extension: 'GovernmentAdvisoryBody'
       },
       8 => {
         name: 'Quasi-state',
-        extension: 'GovernmentBody' # is this right?
+        extension: nil
       },
       9 => {
         name: 'Corporation',

--- a/spec/factories/cmp_entities.rb
+++ b/spec/factories/cmp_entities.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :cmp_entity do
+    entity nil
+    cmp_id 1
+    entity_type 0
+  end
+end

--- a/spec/helpers/entities_helper_spec.rb
+++ b/spec/helpers/entities_helper_spec.rb
@@ -12,9 +12,9 @@ describe EntitiesHelper do
       expect(helper.checkboxes(build(:org), ExtensionDefinition.org_types_tier2).reduce(:+).scan('<span class="entity-type-name"').count).to eq 7
     end
 
-    it 'contains all 20 tier 3 types' do
+    it 'contains all 21 tier 3 types' do
       expect(helper.checkboxes(build(:org), ExtensionDefinition.org_types_tier3)
-               .reduce(:+).scan('<span class="entity-type-name"').count).to eq 20
+               .reduce(:+).scan('<span class="entity-type-name"').count).to eq 21
     end
 
     it 'contains all 9 extension person types' do

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -1,18 +1,77 @@
 require "rails_helper"
 
 describe Cmp::CmpOrg do
+  let(:org) { create(:entity_org) }
+
   let(:attributes) do
     {
       cmpid: Faker::Number.number(6),
       cmpname: 'big oil inc',
-      cmpmnemonic: 'big oil',
+      cmpmnemonic: Faker::Company.name,
       website: 'http://oil.com',
       city: 'Vancouver',
-      ticker: 'BO'
+      country: 'Canada'
     }
   end
   subject { Cmp::CmpOrg.new(attributes) }
-  let(:org) { create(:entity_org) }
+
+  describe 'import!' do
+    before do
+      expect(subject).to receive(:entity_match).and_return(double(:empty? => true))
+    end
+
+    context 'Entity is not already in the database' do
+      it 'creates a new entity' do
+        expect { subject.import! }.to change { Entity.count }.by(1)
+      end
+
+      it 'creates a cmp entity' do
+        expect { subject.import! }.to change { CmpEntity.count }.by(1)
+        expect(CmpEntity.last.attributes.fetch('cmp_id'))
+          .to eql attributes.fetch(:cmpid).to_i
+      end
+
+      it 'updates fields name_nick' do
+        expect { subject.import! }.to change { Org.count }.by(1)
+        expect(Org.last.name_nick).to eql attributes.fetch(:cmpmnemonic)
+        expect(Org.last.revenue).to be_nil
+      end
+
+      it 'creates a new address' do
+        expect { subject.import! }.to change { Address.count }.by(1)
+        expect(Address.last.city).to eql attributes.fetch(:city)
+      end
+    end
+
+    context 'entity has revenue fields' do
+      let(:revenue) { rand(10_000) }
+      subject { Cmp::CmpOrg.new(attributes.merge(revenue: revenue)) }
+
+      it 'updates org field: name_nick' do
+        expect { subject.import! }.to change { Org.count }.by(1)
+        expect(Org.last.name_nick).to eql attributes.fetch(:cmpmnemonic)
+      end
+
+      it 'updates org field: revenue' do
+        subject.import!
+        expect(Org.last.revenue).to eql revenue
+      end
+
+      it 'does not create a public company' do
+        expect { subject.import! }.not_to change { PublicCompany.count }
+      end
+    end
+
+    context 'entity has ticker' do
+      let(:ticker) { ('a'..'z').to_a.sample(3).join }
+      subject { Cmp::CmpOrg.new(attributes.merge(ticker: ticker)) }
+
+      it 'creates and updates the public company' do
+        expect { subject.import! }.to change { PublicCompany.count }.by(1)
+        expect(PublicCompany.last.ticker).to eql ticker
+      end
+    end
+  end
 
   describe 'find_or_create_entity' do
     context 'cmp entity already exists' do
@@ -52,15 +111,15 @@ describe Cmp::CmpOrg do
 
   describe 'helper methods' do
     describe '#attrs_for' do
-      let(:attributes) { { website: 'http://example.com', city: 'new york' } }
+      let(:attributes) { { website: 'http://example.com', city: 'new york', country: 'USA' } }
       subject { Cmp::CmpOrg.new(attributes) }
 
       it 'extracts attributes for given model' do
         expect(subject.send(:attrs_for, :entity))
-          .to eql(website: 'http://example.com')
+          .to eql('website' => 'http://example.com')
 
         expect(subject.send(:attrs_for, :address))
-          .to eql(city: 'new york', latitude: nil, longitude: nil)
+          .to eql(LsHash.new(city: 'new york', latitude: nil, longitude: nil, country_name: 'USA'))
       end
     end
   end

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -176,7 +176,7 @@ describe Cmp::CmpOrg do
 
       it 'extracts attributes for given model' do
         expect(subject.send(:attrs_for, :entity))
-          .to eql('website' => 'http://example.com')
+          .to eql('website' => 'http://example.com', 'is_current' => nil)
 
         expect(subject.send(:attrs_for, :address))
           .to eql(LsHash.new(city: 'new york', latitude: nil, longitude: nil, country_name: 'USA'))

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -1,9 +1,58 @@
 require "rails_helper"
 
 describe Cmp::CmpOrg do
+  let(:attributes) do
+    {
+      cmpid: Faker::Number.number(6),
+      cmpname: 'big oil inc',
+      cmpmnemonic: 'big oil',
+      website: 'http://oil.com',
+      city: 'Vancouver',
+      ticker: 'BO'
+    }
+  end
+  subject { Cmp::CmpOrg.new(attributes) }
+  let(:org) { create(:entity_org) }
+
+  describe 'find_or_create_entity' do
+    context 'cmp entity already exists' do
+      before do
+        create(:cmp_entity, entity: org, entity_type: :org, cmp_id: attributes.fetch(:cmpid))
+      end
+
+      it 'returns the already existing entity' do
+        expect(subject.find_or_create_entity).to eql org
+      end
+    end
+
+    context 'found a matched entity' do
+      let(:org) { build(:org) }
+      before do
+        entity_match = double('EntityMatch')
+        expect(entity_match).to receive(:empty?).and_return(false)
+        expect(entity_match).to receive(:match).and_return(org)
+        subject.instance_variable_set(:@_entity_match, entity_match)
+      end
+
+      it 'returns matched entity' do
+        expect(subject.find_or_create_entity).to eql org
+      end
+    end
+
+    context 'need to create a new entity' do
+      before do
+        expect(subject).to receive(:entity_match).and_return(double(:empty? => true))
+      end
+      it 'creates a new entity' do
+        expect { subject.find_or_create_entity }.to change { Entity.count }.by(1)
+        expect(Entity.last.name).to eql attributes[:cmpname]
+      end
+    end
+  end
+
   describe 'helper methods' do
     describe '#attrs_for' do
-      let(:attributes) { { website: 'http://example.com', city: 'new york'} }
+      let(:attributes) { { website: 'http://example.com', city: 'new york' } }
       subject { Cmp::CmpOrg.new(attributes) }
 
       it 'extracts attributes for given model' do

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Cmp::CmpOrg do
+  describe 'helper methods' do
+    describe '#attrs_for' do
+      let(:attributes) { { website: 'http://example.com', city: 'new york'} }
+      subject { Cmp::CmpOrg.new(attributes) }
+
+      it 'extracts attributes for given model' do
+        expect(subject.send(:attrs_for, :entity))
+          .to eql(website: 'http://example.com')
+
+        expect(subject.send(:attrs_for, :address))
+          .to eql(city: 'new york', latitude: nil, longitude: nil)
+      end
+    end
+  end
+end

--- a/spec/lib/cmp_spec.rb
+++ b/spec/lib/cmp_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Cmp do
-  describe Cmp::CmpEntity do
-    let(:attrs) { { :name => Faker::Cat.name } }
-    subject { Cmp::CmpEntity.new attrs }
+  describe Cmp::CmpEntityImporter do
+    let(:attrs) { LsHash.new(name: Faker::Cat.name) }
+    subject { Cmp::CmpEntityImporter.new attrs }
     specify { expect(subject.attributes).to eql attrs }
   end
 
@@ -13,7 +13,7 @@ describe Cmp do
     end
 
     let(:excel_file_path) { Rails.root.join('spec', 'testdata', 'cmp_orgs.xlsx').to_s }
-      
+
     subject { TestCmpExcelSheet.new(excel_file_path) }
 
     it 'parses excel sheet into an array of hash according to the header converstion map' do

--- a/spec/models/cmp_entity_spec.rb
+++ b/spec/models/cmp_entity_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe CmpEntity, type: :model do
+  it { is_expected.to have_db_column(:entity_id) }
+  it { is_expected.to have_db_column(:cmp_id) }
+  it { is_expected.to have_db_column(:entity_type) }
+
+  describe 'entity type enum' do
+    specify do
+      expect(build(:cmp_entity, entity_type: 0).entity_type)
+        .to eql 'org'
+    end
+    specify do
+      expect(build(:cmp_entity, entity_type: 1).entity_type)
+        .to eql 'person'
+    end
+  end
+end

--- a/spec/models/extension_definition_spec.rb
+++ b/spec/models/extension_definition_spec.rb
@@ -29,6 +29,10 @@ describe ExtensionDefinition, type: :model  do
     expect(ExtensionDefinition.find(39).name).to eql 'GovernmentAdvisoryBody'
   end
 
+  it 'has Elite Consensus' do
+    expect(ExtensionDefinition.find(40).name).to eql 'EliteConsensus'
+  end
+
   describe 'display_names' do
     it 'returns a memozined hash map' do
       expect(ExtensionDefinition.display_names).to be_a Hash

--- a/spec/utility/ls_hash_spec.rb
+++ b/spec/utility/ls_hash_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe LsHash do
+  subject { LsHash.new }
+
+  it { is_expected.to be_a ActiveSupport::HashWithIndifferentAccess }
+  it { is_expected.to respond_to :with_last_user }
+
+  specify do
+    expect(subject.with_last_user(123)).to eql LsHash.new(last_user_id: 123)
+    expect(subject.with_last_user('123')).to eql LsHash.new(last_user_id: 123)
+  end
+end


### PR DESCRIPTION
This is largely a work-in-progress pull request, although the org importer is nearly ready.

Major changes:

- Adds bew entity extension _elite consensus_ (resolves #503)

- New utility class ` LsHash `

- New model  `CmpEntity` which joins cmp ids with LittleSis entity ids 