### PR TITLE
Fix bug when adding new references from entity references display page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
     - 'db/schema.rb'
     - 'db/seeds.rb'
     - 'db/migrate/*.rb'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   TargetRailsVersion: 5.0
 
 Rails:

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -9,7 +9,8 @@ class ReferencesController < ApplicationController
     if params[:data][:url].blank?
       return render json: { errors: { url: ["can't be blank"] } }, status: :bad_request
     end
-    @referenceable.add_reference(reference_params(:data))
+
+    @referenceable.add_reference(reference_params(:data).to_h)
 
     if @referenceable.valid?
       @referenceable.update(last_user_id: current_user.sf_guard_user_id)

--- a/app/models/concerns/referenceable.rb
+++ b/app/models/concerns/referenceable.rb
@@ -32,7 +32,7 @@ module Referenceable
 
     if self.valid?
       url = document_attributes[:url] || document_attributes['url']
-      doc = Document.find_by_url(url) || Document.create(document_attributes)
+      doc = Document.find_by_url(url) || Document.create!(document_attributes)
       references.create(document_id: doc.id) unless references.exists?(document_id: doc.id)
     end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -6,7 +6,7 @@ class Document < ApplicationRecord
   validates :name, length: { maximum: 255 }
   validates :publication_date, date: true
 
-  before_validation :trim_whitespace, :set_hash
+  before_validation :trim_whitespace, :set_hash, :convert_date
 
   has_paper_trail on: [:update, :destroy]
 
@@ -174,6 +174,10 @@ class Document < ApplicationRecord
 
   def set_hash
     self.url_hash = url_to_hash unless url.blank?
+  end
+
+  def convert_date
+    self.publication_date = LsDate.convert(publication_date) unless publication_date.nil?
   end
 
   def url_to_hash

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -28,6 +28,17 @@ describe Document, :pagination_helper, type: :model do
       specify { expect(subject.name).to eql 'LittleSis' }
       specify { expect(subject.url_hash).to eql Digest::SHA1.hexdigest('https://littlesis.org') }
     end
+
+    it 'converts blank string publication dates into nil' do
+      document = build(:document, url: url, publication_date: '')
+      expect(document.valid?).to be true
+    end
+
+    it 'uses LsDate to handle varations on publication date' do
+      document = build(:document, url: url, publication_date: '1999')
+      expect(document.valid?).to be true
+      expect(document.publication_date).to eql '1999-00-00'
+    end
   end
 
   describe 'ref types' do

--- a/spec/requests/references_spec.rb
+++ b/spec/requests/references_spec.rb
@@ -26,4 +26,28 @@ describe 'references requests', type: :request do
         .to eql (entities.map { |e| e.documents.map(&:id) }.flatten + non_requested_entity.documents.map(&:id)).to_set
     end
   end
+
+
+  describe 'creating a new reference' do
+    let(:entity) { create(:entity_person) }
+    let(:url) { Faker::Internet.url }
+    let(:post_data) do
+      {
+        "data" => {
+          "referenceable_id" => entity.id,
+          "referenceable_type" => 'Entity',
+          "url" => url,
+          "name" => "This is a document",
+          "publication_date" => '',
+          "ref_type" => '1',
+          "excerpt" => nil
+        }
+      }
+    end
+
+    it 'returns "created"' do
+      post '/references', params: post_data
+      expect(response).to have_http_status :created
+    end
+  end
 end

--- a/spec/utility/ls_date_spec.rb
+++ b/spec/utility/ls_date_spec.rb
@@ -1,12 +1,11 @@
+# rubocop:disable Lint/UselessComparison
 require 'rails_helper'
 
 describe LsDate do
   describe 'pretty printing' do
-    # date = Time.now
-
     it "prints a date with BASIC_FORMAT" do
-      s17 = Time.new(2011, 9, 17, 12, 0, 0)
-      expect(LsDate.pretty_print(s17)).to eql("September 17, 2011, 12PM")
+      s17 = Date.new(2011, 9, 17, 12)
+      expect(LsDate.pretty_print(s17)).to eql("September 17, 2011, 12AM")
     end
   end
 
@@ -52,8 +51,8 @@ describe LsDate do
         expect(d.month).to eql nil
         expect(d.day).to eql nil
       end
-    end    
-    
+    end
+
     describe 'specificity' do
       it 'has correct specificity :day when full date' do
         expect(LsDate.new('2017-01-01').specificity).to eql :day
@@ -71,7 +70,6 @@ describe LsDate do
         expect(LsDate.new(nil).specificity).to eql :unknown
       end
     end
-    
   end
 
   describe 'convert' do
@@ -86,6 +84,10 @@ describe LsDate do
       expect(LsDate.convert('20011231')).to eql '2001-12-31'
     end
 
+    it 'converts blank strings to nil' do
+      expect(LsDate.convert('')).to eql nil
+    end
+
     it 'returns input if it can\'t convert' do
       expect(LsDate.convert('88')).to eql '88'
       expect(LsDate.convert('1234567')).to eql '1234567'
