### PR TITLE
Intergrate with ActionNetwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ spec/testdata/*_errors.txt
 # coverage files
 coverage
 
+# rdoc
+doc/
+
 # development db
 data/*.sql
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,10 @@ gem 'devise', '~> 4.2'
 # Versioning
 gem 'paper_trail', '7.1.3'
 
-# Required by delayed_job
-gem 'daemons'
+# delayed job
+gem 'daemons' # Required by delayed_job
+gem 'delayed_job', '~> 4.1.4'
+gem 'delayed_job_active_record', '>= 4.1.2'
 
 # Assets, image uploading & processing
 gem 'aws-sdk-cloudfront', '~> 1'
@@ -41,7 +43,6 @@ gem 'activerecord-session_store'
 
 # For search and indexing
 gem 'thinking-sphinx', '~> 3.2.0'
-gem 'delayed_job_active_record', '>= 4.1.2'
 gem 'ts-delayed-delta', '2.0.2', :require => 'thinking_sphinx/deltas/delayed_delta'
 
 gem 'htmlentities'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,7 @@ DEPENDENCIES
   codacy-coverage
   daemons
   database_cleaner
+  delayed_job (~> 4.1.4)
   delayed_job_active_record (>= 4.1.2)
   devise (~> 4.2)
   factory_bot_rails (~> 4.8.2)

--- a/app/assets/stylesheets/styles/home.scss
+++ b/app/assets/stylesheets/styles/home.scss
@@ -223,4 +223,8 @@ div#donate-button-container  {
     }
 }
 
-
+#newsletter-thankyou {
+    padding: 0.8em;
+    background-color: #eee;
+    border-radius: 5px;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
-  before_action :authenticate_user!, except: [:dismiss, :index, :contact, :flag, :token]
+  before_action :authenticate_user!,
+                except: [:dismiss, :index, :contact, :flag, :token, :newsletter_signup]
 
   # [list_id, 'title' ]
   DOTS_CONNECTED_LISTS = [
@@ -106,6 +107,15 @@ class HomeController < ApplicationController
     end
   end
 
+  # Adds user newsletter and redirects back to home page.
+  #
+  # POST /home/newsletter_signup
+  #
+  def newsletter_signup
+    NewsletterSignupJob.perform_later params.fetch('email') unless likely_a_spam_bot
+    redirect_to root_path
+  end
+
   private
 
   def redirect_to_dashboard_if_signed_in
@@ -132,5 +142,9 @@ class HomeController < ApplicationController
 
   def flag_params
     params.permit(:email, :url, :name, :message)
+  end
+
+  def likely_a_spam_bot
+    params['very_important_wink_wink'].present?
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,6 +64,7 @@ class HomeController < ApplicationController
 
   def index
     redirect_to_dashboard_if_signed_in unless request.env['PATH_INFO'] == '/home'
+    @newsletter_thankyou = params[:nlty].present?
     @dots_connected = dots_connected
     @carousel_entities = carousel_entities
     @stats = ExtensionRecord.data_summary
@@ -112,8 +113,10 @@ class HomeController < ApplicationController
   # POST /home/newsletter_signup
   #
   def newsletter_signup
-    NewsletterSignupJob.perform_later params.fetch('email') unless likely_a_spam_bot
-    redirect_to root_path
+    unless likely_a_spam_bot || Rails.env.development?
+      NewsletterSignupJob.perform_later params.fetch('email')
+    end
+    redirect_to root_path(nlty: 'yes')
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
-  before_action :authenticate_user!, except: [:dismiss, :sign_in_as, :index, :contact, :flag, :token, :error]
+  before_action :authenticate_user!, except: [:dismiss, :index, :contact, :flag, :token]
 
   # [list_id, 'title' ]
   DOTS_CONNECTED_LISTS = [
@@ -8,17 +8,17 @@ class HomeController < ApplicationController
     [102, 'Revolving door lobbyists'],
     [114, 'Secretive Super PACs'],
     [34, 'Elite think tanks']
-  ]
+  ].freeze
 
-	def groups
+  def groups
     @groups = Group
-      .select("groups.*, COUNT(DISTINCT(group_users.user_id)) AS user_count")
-      .joins(:group_users)
-      .group("groups.id")
-      .where(id: current_user.group_ids)
-      .order("user_count DESC")
-      .page(params[:page]).per(20)
-	end
+                .select("groups.*, COUNT(DISTINCT(group_users.user_id)) AS user_count")
+                .joins(:group_users)
+                .group("groups.id")
+                .where(id: current_user.group_ids)
+                .order("user_count DESC")
+                .page(params[:page]).per(20)
+  end
 
   def dashboard
     @maps = current_user.network_maps.order("created_at DESC, id DESC")
@@ -36,11 +36,6 @@ class HomeController < ApplicationController
     else
       head :unauthorized
     end
-  end
-
-  def extension_path
-    render :inline => "https://dfl6orqdcqt4f.cloudfront.net/assets/#{Rails.application.assets.find_asset('extension.js').digest_path}"
-    render :inline => "<%= csrf_meta_tags %>"
   end
 
   def dismiss
@@ -62,7 +57,7 @@ class HomeController < ApplicationController
       .group("ls_list.id")
       .order("entity_count DESC")
       .page(params[:page]).per(20)
-      
+
     render 'lists/index'
   end
 
@@ -109,10 +104,6 @@ class HomeController < ApplicationController
     else
       @referrer = request.referrer
     end
-  end
-
-  def error
-    raise StandardError
   end
 
   private

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -22,8 +22,10 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
         if IpBlocker.restricted?(request.remote_ip)
           user.update(is_restricted: true)
         else
+          # TODO: combine these into a unifed "post-signup" method
           user.delay.create_chat_account
-          NotificationMailer.signup_email(user).deliver_later                    
+          NotificationMailer.signup_email(user).deliver_later
+          NewsletterSignupJob.perform_later(user)
         end
 
       end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/newsletter_signup_job.rb
+++ b/app/jobs/newsletter_signup_job.rb
@@ -1,7 +1,13 @@
 class NewsletterSignupJob < ApplicationJob
   queue_as :default
 
-  def perform(email_address)
-    ActionNetwork.add_email_to_newsletter(email_address)
+  def perform(email_address_or_user)
+    if email_address_or_user.is_a?(String)
+      ActionNetwork.add_email_to_newsletter email_address_or_user
+    elsif email_address_or_user.is_a?(User)
+      ActionNetwork.signup email_address_or_user
+    else
+      raise ArgumentError, "NewsletterSignupJob accepts Email Addresses or Users"
+    end
   end
 end

--- a/app/jobs/newsletter_signup_job.rb
+++ b/app/jobs/newsletter_signup_job.rb
@@ -1,0 +1,7 @@
+class NewsletterSignupJob < ApplicationJob
+  queue_as :default
+
+  def perform(email_address)
+    ActionNetwork.add_email_to_newsletter(email_address)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,9 +22,10 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :sf_guard_user
 
   before_validation :set_default_network_id
-  
+
   # delegate :sf_guard_user_profile, to: :sf_guard_user, allow_nil: true
   delegate :image_path, to: :sf_guard_user_profile, allow_nil: true
+  delegate :name_first, :name_last, to: :sf_guard_user_profile
 
   has_many :edited_entities, class_name: "Entity", foreign_key: "last_user_id", primary_key: "sf_guard_user_id"
 
@@ -46,6 +47,8 @@ class User < ApplicationRecord
 
   has_one :api_token
   has_many :user_permissions
+
+  
 
   def to_param
     username

--- a/app/utility/action_network.rb
+++ b/app/utility/action_network.rb
@@ -1,0 +1,25 @@
+module ActionNetwork
+  API_KEY = APP_CONFIG.fetch('action_network_api_key').dup.freeze
+  API_INFO_URL = 'https://actionnetwork.org/api/v2'.freeze
+
+  def self.api_info
+    uri = URI.parse(API_INFO_URL)
+    request = Net::HTTP::Get.new uri
+    request["User-Agent"] = "Mozilla/5.0"
+    request["Content-Type"] = "application/json"
+    request["OSDI-API-Token"] = API_KEY
+
+    http(uri, request)
+  end
+
+  def self.http(uri, request)
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      response = http.request(request)
+      return JSON.parse(response.body) if response.is_a? Net::HTTPSuccess
+      raise HTTPRequestFailedError, "Response code: #{response.code}"
+    end
+  end
+
+  class HTTPRequestFailedError < StandardError
+  end
+end

--- a/app/utility/action_network.rb
+++ b/app/utility/action_network.rb
@@ -1,32 +1,38 @@
 ##
 # Interacts with the action network api
+# can add users and email address to LittleSis
 #
 module ActionNetwork
   API_KEY = APP_CONFIG.fetch('action_network_api_key').dup.freeze
   API_INFO_URL = 'https://actionnetwork.org/api/v2'.freeze
   PEOPLE_URL = 'https://actionnetwork.org/api/v2/people'.freeze
-  TAGS = { signup: 'LS-Signup', newsletter: 'PAI and LittleSis Updates', map_the_power: 'MTP' }.freeze
+
+  # Tags are primarily how the LittleSis staff
+  # organizes and sorts  users on action network
+  TAGS = {
+    signup: 'LS-Signup',
+    newsletter: 'PAI and LittleSis Updates',
+    map_the_power: 'MTP'
+  }.freeze
 
   # :section: Public API
 
   # Signs up a user to Action Network
-  # If the request is sucussful, it returns +true+.
-  # If the requests fails, it returns +false+
-  # and sends a warning message to the rails logger.
   #
   # User --> Boolean
   def self.signup(user)
-    uri = URI.parse(PEOPLE_URL)
-    req = request(uri, :Post)
-    req.set_form_data(signup_params(user))
-    Rails.logger.debug http(uri, req)
-    true
-  rescue HTTPRequestFailedError
-    Rails.logger.warn "Failed to add user #{user.username}(#{user.id}) to ActionNetwork"
-    false
+    post URI.parse(PEOPLE_URL), signup_params(user)
   end
 
-  # Returns list people in ActionNetwork
+  # Adds an email address to the LittleSis Newsletter on action network
+  #
+  # String --> Boolean
+  def self.add_email_to_newsletter(email)
+    post URI.parse(PEOPLE_URL), email_params(email)
+  end
+  
+  # Retrieves people from our Action Network Api
+  # Int --> Hash
   def self.people(page = 1)
     uri = URI.parse(PEOPLE_URL)
     req = request(uri, :Get)
@@ -35,7 +41,7 @@ module ActionNetwork
   end
 
   # Returns a hash of basic information about ActionNetwork's Api
-  # Not that useful in produciton, but helpful in development.
+  # Not that useful in production, but helpful in development.
   def self.api_info
     uri = URI.parse(API_INFO_URL)
     http uri, request(uri, :Get)
@@ -43,27 +49,61 @@ module ActionNetwork
 
   # :section: HTTP Helper Functions
 
-  # Generates hash of user infor for submission to action network
+  # Generates hash of user information for submission to action network
+  # User --> Hash
   def self.signup_params(user)
     {
       "person" => {
-        "identifiers" => [ action_network_identifier(user) ],
+        "identifiers" => [action_network_identifier(user)],
         "family_name" => user.name_last,
         "given_name" => user.name_first,
-        "email_addresses" => [ { "address" => user.email } ]
+        "email_addresses" => [{ "address" => user.email }]
       },
       "add_tags" => action_network_tags(user)
     }
   end
   
+  # Generates hash for action network singups
+  # for an email address interested in joining the newsletter
+  # String --> Hash
+  def self.email_params(email)
+    {
+      "person" => {
+        "email_addresses" => [{ "address" => email }]
+      },
+      "add_tags" => Array.wrap(TAGS[:newsletter])
+    }
+  end
+
+  # Posts data to Action Network
+  # Suppresses http errors and sends messages to logger
+  # If the request is successful, it returns +true+.
+  # If the request fails, it returns +false+
+  # and sends a warning message to the rails logger.
+  #
+  # URI, Hash --> Boolean
+  def self.post(uri, data)
+    req = request(uri, :Post)
+    req.body = data.to_json
+    Rails.logger.debug http(uri, req)
+    true
+  rescue HTTPRequestFailedError
+    Rails.logger.warn "Post request failed: #{data}"
+    false
+  end
+
   # Performs a http request and return response as a hash
   #
-  # URI,  Net::HTTP::Get --> Hash
+  # URI,  Net::HTTP::Get --> Hash | raises HTTPRequestFailedError
   def self.http(uri, request)
     Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
       response = http.request(request)
-      return JSON.parse(response.body) if response.is_a? Net::HTTPSuccess
-      raise HTTPRequestFailedError, "Response code: #{response.code}"
+      if response.is_a? Net::HTTPSuccess
+        return JSON.parse(response.body)
+      else
+        Rails.logger.debug response.body if response.body
+        raise HTTPRequestFailedError, "Response code: #{response.code}"
+      end
     end
   end
 
@@ -74,14 +114,14 @@ module ActionNetwork
       request["Content-Type"] = "application/json"
       request["OSDI-API-Token"] = API_KEY
     end
-  end    
+  end
 
   private_class_method def self.action_network_identifier(user)
     "littlesis_user_id:#{user.id}"
   end
 
   private_class_method def self.action_network_tags(user)
-    tags = [ TAGS[:signup] ]
+    tags = Array.wrap(TAGS[:signup])
     tags << TAGS[:newsletter] if user.newsletter
     tags << TAGS[:map_the_power] if user.map_the_power
     tags

--- a/app/utility/action_network.rb
+++ b/app/utility/action_network.rb
@@ -1,17 +1,64 @@
+##
+# Interacts with the action network api
+#
 module ActionNetwork
   API_KEY = APP_CONFIG.fetch('action_network_api_key').dup.freeze
   API_INFO_URL = 'https://actionnetwork.org/api/v2'.freeze
+  PEOPLE_URL = 'https://actionnetwork.org/api/v2/people'.freeze
+  TAGS = { signup: 'LS-Signup', newsletter: 'PAI and LittleSis Updates', map_the_power: 'MTP' }.freeze
 
-  def self.api_info
-    uri = URI.parse(API_INFO_URL)
-    request = Net::HTTP::Get.new uri
-    request["User-Agent"] = "Mozilla/5.0"
-    request["Content-Type"] = "application/json"
-    request["OSDI-API-Token"] = API_KEY
+  # :section: Public API
 
-    http(uri, request)
+  # Signs up a user to Action Network
+  # If the request is sucussful, it returns +true+.
+  # If the requests fails, it returns +false+
+  # and sends a warning message to the rails logger.
+  #
+  # User --> Boolean
+  def self.signup(user)
+    uri = URI.parse(PEOPLE_URL)
+    req = request(uri, :Post)
+    req.set_form_data(signup_params(user))
+    Rails.logger.debug http(uri, req)
+    true
+  rescue HTTPRequestFailedError
+    Rails.logger.warn "Failed to add user #{user.username}(#{user.id}) to ActionNetwork"
+    false
   end
 
+  # Returns list people in ActionNetwork
+  def self.people(page = 1)
+    uri = URI.parse(PEOPLE_URL)
+    req = request(uri, :Get)
+    req.set_form_data(page: page)
+    http(uri, req)
+  end
+
+  # Returns a hash of basic information about ActionNetwork's Api
+  # Not that useful in produciton, but helpful in development.
+  def self.api_info
+    uri = URI.parse(API_INFO_URL)
+    http uri, request(uri, :Get)
+  end
+
+  # :section: HTTP Helper Functions
+
+  # Generates hash of user infor for submission to action network
+  def self.signup_params(user)
+    {
+      "person" => {
+        "identifiers" => [ action_network_identifier(user) ],
+        "family_name" => user.name_last,
+        "given_name" => user.name_first,
+        "email_addresses" => [ { "address" => user.email } ]
+      },
+      "add_tags" => action_network_tags(user)
+    }
+  end
+  
+  # Performs a http request and return response as a hash
+  #
+  # URI,  Net::HTTP::Get --> Hash
   def self.http(uri, request)
     Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
       response = http.request(request)
@@ -20,6 +67,28 @@ module ActionNetwork
     end
   end
 
+  # Formats a URI into an http request with correct API Headers
+  def self.request(uri, method)
+    Net::HTTP.const_get(method).new(uri).tap do |request|
+      request["User-Agent"] = "Mozilla/5.0"
+      request["Content-Type"] = "application/json"
+      request["OSDI-API-Token"] = API_KEY
+    end
+  end    
+
+  private_class_method def self.action_network_identifier(user)
+    "littlesis_user_id:#{user.id}"
+  end
+
+  private_class_method def self.action_network_tags(user)
+    tags = [ TAGS[:signup] ]
+    tags << TAGS[:newsletter] if user.newsletter
+    tags << TAGS[:map_the_power] if user.map_the_power
+    tags
+  end
+
+  # Any failed response, regardless of the status code,
+  # will raise this error
   class HTTPRequestFailedError < StandardError
   end
 end

--- a/app/views/home/_newsletter_signup_form.html.erb
+++ b/app/views/home/_newsletter_signup_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_tag('/home/newsletter_signup', id: 'newsletter-signup-form') do %>
+  <%# honeypot for spam bots %>
+  <div style="position: absolute; left: -5000px;" aria-hidden="true">
+    <%= text_field_tag 'very_important_wink_wink' %>
+  </div>
+  
+  <div class="input-group">
+    
+    <%= email_field_tag 'email', nil,
+      class: 'form-control',
+      placeholder: 'Your email',
+      required: true,
+      id: 'newsletter-signup-form-email'
+    %>
+
+    <span class="input-group-btn">
+      <button class="btn btn-default" type="submit">Join!</button>
+    </span>
+
+  </div>
+<% end %>

--- a/app/views/home/_newsletter_thankyou.html.erb
+++ b/app/views/home/_newsletter_thankyou.html.erb
@@ -1,0 +1,12 @@
+<div id="newsletter-thankyou">
+  <h4>Thank you!<br/>
+    <small>You've been added to our newsletter.</small>
+  </h4>
+</div>
+
+<script>
+ <%# Remove the thank you query param from the url %>
+ $(function(){
+   window.history.pushState({}, document.title, "/");
+ });
+</script>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,11 +15,15 @@
     </div>
     
     <div class="row position-relative">
-      <div class="col-xs-5 nopadding">
-	<%= render partial: 'newsletter_signup_form' %>
+      <div class="col-xs-6 nopadding">
+	<% if @newsletter_thankyou %>
+	  <%= render partial: 'newsletter_thankyou' %>
+	<% else %>
+	  <%= render partial: 'newsletter_signup_form' %>
+	<% end %>
       </div>
       
-      <div class="col-xs-7 double-left-padding">
+      <div class="col-xs-6 double-left-padding">
 	<%= render partial: 'social_media_buttons' %>
       </div>
       

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,51 +4,31 @@
 <%= render partial: 'shared/facebook_sdk' %>
 
 <div class="row">
-    <div class="col-sm-7">
-        <div class="row">
-            <h1 class="big-text">LittleSis<span style="color: #cc5454;">*</span> is a free database of who-knows-who at the heights of business and government.</h1>
-            <div style="font-weight: 300; font-size: 14px; color: #cc5454;"><span style="font-size: 16px; font-weight: bold;">*</span> opposite of Big Brother</div>
+  <div class="col-sm-7">
+    <div class="row">
+      <h1 class="big-text">LittleSis<span style="color: #cc5454;">*</span> is a free database of who-knows-who at the heights of business and government.</h1>
+      <div style="font-weight: 300; font-size: 14px; color: #cc5454;"><span style="font-size: 16px; font-weight: bold;">*</span> opposite of Big Brother</div>
 
-            <div id="homepage-splash-subheader">
-                We're a grassroots watchdog network connecting the dots between the world's most powerful people and organizations.
-            </div>
-        </div>
-        
-	<div class="row position-relative">
-	    <div class="col-xs-5">
-		<!-- Begin MailChimp Signup Form -->
-		<div id="mc_embed_signup" class="input-group">
-		    <form action="https://public-accountability.us12.list-manage.com/subscribe/post?u=2c4abf91104beecf1c903bef4&amp;id=2d81c1bf80" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
-			<div id="mc_embed_signup_scroll">
-			    <div class="input-group">
-				<div class="mc-field-group">
-				    <input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="Your email" required>
-				</div>
-				<div id="mce-responses" class="clear">
-				    <div class="response" id="mce-error-response" style="display:none"></div>
-				    <div class="response" id="mce-success-response" style="display:none"></div>
-				</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-				<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_2c4abf91104beecf1c903bef4_2d81c1bf80" tabindex="-1" value=""></div>
-				<span class="input-group-btn">
-				    <button type="submit" name="subscribe" id="mc-embedded-subscribe" class="btn btn-default">Join us!</button>
-				</span>
-			    </div> <!-- end of input-group -->
-			</div>
-		    </form>
-		</div>
-		<!--End mc_embed_signup-->
-	    </div>		    
-	    
-	    <div class="col-xs-7">
-		<%= render partial: 'social_media_buttons' %>
-            </div>
-	    
-        </div>
+      <div id="homepage-splash-subheader">
+        We're a grassroots watchdog network connecting the dots between the world's most powerful people and organizations.
+      </div>
     </div>
-    <div class="col-sm-1"></div>
-    <div class="col-sm-4">
-        <%= render partial: 'dots_connected' %>
+    
+    <div class="row position-relative">
+      <div class="col-xs-5 nopadding">
+	<%= render partial: 'newsletter_signup_form' %>
+      </div>
+      
+      <div class="col-xs-7 double-left-padding">
+	<%= render partial: 'social_media_buttons' %>
+      </div>
+      
     </div>
+  </div>
+  <div class="col-sm-1"></div>
+  <div class="col-sm-4">
+    <%= render partial: 'dots_connected' %>
+  </div>
 </div>
 <br />
 <br />

--- a/config/lilsis.yml.sample
+++ b/config/lilsis.yml.sample
@@ -52,6 +52,7 @@ defaults: &defaults
   recaptcha:
     site_key: 'your-recaptcha-site-key-here'
     secret_key: 'your-recaptcha-secret-key-here'
+  action_network_api_key: 'your-action-network-api-key-here'
   
 
 test:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,9 +253,6 @@ Lilsis::Application.routes.draw do
   get "/home/lists" => "home#lists"
   get "/home/dashboard" => "home#dashboard"
   get "/home/token" => "home#token"
-  get "/home/extension_path" => "home#extension_path"
-
-  get "/home/error" => "home#error"
 
   post "/home/dismiss",
     controller: 'home',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Lilsis::Application.routes.draw do
   post '/contact' => 'home#contact'
   get '/flag' => 'home#flag'
   post '/flag' => 'home#flag'
+  post '/home/newsletter_signup' => 'home#newsletter_signup'
 
   get '/bug_report' => 'errors#bug_report'
   post '/bug_report' => 'errors#file_bug_report'

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,25 +2,11 @@ require 'rails_helper'
 
 describe HomeController, type: :controller do
   describe 'routes' do
-    it { should route(:get, '/contact').to(action: :contact) }
-    it { should route(:post, '/contact').to(action: :contact) }
-    it { should route(:get, '/flag').to(action: :flag) }
-    it { should route(:post, '/flag').to(action: :flag) }
-  end
-
-  describe 'GET #index' do
-    before do
-      expect_any_instance_of(HomeController).to receive(:redirect_to_dashboard_if_signed_in).and_return(nil)
-      expect_any_instance_of(HomeController).to receive(:carousel_entities).and_return(double(:entities => double(:to_a => [])))
-      get :index
-    end
-
-    it { should respond_with(200) }
-    it { should render_template('index') }
-
-    it 'has @dots_connected' do
-      expect(assigns(:dots_connected)).to be_a(Array)
-    end
+    it { is_expected.to route(:get, '/contact').to(action: :contact) }
+    it { is_expected.to route(:post, '/contact').to(action: :contact) }
+    it { is_expected.to route(:get, '/flag').to(action: :flag) }
+    it { is_expected.to route(:post, '/flag').to(action: :flag) }
+    it { is_expected.to route(:post, '/home/newsletter_signup').to(action: :newsletter_signup) }
   end
 
   describe 'GET contact' do

--- a/spec/controllers/users_confirmations_controllers_spec.rb
+++ b/spec/controllers/users_confirmations_controllers_spec.rb
@@ -14,7 +14,8 @@ describe Users::ConfirmationsController, type: :controller do
     before do
       expect(@user).not_to receive(:update)
       expect(NotificationMailer).to receive(:signup_email)
-                            .with(@user).and_return(double(:deliver_later => nil))
+                                      .with(@user).and_return(double(:deliver_later => nil))
+      expect(NewsletterSignupJob).to receive(:perform_later).with(@user)
       expect(@user).to receive(:delay).once.and_return(double(:create_chat_account => nil))
       get :show
     end
@@ -25,6 +26,7 @@ describe Users::ConfirmationsController, type: :controller do
     before do
       expect(IpBlocker).to receive(:restricted?).with('0.0.0.0').and_return(true)
       expect(NotificationMailer).not_to receive(:signup_email)
+      expect(NewsletterSignupJob).not_to receive(:perform_later)
       expect(@user).to receive(:update).with(is_restricted: true)
       expect(@user).not_to receive(:delay)
       get :show

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     about_me { Faker::Movie.quote }
     default_network_id 79
-    confirmed_at { Time.now }
+    confirmed_at { Time.current }
   end
 
   # sub-factory pattern. see: https://devhints.io/factory_bot

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -14,8 +14,33 @@ describe 'Homepage' do
 
     scenario 'anonymous user visiting the home page' do
       expect(page.status_code).to eq 200
-
       page_has_selector 'h1', text: 'LittleSis* is a free database of who-knows-who at the heights of business and government.'
+    end
+  end
+
+  feature 'newsletter signup' do
+    let(:email) { Faker::Internet.email }
+    before { visit '/' }
+
+    scenario 'sigining up for the newsletter' do
+      expect(NewsletterSignupJob).to receive(:perform_later).with(email).once
+
+      expect(page.status_code).to eq 200
+
+      fill_in 'newsletter-signup-form-email', with: email
+      click_button 'Join!'
+
+      successfully_visits_page '/'
+
+      # check for display of 'thank you!'
+    end
+
+    scenario 'super advanced™ spam bot protection' do
+      expect(NewsletterSignupJob).not_to receive(:perform_later)
+      fill_in 'newsletter-signup-form-email', with: email
+      fill_in 'very_important_wink_wink', with: "i'm a bot and i don't know any better"
+      click_button 'Join!'
+      successfully_visits_page '/'
     end
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -26,13 +26,17 @@ describe 'Homepage' do
       expect(NewsletterSignupJob).to receive(:perform_later).with(email).once
 
       expect(page.status_code).to eq 200
+      expect(page).not_to have_selector '#newsletter-thankyou'
 
       fill_in 'newsletter-signup-form-email', with: email
       click_button 'Join!'
 
-      successfully_visits_page '/'
+      successfully_visits_page '/?nlty=yes'
 
-      # check for display of 'thank you!'
+      page_has_selector '#newsletter-thankyou',
+                        text: "Thank you! You've been added to our newsletter."
+
+      expect(page).not_to have_selector '#newsletter-signup-form'
     end
 
     scenario 'super advanced™ spam bot protection' do
@@ -40,7 +44,7 @@ describe 'Homepage' do
       fill_in 'newsletter-signup-form-email', with: email
       fill_in 'very_important_wink_wink', with: "i'm a bot and i don't know any better"
       click_button 'Join!'
-      successfully_visits_page '/'
+      successfully_visits_page '/?nlty=yes'
     end
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'Homepage' do
+  let(:entity) { create(:entity_org) }
+  let(:list) { create(:list) }
+
+  before do
+    allow_any_instance_of(HomeController).to receive(:carousel_entities).and_return([entity])
+    stub_const("HomeController::DOTS_CONNECTED_LISTS", [[list.id, 'Corporate fat cats']])
+  end
+
+  feature 'visting the home page' do
+    before { visit '/' }
+
+    scenario 'anonymous user visiting the home page' do
+      expect(page.status_code).to eq 200
+
+      page_has_selector 'h1', text: 'LittleSis* is a free database of who-knows-who at the heights of business and government.'
+    end
+  end
+end

--- a/spec/jobs/newsletter_signup_job_spec.rb
+++ b/spec/jobs/newsletter_signup_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe NewsletterSignupJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,19 @@ describe User do
     end
   end
 
+  describe 'delagates first and last names to sf_guard_user_profile' do
+    let!(:user) { create_really_basic_user }
+    let!(:sf_profile) do
+      create(:sf_guard_user_profile,
+             name_first: Faker::Name.first_name,
+             name_last: Faker::Name.last_name,
+             user_id: user.sf_guard_user_id)
+    end
+
+    specify { expect(user.name_first).to eql sf_profile.name_first }
+    specify { expect(user.name_last).to eql sf_profile.name_last }
+  end
+
   describe 'set_default_network_id' do
     let(:user) do
       User.new(sf_guard_user_id: rand(1000),

--- a/spec/testdata/action_network_api_info.json
+++ b/spec/testdata/action_network_api_info.json
@@ -1,0 +1,96 @@
+{
+  "motd": "Welcome to the Action Network OSDI API v2 Entry Point!",
+  "_links": {
+    "curies": [
+      {
+        "name": "osdi",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      },
+      {
+        "name": "action_network",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      }
+    ],
+    "canvasser:brand_logo": {
+      "href": "https://actionnetwork.org/images/logo.png",
+      "title": "The branding logo for use in UI"
+    },
+    "docs": {
+      "href": "https://actionnetwork.org/docs/",
+      "title": "Documentation",
+      "name": "Docs",
+      "index": "index"
+    },
+    "self": {
+      "title": "This API entry point",
+      "href": "https://actionnetwork.org/api/v2/"
+    },
+    "osdi:people": {
+      "title": "The collection of people in the system",
+      "href": "https://actionnetwork.org/api/v2/people"
+    },
+    "osdi:events": {
+      "title": "The collection of events in the system",
+      "href": "https://actionnetwork.org/api/v2/events"
+    },
+    "osdi:petitions": {
+      "title": "The collection of petitions in the system",
+      "href": "https://actionnetwork.org/api/v2/petitions"
+    },
+    "osdi:fundraising_pages": {
+      "title": "The collection of fundraising_pages in the system",
+      "href": "https://actionnetwork.org/api/v2/fundraising_pages"
+    },
+    "osdi:donations": {
+      "title": "The collection of donations in the system",
+      "href": "https://actionnetwork.org/api/v2/donations"
+    },
+    "osdi:queries": {
+      "title": "The collection of queries in the system",
+      "href": "https://actionnetwork.org/api/v2/queries"
+    },
+    "osdi:forms": {
+      "title": "The collection of forms in the system",
+      "href": "https://actionnetwork.org/api/v2/forms"
+    },
+    "action_network:event_campaigns": {
+      "title": "The collection of event campaigns in the system",
+      "href": "https://actionnetwork.org/api/v2/event_campaigns"
+    },
+    "action_network:campaigns": {
+      "title": "The collection of campaigns in the system",
+      "href": "https://actionnetwork.org/api/v2/campaigns"
+    },
+    "osdi:tags": {
+      "title": "The collection of tags in the system",
+      "href": "https://actionnetwork.org/api/v2/tags"
+    },
+    "osdi:lists": {
+      "title": "The collection of lists in the system",
+      "href": "https://actionnetwork.org/api/v2/lists"
+    },
+    "osdi:wrappers": {
+      "title": "The collection of email wrappers in the system",
+      "href": "https://actionnetwork.org/api/v2/wrappers"
+    },
+    "osdi:messages": {
+      "title": "The collection of messages in the system",
+      "href": "https://actionnetwork.org/api/v2/messages"
+    },
+    "osdi:person_signup_helper": {
+      "title": "Person Signup Helper",
+      "href": "https://actionnetwork.org/api/v2/people"
+    },
+    "osdi:advocacy_campaigns": {
+      "title": "The collection of advocacy_campaigns in the system",
+      "href": "https://actionnetwork.org/api/v2/advocacy_campaigns"
+    }
+  },
+  "max_page_size": 25,
+  "vendor_name": "Action Network",
+  "product_name": "Action Network",
+  "namespace": "action_network",
+  "osdi_version": "1.1.1"
+}

--- a/spec/utility/action_network_spec.rb
+++ b/spec/utility/action_network_spec.rb
@@ -45,7 +45,7 @@ describe ActionNetwork do
                 .with(URI.parse(ActionNetwork::PEOPLE_URL), kind_of(Net::HTTP::Post))
                 .and_raise(ActionNetwork::HTTPRequestFailedError)
         expect(Rails.logger)
-          .to receive(:warn).with("Failed to add user #{user.username}(#{user.id}) to ActionNetwork")
+          .to receive(:warn).with("Post request failed: #{ActionNetwork.signup_params(user)}")
       end
 
       specify { expect(ActionNetwork.signup(user)).to be false }
@@ -80,4 +80,26 @@ describe ActionNetwork do
       end
     end
   end # end signup
+
+  describe 'add_email_to_newsletter' do
+    let(:email) { Faker::Internet.email }
+    let(:email_params) do
+      { "person" => { "email_addresses" => [{ "address" => email }] },
+        "add_tags" => ['PAI and LittleSis Updates'] }
+    end
+
+    before do
+      expect(ActionNetwork)
+        .to receive(:post)
+              .with(URI.parse(ActionNetwork::PEOPLE_URL), email_params)
+              .and_call_original
+
+      expect(ActionNetwork)
+        .to receive(:http).once
+              .with(URI.parse(ActionNetwork::PEOPLE_URL), kind_of(Net::HTTP::Post))
+              .and_return({})
+    end
+
+    specify { expect(ActionNetwork.add_email_to_newsletter(email)).to be true }
+  end
 end

--- a/spec/utility/action_network_spec.rb
+++ b/spec/utility/action_network_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe ActionNetwork do
+  API_INFO_HASH = JSON.parse(File.read(Rails.root.join('spec', 'testdata', 'action_network_api_info.json'))) # rubocop:disable Metrics/LineLength
+
+  describe 'api_info' do
+    it 'returns hash of response' do
+      expect(Net::HTTP).to receive(:start)
+                             .with('actionnetwork.org', 443, :use_ssl => true)
+                             .and_return(API_INFO_HASH)
+
+      expect(ActionNetwork.api_info).to eql API_INFO_HASH
+    end
+  end
+
+  describe 'signup' do
+    let(:first_name) { Faker::Name.first_name }
+    let(:last_name) { Faker::Name.last_name }
+    let(:newsletter) { false }
+    let(:map_the_power) { false }
+    let(:user) do
+      build(:user, id: rand(1000), newsletter: newsletter, map_the_power: map_the_power).tap do |user|
+        allow(user).to receive(:name_first).and_return(first_name)
+        allow(user).to receive(:name_last).and_return(last_name)
+      end
+    end
+
+    context 'successful signup' do
+      let(:mock_http_response) { { 'foo' => 'bar' } }
+      before do
+        expect(ActionNetwork)
+          .to receive(:http).once
+                .with(URI.parse(ActionNetwork::PEOPLE_URL), kind_of(Net::HTTP::Post))
+                .and_return(mock_http_response)
+        expect(Rails.logger).to receive(:debug).with(mock_http_response)
+      end
+
+      specify { expect(ActionNetwork.signup(user)).to be true }
+    end
+
+    context 'failed signup' do
+      before do
+        expect(ActionNetwork)
+          .to receive(:http).once
+                .with(URI.parse(ActionNetwork::PEOPLE_URL), kind_of(Net::HTTP::Post))
+                .and_raise(ActionNetwork::HTTPRequestFailedError)
+        expect(Rails.logger)
+          .to receive(:warn).with("Failed to add user #{user.username}(#{user.id}) to ActionNetwork")
+      end
+
+      specify { expect(ActionNetwork.signup(user)).to be false }
+    end
+
+    describe 'signup_params' do
+      subject { ActionNetwork.signup_params(user) }
+
+      context 'user does not check newsletter or map the power boxes' do
+        it do
+          is_expected.to eql('person' => {
+                               'identifiers' => ["littlesis_user_id:#{user.id}"],
+                               'family_name' => last_name,
+                               'given_name' => first_name,
+                               'email_addresses' => [{ 'address' => user.email }]
+                             },
+                             'add_tags' => ['LS-Signup'])
+        end
+      end
+
+      context 'user checks map the power only' do
+        let(:map_the_power) { true }
+        specify { expect(subject['add_tags']).to eql %w[LS-Signup MTP] }
+      end
+
+      context 'user checks map the power and newsletter' do
+        let(:map_the_power) { true }
+        let(:newsletter) { true }
+        specify do
+          expect(subject['add_tags']).to eql ['LS-Signup', 'PAI and LittleSis Updates', 'MTP']
+        end
+      end
+    end
+  end # end signup
+end


### PR DESCRIPTION
- use action network api to signup users (if they request it) to our mailing it
- create the app's first `ApplicationJob` to send api requests
- replace mailchimp form on front page
- clean up HomeController and specs


closes #533 
closes #538 