### PR TITLE
[#506] update navbar links under 'Help'

### DIFF
--- a/app/views/shared/_bootstrap_nav_menu.html.erb
+++ b/app/views/shared/_bootstrap_nav_menu.html.erb
@@ -58,9 +58,7 @@ end
 items['Help'] = {
   items: {
     'Toolkit' => "/toolkit",
-    'Search Help Pages' => "/help",
-    Beginners: "/beginnerhelp",
-    Advanced: "/advancedhelp",
+    'Help' => "/help",
     'Report a bug' => '/bug_report'
   }
 }

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -17,6 +17,7 @@ describe 'home/dashboard', type: :feature do
       expect(page).to have_selector 'ul.nav li a', text: current_user.username
       expect(page).to have_selector 'ul.nav li a', text: 'Tags'
       expect(page).to have_selector 'ul.nav li a', text: 'Donate'
+      expect(page).to have_selector 'ul.nav li a', text: 'Help'
       # verifing that networks have been removed:
       expect(page).not_to have_selector 'ul.nav li a', text: 'United States'
     end


### PR DESCRIPTION
- removed Beginners and Advanced help

- renamed "Search Help Pages" to "Help"