@@ -96,63 +98,64 @@ describe LsDate do
 
   describe 'Comparisons' do
     it 'returns equal when both are unknown' do
-      expect( LsDate.new(nil) == LsDate.new(nil)).to be true
+      expect(LsDate.new(nil) == LsDate.new(nil)).to be true
     end
-    
+
     it 'a defined date is greater than an unknown date' do
-      expect( LsDate.new('1799-00-00') > LsDate.new(nil)).to be true
-      expect( LsDate.new('1799-01-00') > LsDate.new(nil)).to be true
-      expect( LsDate.new('1799-01-31') > LsDate.new(nil)).to be true
-      expect( LsDate.new(nil) < LsDate.new('1799-00-00')).to be true 
+      expect(LsDate.new('1799-00-00') > LsDate.new(nil)).to be true
+      expect(LsDate.new('1799-01-00') > LsDate.new(nil)).to be true
+      expect(LsDate.new('1799-01-31') > LsDate.new(nil)).to be true
+      expect(LsDate.new(nil) < LsDate.new('1799-00-00')).to be true
     end
 
     it 'works when years are different' do
-      expect( LsDate.new('1799-00-00') > LsDate.new('1600-00-00')).to be true
-      expect( LsDate.new('2017-00-00') > LsDate.new('2016-10-28')).to be true
-      expect( LsDate.new('2017-10-00') > LsDate.new('2016-10-00')).to be true
-      expect( LsDate.new('2000-00-00') < LsDate.new('2016-10-28')).to be true
+      expect(LsDate.new('1799-00-00') > LsDate.new('1600-00-00')).to be true
+      expect(LsDate.new('2017-00-00') > LsDate.new('2016-10-28')).to be true
+      expect(LsDate.new('2017-10-00') > LsDate.new('2016-10-00')).to be true
+      expect(LsDate.new('2000-00-00') < LsDate.new('2016-10-28')).to be true
     end
 
     context 'years are the same' do
       it 'if month is defined, the more specific date wins' do
-        expect( LsDate.new('2017-00-00') < LsDate.new('2017-03-00')).to be true
-        expect( LsDate.new('2017-00-00') < LsDate.new('2017-01-01')).to be true
+        expect(LsDate.new('2017-00-00') < LsDate.new('2017-03-00')).to be true
+        expect(LsDate.new('2017-00-00') < LsDate.new('2017-01-01')).to be true
       end
-      
+
       it 'if only year is defined, then they are equal' do
-        expect( LsDate.new('2017-00-00') == LsDate.new('2017-00-00')).to be true
+        expect(LsDate.new('2017-00-00') == LsDate.new('2017-00-00')).to be true
       end
     end
-    
+
     it 'works when years is the same, but the months are different' do
-      expect( LsDate.new('2017-02-00') < LsDate.new('2017-03-00')).to be true
-      expect( LsDate.new('2017-10-00') < LsDate.new('2017-11-00')).to be true
+      expect(LsDate.new('2017-02-00') < LsDate.new('2017-03-00')).to be true
+      expect(LsDate.new('2017-10-00') < LsDate.new('2017-11-00')).to be true
     end
 
-    it 'is equal when year and month are the same and both are missing days' do 
-      expect( LsDate.new('2017-02-00') == LsDate.new('2017-02-00')).to be true
+    it 'is equal when year and month are the same and both are missing days' do
+      expect(LsDate.new('2017-02-00') == LsDate.new('2017-02-00')).to be true
     end
 
-    it 'works when year and month are the same and one is missing a day' do 
-      expect( LsDate.new('2017-02-27') > LsDate.new('2017-02-00')).to be true
+    it 'works when year and month are the same and one is missing a day' do
+      expect(LsDate.new('2017-02-27') > LsDate.new('2017-02-00')).to be true
     end
   end
 
   describe 'display' do
     it 'displays unknown as ?' do
-      expect( LsDate.new(nil).display).to eql '?'
+      expect(LsDate.new(nil).display).to eql '?'
     end
 
     it "displays :year as 'YY" do
-      expect( LsDate.new('1926-00-00').display).to eql "'26"
+      expect(LsDate.new('1926-00-00').display).to eql "'26"
     end
 
     it "displays :month as 'Mon 'YY" do
-      expect( LsDate.new('1926-11-00').display).to eql "Nov '26"
+      expect(LsDate.new('1926-11-00').display).to eql "Nov '26"
     end
 
     it "displays :year as 'Mon DD, 'YY" do
-      expect( LsDate.new('2008-02-24').display).to eql "Feb 24 '08"
+      expect(LsDate.new('2008-02-24').display).to eql "Feb 24 '08"
     end
   end
 end
+# rubocop:enable Lint/UselessComparison


### PR DESCRIPTION
- `Document` will first convert the provided publication date using LsDate

- `LsDate.convert` turns blank strings into nil

- linting for LsDate and document specs

fixes #547 