### PR TITLE
Entity resolution work in progress #2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,6 @@ gem "recaptcha", '>= 4.6.2', require: "recaptcha/rails"
 
 # Used by `lib/cmp`
 gem "roo", "~> 2.7.0", :require => false
+
+# Used by NameSimilarity
+gem 'text', '>= 1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    text (1.3.1)
     thinking-sphinx (3.4.2)
       activerecord (>= 3.1.0)
       builder (>= 2.1.2)
@@ -512,6 +513,7 @@ DEPENDENCIES
   spring (~> 2.0.2)
   spring-commands-rspec
   sprockets (~> 3.0)
+  text (>= 1.3.1)
   thinking-sphinx (~> 3.4.2)
   tinymce-rails (~> 4.6.4)
   ts-delayed-delta (= 2.0.2)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,6 +74,8 @@ class Person < ApplicationRecord
   end
 
   def self.same_first_names(name)
-    [].concat(Array(SHORT_FIRST_NAMES[name.downcase])).concat(LONG_FIRST_NAMES.fetch(name.downcase, [])).compact
+    Array.wrap(SHORT_FIRST_NAMES.fetch(name.downcase, []))
+      .concat(Array.wrap(LONG_FIRST_NAMES.fetch(name.downcase, [])))
+      .compact
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -69,6 +69,10 @@ class Person < ApplicationRecord
     return 'Other' if gender_id == 3
   end
 
+  def name_attributes
+    attributes.slice("name_last", "name_first", "name_middle", "name_prefix", "name_suffix", "name_nick")
+  end
+
   def self.same_first_names(name)
     [].concat(Array(SHORT_FIRST_NAMES[name.downcase])).concat(LONG_FIRST_NAMES.fetch(name.downcase, [])).compact
   end

--- a/app/utility/entity_matcher.rb
+++ b/app/utility/entity_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'entity_matcher/query'
 require_relative 'entity_matcher/search'
 

--- a/app/utility/entity_matcher.rb
+++ b/app/utility/entity_matcher.rb
@@ -2,7 +2,8 @@
 
 require_relative 'entity_matcher/query'
 require_relative 'entity_matcher/search'
-require_relative 'entity_matcher/evaluator'
+require_relative 'entity_matcher/evaluation_result'
+require_relative 'entity_matcher/evaluation'
 
 module EntityMatcher
   class Matcher < SimpleDelegator

--- a/app/utility/entity_matcher.rb
+++ b/app/utility/entity_matcher.rb
@@ -2,6 +2,7 @@
 
 require_relative 'entity_matcher/query'
 require_relative 'entity_matcher/search'
+require_relative 'entity_matcher/evaluator'
 
 module EntityMatcher
   class Matcher < SimpleDelegator

--- a/app/utility/entity_matcher/evaluation.rb
+++ b/app/utility/entity_matcher/evaluation.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
-
 module EntityMatcher
+
+  # EntityMatcher::TestCase::Person ---> EntityMatcher::EvaluationResult
+  def self.evaluate(*args)
+    EntityMatcher::Evaluation.new(*args).result
+  end
+
+  # Evaluations two instances +TestCase+
+  # 
   class Evaluation
     attr_reader :result, :test_case, :match
 
@@ -47,7 +54,7 @@ module EntityMatcher
       NameSimilarity
         .similar?(@test_case.fetch('name_first'), @match.fetch('name_first'), first_name: true)
     end
-
+    
     def similar_last_name
       NameSimilarity
         .similar?(@test_case.fetch('name_last'), @match.fetch('name_last'))
@@ -64,33 +71,5 @@ module EntityMatcher
       raise ArgumentError unless match.is_a? EntityMatcher::TestCase::Person
       raise ArgumentError unless match.entity.is_a? Entity
     end
-  end
-
-  # criteria
-  #  name:
-  #    - same_last_name
-  #    - same_first_name
-  #    - same_prefix
-  #    - same_suffix
-  #    - same_middle
-  #    - mismatched_suffix
-  #    - similar_first_name
-  #    - similar_last_name
-  #  relationship:
-  #    - common_relationship
-  #  keywords:
-  #    - keyword_found_in_blurb
-
-
-  class EvaluationResult
-    attr_accessor :same_last_name,
-                  :same_first_name,
-                  :same_prefix,
-                  :same_middle,
-                  :same_suffix,
-                  :mismatched_suffix,
-                  :similar_last_name,
-                  :similar_first_name,
-                  :common_relationship
   end
 end

--- a/app/utility/entity_matcher/evaluation.rb
+++ b/app/utility/entity_matcher/evaluation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-module EntityMatcher
 
+module EntityMatcher
   # EntityMatcher::TestCase::Person ---> EntityMatcher::EvaluationResult
   def self.evaluate(*args)
     EntityMatcher::Evaluation.new(*args).result
@@ -28,8 +28,8 @@ module EntityMatcher
     def comparisons
       @result.same_last_name = compare_field(:last)
       @result.same_first_name = compare_field(:first)
+      @result.same_middle_name = compare_field(:middle)
       @result.same_prefix = compare_field(:prefix)
-      @result.same_middle = compare_field(:prefix)
       @result.same_suffix = compare_field(:suffix)
       @result.mismatched_suffix = mismatched_suffix
       @result.similar_first_name = similar_first_name
@@ -39,10 +39,10 @@ module EntityMatcher
     end
 
     def blurb_keyword
-      return nil unless @test_case.keywords.present?
+      return nil if @test_case.keywords.blank?
       return false if @match.entity.blurb.blank? && @match.entity.summary.blank?
 
-      test_keywords =  "#{@match.entity.blurb} #{@match.entity.summary}"
+      test_keywords = "#{@match.entity.blurb} #{@match.entity.summary}"
                          .downcase
                          .gsub(/[[:punct:]]/, '')
                          .split(' ')
@@ -53,8 +53,8 @@ module EntityMatcher
       end
 
       return false
-    end 
-    
+    end
+
     def common_relationship
       return nil if @test_case.associated_entities.blank?
       @common_relationship = (@test_case.associated_entities.to_set & @match.associated_entities.to_set).present?
@@ -64,7 +64,7 @@ module EntityMatcher
       NameSimilarity
         .similar?(@test_case.fetch('name_first'), @match.fetch('name_first'), first_name: true)
     end
-    
+
     def similar_last_name
       NameSimilarity
         .similar?(@test_case.fetch('name_last'), @match.fetch('name_last'))

--- a/app/utility/entity_matcher/evaluation.rb
+++ b/app/utility/entity_matcher/evaluation.rb
@@ -6,8 +6,7 @@ module EntityMatcher
     EntityMatcher::Evaluation.new(*args).result
   end
 
-  # Evaluations two instances +TestCase+
-  # 
+  # Evaluatutes two instances of +TestCase+
   class Evaluation
     attr_reader :result, :test_case, :match
 
@@ -40,6 +39,20 @@ module EntityMatcher
     end
 
     def blurb_keyword
+      return nil unless @test_case.keywords.present?
+      return false if @match.entity.blurb.blank? && @match.entity.summary.blank?
+
+      test_keywords =  "#{@match.entity.blurb} #{@match.entity.summary}"
+                         .downcase
+                         .gsub(/[[:punct:]]/, '')
+                         .split(' ')
+                         .to_set
+
+      @test_case.keywords.each do |keyword|
+        return true if test_keywords.include? keyword.downcase
+      end
+
+      return false
     end 
     
     def common_relationship

--- a/app/utility/entity_matcher/evaluation_result.rb
+++ b/app/utility/entity_matcher/evaluation_result.rb
@@ -14,7 +14,7 @@
 #  relationship:
 #    - common_relationship
 #  keywords:
-#    - keyword_found_in_blurb
+#    - blurb_keyword
   
 module EntityMatcher
   class EvaluationResult
@@ -26,6 +26,7 @@ module EntityMatcher
                   :mismatched_suffix,
                   :similar_last_name,
                   :similar_first_name,
-                  :common_relationship
+                  :common_relationship,
+                  :blurb_keyword
   end
 end

--- a/app/utility/entity_matcher/evaluation_result.rb
+++ b/app/utility/entity_matcher/evaluation_result.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Simple data class for results of matching evaluation
+# Criteria
+#  name:
+#    - same_last_name
+#    - same_first_name
+#    - same_prefix
+#    - same_suffix
+#    - same_middle
+#    - mismatched_suffix
+#    - similar_first_name
+#    - similar_last_name
+#  relationship:
+#    - common_relationship
+#  keywords:
+#    - keyword_found_in_blurb
+  
+module EntityMatcher
+  class EvaluationResult
+    attr_accessor :same_last_name,
+                  :same_first_name,
+                  :same_prefix,
+                  :same_middle,
+                  :same_suffix,
+                  :mismatched_suffix,
+                  :similar_last_name,
+                  :similar_first_name,
+                  :common_relationship
+  end
+end

--- a/app/utility/entity_matcher/evaluation_result.rb
+++ b/app/utility/entity_matcher/evaluation_result.rb
@@ -5,9 +5,9 @@
 #  name:
 #    - same_last_name
 #    - same_first_name
+#    - same_middle_name
 #    - same_prefix
 #    - same_suffix
-#    - same_middle
 #    - mismatched_suffix
 #    - similar_first_name
 #    - similar_last_name
@@ -15,13 +15,13 @@
 #    - common_relationship
 #  keywords:
 #    - blurb_keyword
-  
+
 module EntityMatcher
   class EvaluationResult
     attr_accessor :same_last_name,
                   :same_first_name,
+                  :same_middle_name,
                   :same_prefix,
-                  :same_middle,
                   :same_suffix,
                   :mismatched_suffix,
                   :similar_last_name,

--- a/app/utility/entity_matcher/evaluator.rb
+++ b/app/utility/entity_matcher/evaluator.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module EntityMatcher
+  class ResultSet
+    def initialize(test_case, matches)
+    end
+  end
+
+  # Compares the test_case to the match
+  class Evaluation
+    attr_reader :result, :test_case, :match
+
+    def initialize(test_case, match)
+      validate_arguments(test_case, match)
+
+      @test_case = test_case
+      @match = match
+      @result = EvaluationResult.new
+      compare
+    end
+
+    def compare
+      [
+        [:same_last_name, -> { compare_field :last }],
+        [:same_first_name, -> { compare_field :first }],
+        [:same_prefix, -> { compare_field :prefix }]
+      ].each do |(criteria, score)|
+        @result.public_send "#{criteria}=", score.call
+      end
+    end
+
+    private
+
+    def compare_field(field)
+      return nil if @test_case.public_send(field).nil? || @match.public_send(field).nil?
+      @test_case.public_send(field) == @match.public_send(field)
+    end
+
+    def validate_arguments(test_case, match)
+      raise ArgumentError unless test_case.is_a? EntityMatcher::TestCase::Person
+      raise ArgumentError unless match.is_a? EntityMatcher::TestCase::Person
+      raise ArgumentError unless match.entity.is_a? Entity
+    end
+  end
+
+  # Critia:
+  #  name:
+  #    - same_last_name
+  #    - similar_last_name
+  #    - same_first_name
+  #    - similar_first_name
+  #    - same_prefix
+  #    - same_suffix
+  #    - same_middle
+  #  keywords:
+  #    - keyword_found_in_blurb
+  #  relationship:
+  #    - relationship_in_common
+
+  class EvaluationResult
+    attr_accessor :same_last_name,
+                  :similar_last_name,
+                  :same_first_name,
+                  :similar_first_name,
+                  :same_prefix
+  end
+
+    
+end

--- a/app/utility/entity_matcher/evaluator.rb
+++ b/app/utility/entity_matcher/evaluator.rb
@@ -6,31 +6,41 @@ module EntityMatcher
     end
   end
 
-  # Compares the test_case to the match
   class Evaluation
     attr_reader :result, :test_case, :match
 
+    # call with two instances of EntityMatcher::TestCase::Person
+    # +match+ is required to be assoicated with an +Entity+
+    #
+    # .result returns an instance of  `EvaluationResult`
     def initialize(test_case, match)
       validate_arguments(test_case, match)
 
       @test_case = test_case
       @match = match
       @result = EvaluationResult.new
-      compare
-    end
 
-    def compare
-      [
-        [:same_last_name, -> { compare_field :last }],
-        [:same_first_name, -> { compare_field :first }],
-        [:same_prefix, -> { compare_field :prefix }]
-      ].each do |(criteria, score)|
-        @result.public_send "#{criteria}=", score.call
+      comparisons.each do |(criteria, evaluation)|
+        @result.public_send "#{criteria}=", evaluation.call
       end
     end
 
     private
 
+    # nested array containing the result field name
+    # and a lambda that returns the value for that field
+    def comparisons
+      [
+        [:same_last_name, -> { compare_field :last }],
+        [:same_first_name, -> { compare_field :first }],
+        [:same_prefix, -> { compare_field :prefix }],
+        [:same_middle, -> { compare_field :prefix }],
+        [:same_suffix, -> { compare_field :suffix }],
+        [:mismatched_suffix, -> { @test_case.suffix.present? || @match.suffix.present? }]
+      ]
+    end
+
+    # symbol --> nil | true | false
     def compare_field(field)
       return nil if @test_case.public_send(field).nil? || @match.public_send(field).nil?
       @test_case.public_send(field) == @match.public_send(field)
@@ -43,15 +53,16 @@ module EntityMatcher
     end
   end
 
-  # Critia:
+  # criteria
   #  name:
   #    - same_last_name
-  #    - similar_last_name
   #    - same_first_name
-  #    - similar_first_name
   #    - same_prefix
   #    - same_suffix
   #    - same_middle
+  #    - mismatched_suffix
+  #    - similar_first_name
+  #    - similar_last_name
   #  keywords:
   #    - keyword_found_in_blurb
   #  relationship:
@@ -59,11 +70,12 @@ module EntityMatcher
 
   class EvaluationResult
     attr_accessor :same_last_name,
-                  :similar_last_name,
                   :same_first_name,
-                  :similar_first_name,
-                  :same_prefix
+                  :same_prefix,
+                  :same_middle,
+                  :same_suffix,
+                  :mismatched_suffix,
+                  :similar_last_name,
+                  :similar_first_name
   end
-
-    
 end

--- a/app/utility/entity_matcher/evaluator.rb
+++ b/app/utility/entity_matcher/evaluator.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 module EntityMatcher
-  class ResultSet
-    def initialize(test_case, matches)
-    end
-  end
-
   class Evaluation
     attr_reader :result, :test_case, :match
 
@@ -36,8 +31,20 @@ module EntityMatcher
         [:same_prefix, -> { compare_field :prefix }],
         [:same_middle, -> { compare_field :prefix }],
         [:same_suffix, -> { compare_field :suffix }],
-        [:mismatched_suffix, -> { @test_case.suffix.present? || @match.suffix.present? }]
+        [:mismatched_suffix, -> { @test_case.suffix.present? || @match.suffix.present? }],
+        [:similar_first_name, -> { similar_first_name }],
+        [:similar_last_name, -> { similar_last_name }]
       ]
+    end
+
+    def similar_first_name
+      NameSimilarity
+        .similar?(@test_case.fetch('name_first'), @match.fetch('name_first'), first_name: true)
+    end
+
+    def similar_last_name
+      NameSimilarity
+        .similar?(@test_case.fetch('name_last'), @match.fetch('name_last'))
     end
 
     # symbol --> nil | true | false

--- a/app/utility/entity_matcher/evaluator.rb
+++ b/app/utility/entity_matcher/evaluator.rb
@@ -33,8 +33,14 @@ module EntityMatcher
         [:same_suffix, -> { compare_field :suffix }],
         [:mismatched_suffix, -> { @test_case.suffix.present? || @match.suffix.present? }],
         [:similar_first_name, -> { similar_first_name }],
-        [:similar_last_name, -> { similar_last_name }]
+        [:similar_last_name, -> { similar_last_name }],
+        [:common_relationship, -> { common_relationship }]
       ]
+    end
+
+    def common_relationship
+      return nil if @test_case.associated_entities.blank?
+      @common_relationship = (@test_case.associated_entities.to_set & @match.associated_entities.to_set).present?
     end
 
     def similar_first_name
@@ -70,10 +76,11 @@ module EntityMatcher
   #    - mismatched_suffix
   #    - similar_first_name
   #    - similar_last_name
+  #  relationship:
+  #    - common_relationship
   #  keywords:
   #    - keyword_found_in_blurb
-  #  relationship:
-  #    - relationship_in_common
+
 
   class EvaluationResult
     attr_accessor :same_last_name,
@@ -83,6 +90,7 @@ module EntityMatcher
                   :same_suffix,
                   :mismatched_suffix,
                   :similar_last_name,
-                  :similar_first_name
+                  :similar_first_name,
+                  :common_relationship
   end
 end

--- a/app/utility/entity_matcher/test_case.rb
+++ b/app/utility/entity_matcher/test_case.rb
@@ -20,6 +20,14 @@ module EntityMatcher
       attr_reader :entity, :name
       delegate :fetch, to: :name
 
+      # calling .first, .last, etc.
+      # returns upcased versions of the name component
+      %i[prefix first middle last suffix nick].each do |name_component|
+        define_method(name_component) do
+          fetch("name_#{name_component}")&.upcase
+        end
+      end
+
       # input: Entity | String | Hash
       def initialize(input)
         case input

--- a/app/utility/entity_matcher/test_case.rb
+++ b/app/utility/entity_matcher/test_case.rb
@@ -42,7 +42,7 @@ module EntityMatcher
         else
           raise TypeError
         end
-        
+
         @keywords = keywords
         parse_associated(associated)
       end

--- a/app/utility/entity_matcher/test_case.rb
+++ b/app/utility/entity_matcher/test_case.rb
@@ -2,10 +2,10 @@
 
 module EntityMatcher
   ##
-  # Module contain wrapper objects for the *test case*
+  # Module containing wrapper objects for the *test case*
   #
   # They can be initalized with an Entity (use case: searching for duplicates), strings or hashes.
-  # The hashes have to contain the attributes used in the +Person+ model
+  # The hashes must contain the attributes used in the +Person+ model
   #
   module TestCase
     class Person
@@ -17,11 +17,10 @@ module EntityMatcher
                                name_suffix: nil,
                                name_nick: nil).freeze
 
-      attr_reader :entity, :name, :associated_entities
+      attr_reader :entity, :name, :associated_entities, :keywords
       delegate :fetch, to: :name
 
-      # calling .first, .last, etc.
-      # returns upcased versions of the name component
+      # calling .first, .last, etc. returns upcased versions of the name component
       %i[prefix first middle last suffix nick].each do |name_component|
         define_method(name_component) do
           fetch("name_#{name_component}")&.upcase
@@ -29,7 +28,7 @@ module EntityMatcher
       end
 
       # input: Entity | String | Hash
-      def initialize(input, associated: nil)
+      def initialize(input, associated: nil, keywords: [])
         case input
         when Entity
           raise WrongEntityTypeError unless input.person?
@@ -43,7 +42,8 @@ module EntityMatcher
         else
           raise TypeError
         end
-
+        
+        @keywords = keywords
         parse_associated(associated)
       end
 

--- a/app/utility/entity_matcher/test_case.rb
+++ b/app/utility/entity_matcher/test_case.rb
@@ -1,38 +1,55 @@
+# frozen_string_literal: true
+
 module EntityMatcher
   ##
-  # Module contain wrapper objects for the *test case*, the
-  # are is the input entity
+  # Module contain wrapper objects for the *test case*
   #
-  # They can be initalized with an Entity (use case: searching for duplicates) or strings.
-  # Person test cases can be initalized with hash containing the attributes
-  # used in the +Person+ model
+  # They can be initalized with an Entity (use case: searching for duplicates), strings or hashes.
+  # The hashes have to contain the attributes used in the +Person+ model
   #
   module TestCase
-    class Base
-      attr_reader :primary_ext, :entity
+    class Person
+      BLANK_NAME_HASH = ActiveSupport::HashWithIndifferentAccess
+                          .new(name_prefix: nil,
+                               name_first: nil,
+                               name_middle: nil,
+                               name_last: nil,
+                               name_suffix: nil,
+                               name_nick: nil).freeze
 
-      # Primary_ext is required unless an +Entity+ is provided
-      def initialize(name_or_entity, primary_ext: nil)
-        @primary_ext = standardize_primary_ext(name_or_entity, primary_ext)
-        @entity = name_or_entity if name_or_entity.is_a? Entity
+      attr_reader :entity, :name
+      delegate :fetch, to: :name
+
+      # input: Entity | String | Hash
+      def initialize(input)
+        case input
+        when Entity
+          raise WrongEntityTypeError unless input.person?
+          @entity = input
+          @name = ActiveSupport::HashWithIndifferentAccess.new(@entity.person.name_attributes)
+        when String
+          @name = NameParser.new(input).to_indifferent_hash
+        when Hash
+          validate_input_hash(input)
+          @name = BLANK_NAME_HASH.merge(input)
+        else
+          raise ArgumentError
+        end
       end
 
       private
 
-      def standardize_primary_ext(name_or_entity, primary_ext)
-        return name_or_entity.primary_ext if name_or_entity.is_a? Entity
-        ext = primary_ext.to_s.capitalize
-        return ext if %w[Org Person].include? ext
-        raise MissingOrInvalidPrimaryExtError
+      def validate_input_hash(h)
+        unless (h[:name_first] || h['name_first']) && (h[:name_last] || h['name_last'])
+          raise InvalidPersonHash
+        end
       end
-    end
-
-    class PersonTestCase < Base
     end
 
     ##
     # Exceptions
     #
-    class MissingOrInvalidPrimaryExtError < StandardError; end
+    class WrongEntityTypeError < StandardError; end
+    class InvalidPersonHash < StandardError; end
   end
 end

--- a/app/utility/name_similarity.rb
+++ b/app/utility/name_similarity.rb
@@ -9,15 +9,23 @@ class NameSimilarity
               :equal,
               :levenshtein,
               :first_name_alias
-  
+
   MAX_LEVENSHTEIN_VALUE = 2
+
+  def self.compare(a, b)
+    new(a, b)
+  end
+
+  def self.similar?(a, b, **kwargs)
+    new(a, b, **kwargs).similar
+  end
 
   def initialize(a, b, first_name: false)
     type_check a, String
     type_check b, String
     @a = a.upcase
     @b = b.upcase
-    
+
     run { equal_test }
     run { levenshtein_test }
     run { first_name_test } if first_name
@@ -25,6 +33,8 @@ class NameSimilarity
     # set similar to false if it hasn't changed in the tests
     @similar = false if @similar.nil?
   end
+
+  private
 
   def equal_test
     @equal = (@a == @b)
@@ -43,21 +53,11 @@ class NameSimilarity
     end
   end
 
-  private
-
   def run
     yield unless similar
   end
 
   def is_similar
     @similar = true
-  end
-
-  def self.compare(a,b)
-    new(a,b)
-  end
-
-  def self.similar?(a,b, **kwargs)
-    new(a,b, **kwargs).similar
   end
 end

--- a/app/utility/name_similarity.rb
+++ b/app/utility/name_similarity.rb
@@ -56,4 +56,8 @@ class NameSimilarity
   def self.compare(a,b)
     new(a,b)
   end
+
+  def self.similar?(a,b, **kwargs)
+    new(a,b, **kwargs).similar
+  end
 end

--- a/app/utility/name_similarity.rb
+++ b/app/utility/name_similarity.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# A class to compare names using a variety of metrics.
+#
+# All string are handled case-insensitively
+class NameSimilarity
+  include TypeCheck
+  attr_reader :similar,
+              :equal,
+              :levenshtein,
+              :first_name_alias
+  
+  MAX_LEVENSHTEIN_VALUE = 2
+
+  def initialize(a, b, first_name: false)
+    type_check a, String
+    type_check b, String
+    @a = a.upcase
+    @b = b.upcase
+    
+    run { equal_test }
+    run { levenshtein_test }
+    run { first_name_test } if first_name
+
+    # set similar to false if it hasn't changed in the tests
+    @similar = false if @similar.nil?
+  end
+
+  def equal_test
+    @equal = (@a == @b)
+    is_similar if @equal
+  end
+
+  def levenshtein_test
+    @levenshtein = Text::Levenshtein.distance(@a, @b)
+    is_similar if @levenshtein <= MAX_LEVENSHTEIN_VALUE
+  end
+
+  def first_name_test
+    if Person.same_first_names(@a).include?(@b.downcase) || Person.same_first_names(@b).include?(@a.downcase)
+      @first_name_alias = true
+      is_similar
+    end
+  end
+
+  private
+
+  def run
+    yield unless similar
+  end
+
+  def is_similar
+    @similar = true
+  end
+
+  def self.compare(a,b)
+    new(a,b)
+  end
+end

--- a/app/utility/type_check.rb
+++ b/app/utility/type_check.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Simple typechecker
+# ::examples::
+#    TypeCheck.check 'hello', String
+#    TypeCheck.check 123, [Array, Integer]
+#
+# if included in a class, it provides the method type_check()
+module TypeCheck
+  delegate :check, to: 'TypeCheck', prefix: :type
+
+  def self.check(val, valid_types, allow_subclass: true)
+    check_method = allow_subclass ? :is_a? : :instance_of?
+
+    Array.wrap(valid_types).each do |valid_type|
+      return true if val.send(check_method, valid_type)
+    end
+
+    raise TypeError, "wrong argument type #{val.class} (expected #{Array.wrap(valid_types).join(',')})"
+  end
+end

--- a/lib/cmp/cmp_person.rb
+++ b/lib/cmp/cmp_person.rb
@@ -14,33 +14,33 @@ module Cmp
       )
     end
 
-   def to_person_hash
-     {
-       name_prefix: fetch("salutation"),
-       name_first: fetch("firstname"),
-       name_middle: fetch("middlename"),
-       name_last: fetch("lastname"),
-       name_suffix: fetch("suffix")
+    def to_person_hash
+      {
+        name_prefix: fetch("salutation"),
+        name_first: fetch("firstname"),
+        name_middle: fetch("middlename"),
+        name_last: fetch("lastname"),
+        name_suffix: fetch("suffix")
       }
     end
 
-   def associated_entities
-     CmpEntity
-       .where(cmp_id: Cmp::Datasets.relationships
-                .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == fetch(:cmpid, "ATTR_ID") }
-                .map { |r| r.fetch(:cmp_org_id) })
-       .map(&:entity)
-   end
+    def associated_entities
+      CmpEntity
+        .where(cmp_id: Cmp::Datasets.relationships
+                 .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == fetch(:cmpid, "ATTR_ID") }
+                 .map { |r| r.fetch(:cmp_org_id) })
+        .map(&:entity)
+    end
 
     def potential_matches
       EntityMatcher::Search.by_name(fetch('lastname')).map do |entity|
+        test_case = EntityMatcher::TestCase::Person
+                      .new(to_person_hash, associated: associated_entities)
 
-        test_case = EntityMatcher::TestCase::Person.new(to_person_hash, associated: associated_entities)
-        match =  EntityMatcher::TestCase::Person.new(entity)
+        match = EntityMatcher::TestCase::Person.new(entity)
         EntityMatcher.evaluate(test_case, match)
       end
     end
-
 
     # def potential_matches
     #   @_potential_matches ||=

--- a/lib/cmp/cmp_person.rb
+++ b/lib/cmp/cmp_person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cmp
   class CmpPerson < CmpEntityImporter
     ATTRIBUTE_MAP = {
@@ -12,10 +14,38 @@ module Cmp
       )
     end
 
-    def potential_matches
-      @_potential_matches ||=
-        EntityMatch.new(name: entity_name, primary_ext: 'Person', cmpid: cmpid).search_results
+   def to_person_hash
+     {
+       name_prefix: fetch("salutation"),
+       name_first: fetch("firstname"),
+       name_middle: fetch("middlename"),
+       name_last: fetch("lastname"),
+       name_suffix: fetch("suffix")
+      }
     end
+
+   def associated_entities
+     CmpEntity
+       .where(cmp_id: Cmp::Datasets.relationships
+                .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == fetch(:cmpid, "ATTR_ID") }
+                .map { |r| r.fetch(:cmp_org_id) })
+       .map(&:entity)
+   end
+
+    def potential_matches
+      EntityMatcher::Search.by_name(fetch('lastname')).map do |entity|
+
+        test_case = EntityMatcher::TestCase::Person.new(to_person_hash, associated: associated_entities)
+        match =  EntityMatcher::TestCase::Person.new(entity)
+        EntityMatcher.evaluate(test_case, match)
+      end
+    end
+
+
+    # def potential_matches
+    #   @_potential_matches ||=
+    #     EntityMatch.new(name: entity_name, primary_ext: 'Person', cmpid: cmpid).search_results
+    # end
 
     private
 

--- a/lib/tasks/cmp.rake
+++ b/lib/tasks/cmp.rake
@@ -32,19 +32,19 @@ namespace :cmp do
 
       file_path = Rails.root.join('data', 'cmp_individuals_with_match_info.csv').to_s
 
+
       people = Cmp::Datasets.people.values.map do |cmp_person|
-        attrs = LsHash.new(littlesis_entity_id: '').merge!(cmp_person.attributes_with_matches)
+        attrs = LsHash.new(littlesis_entity_id: '').merge!(cmp_person.attributes)
 
-        attrs['littlesis_entity_id'] = 'new' if attrs['match1_name'].blank?
+        #attrs['littlesis_entity_id'] = 'new' if attrs['match1_name'].blank?
 
-        org_names = Cmp::Datasets
-                          .relationships
-                          .select { |r| r.fetch(:cmp_person_id, nil) == attrs.fetch(:cmpid, nil) }
-                          .map { |r| r.fetch(:cmp_org_id) }
-                          .map { |id| Cmp::Datasets.orgs.find { |o| o.fetch(:cmpid).to_s == id } }
-                          .compact
-                          .map { |cmp_org| cmp_org.fetch(:cmpname, '') }
-                          .join('| ')
+        associated = CmpEntity
+                       .where(cmp_id:Cmp::Datasets.relationships
+                                .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == attrs.fetch(:cmpid, "ATTR_ID") }
+                                .map { |r| r.fetch(:cmp_org_id) })
+                       .map(&:entity)
+        
+        
 
         attrs.merge!('associated_corps' => org_names)
       end

--- a/lib/tasks/cmp.rake
+++ b/lib/tasks/cmp.rake
@@ -32,19 +32,16 @@ namespace :cmp do
 
       file_path = Rails.root.join('data', 'cmp_individuals_with_match_info.csv').to_s
 
-
       people = Cmp::Datasets.people.values.map do |cmp_person|
         attrs = LsHash.new(littlesis_entity_id: '').merge!(cmp_person.attributes)
 
-        #attrs['littlesis_entity_id'] = 'new' if attrs['match1_name'].blank?
+        # attrs['littlesis_entity_id'] = 'new' if attrs['match1_name'].blank?
 
         associated = CmpEntity
                        .where(cmp_id:Cmp::Datasets.relationships
                                 .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == attrs.fetch(:cmpid, "ATTR_ID") }
                                 .map { |r| r.fetch(:cmp_org_id) })
                        .map(&:entity)
-        
-        
 
         attrs.merge!('associated_corps' => org_names)
       end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -78,5 +78,10 @@ describe Person do
       names = Person.same_first_names 'cy'
       expect(names).to eq ['cyrus']
     end
+
+    it 'returns empty list if no names found ' do
+      names = Person.same_first_names 'mynamecannotbeshorten'
+      expect(names).to eq []
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # these run inside an example (ie: it block)
+  config.include RspecExampleHelpers
   config.include Devise::Test::ControllerHelpers, :type => :controller
   config.include Devise::Test::ControllerHelpers, :type => :view
   config.include Warden::Test::Helpers
@@ -55,6 +56,7 @@ RSpec.configure do |config|
   config.include SphinxTestHelper, :sphinx
 
   # these run inside example groups (ie: describe blocks)
+  config.extend RspecGroupHelpers
   config.extend ControllerMacros, :type => :controller
   config.extend FeatureGroupMacros, :type => :feature
   config.extend RequestGroupMacros, :type => :request

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -100,6 +100,12 @@ module RspecExampleHelpers
 end
 
 module RspecGroupHelpers
+  def assert_attribute(attr, expected)
+    it "attribute \"#{attr}\" is equal to #{expected}" do
+      expect(subject.send(attr)).to eql expected
+    end
+  end
+
   # thanks to https://stackoverflow.com/questions/3853098/turn-off-transactional-fixtures-for-one-spec-with-rspec-2
   def without_transactional_fixtures(&block)
     self.use_transactional_fixtures = false

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,116 +1,119 @@
-def css(*args)
-  expect(rendered).to have_css(*args)
-end
-
-def not_css(*args)
-  expect(rendered).not_to have_css(*args)
-end
-
-# thanks to https://stackoverflow.com/questions/3853098/turn-off-transactional-fixtures-for-one-spec-with-rspec-2
-def without_transactional_fixtures(&block)
-  self.use_transactional_fixtures = false
-
-  before(:all) do
-    DatabaseCleaner.strategy = :truncation
+module RspecExampleHelpers
+  def css(*args)
+    expect(rendered).to have_css(*args)
   end
 
-  yield
+  def not_css(*args)
+    expect(rendered).not_to have_css(*args)
+  end
 
-  after(:all) do
-    DatabaseCleaner.strategy = :transaction
+  def create_admin_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    create(:sf_guard_user_profile, user_id: sf_user.id)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 1, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
+    user
+  end
+
+  def create_bulk_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 9, user_id: sf_user.id)
+    user
+  end
+
+  def create_merger_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 7, user_id: sf_user.id)
+    user
+  end
+
+  def create_list_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
+    user
+  end
+
+  def create_contributor
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+    user
+  end
+
+  def create_importer
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 8, user_id: sf_user.id)
+    user
+  end
+
+
+  def create_really_basic_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+  end
+
+  def create_basic_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
+    user
+  end
+
+  def create_bulker_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 9, user_id: sf_user.id)
+    user
+  end
+
+  def create_restricted_user
+    sf_user = FactoryBot.create(:sf_guard_user)
+    user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id, is_restricted: true)
+    SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    user
+  end
+
+  def create_user_with_sf(attrs = {})
+    sf_user = FactoryBot.create(:sf_user)
+    FactoryBot.create(:sf_guard_user_profile, user_id: sf_user.id)
+    FactoryBot.create(:user, attrs.merge(sf_guard_user: sf_user))
+  end
+
+  def create_generic_relationship
+    person = FactoryBot.create(:person)
+    org = FactoryBot.create(:org)
+    FactoryBot.create(:generic_relationship, entity: person, related: org, last_user_id: 1)
   end
 end
 
+module RspecGroupHelpers
+  # thanks to https://stackoverflow.com/questions/3853098/turn-off-transactional-fixtures-for-one-spec-with-rspec-2
+  def without_transactional_fixtures(&block)
+    self.use_transactional_fixtures = false
 
-def create_admin_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  create(:sf_guard_user_profile, user_id: sf_user.id)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 1, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
-  user
-end
+    before(:all) do
+      DatabaseCleaner.strategy = :truncation
+    end
 
-def create_bulk_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 9, user_id: sf_user.id)
-  user
-end
+    yield
 
-def create_merger_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 7, user_id: sf_user.id)
-  user
-end
-
-def create_list_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
-  user
-end
-
-def create_contributor
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
-  user
-end
-
-def create_importer
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 8, user_id: sf_user.id)
-  user
-end
-
-
-def create_really_basic_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-end
-
-def create_basic_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
-  user
-end
-
-def create_bulker_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 9, user_id: sf_user.id)
-  user
-end
-
-def create_restricted_user
-  sf_user = FactoryBot.create(:sf_guard_user)
-  user = FactoryBot.create(:user, sf_guard_user_id: sf_user.id, is_restricted: true)
-  SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
-  SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
-  user
-end
-
-def create_user_with_sf(attrs = {})
-  sf_user = FactoryBot.create(:sf_user)
-  FactoryBot.create(:sf_guard_user_profile, user_id: sf_user.id)
-  FactoryBot.create(:user, attrs.merge(sf_guard_user: sf_user))
-end
-
-def create_generic_relationship
-  person = FactoryBot.create(:person)
-  org = FactoryBot.create(:org)
-  FactoryBot.create(:generic_relationship, entity: person, related: org, last_user_id: 1)
+    after(:all) do
+      DatabaseCleaner.strategy = :transaction
+    end
+  end
 end
 
 class TestActiveRecord

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -176,14 +176,14 @@ describe EntityMatcher, :sphinx do
       context 'test_case is invalid' do
         specify do
           expect { subject.new(build(:person), generate_test_case) }
-            .to raise_error(ArgumentError)
+            .to raise_error(TypeError)
         end
       end
 
       context 'match is invalid' do
         specify do
           expect { subject.new(generate_test_case, EntityMatcher::TestCase::Person.new('first last')) }
-            .to raise_error(ArgumentError)
+            .to raise_error(TypeError)
         end
       end
     end

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -215,7 +215,7 @@ describe EntityMatcher, :sphinx do
             .to eql false
         end
       end
-      
+
       context 'same first name' do
         let(:first_name) { Faker::Name.first_name }
         let(:test_case) do
@@ -235,6 +235,20 @@ describe EntityMatcher, :sphinx do
         end
       end
 
+      context 'mismatched suffix ' do
+        let(:test_case) do
+          EntityMatcher::TestCase::Person.new "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+        end
+
+        let(:match) do
+          generate_test_case name_first: Faker::Name.first_name, name_suffix: 'JR'
+        end
+
+        specify do
+          expect(subject.new(test_case, match).result.same_suffix).to be_nil
+          expect(subject.new(test_case, match).result.mismatched_suffix).to eql true
+        end
+      end
     end
 
   end

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -249,7 +249,21 @@ describe EntityMatcher, :sphinx do
           expect(subject.new(test_case, match).result.mismatched_suffix).to eql true
         end
       end
-    end
 
+      context 'similar first names' do
+        let(:test_case) do
+          EntityMatcher::TestCase::Person.new "Cindi #{Faker::Name.unique.last_name}"
+        end
+
+        let(:match) do
+          generate_test_case name_first: 'cindy', name_last: Faker::Name.unique.last_name
+        end
+
+        specify do
+          expect(subject.new(test_case, match).result.similar_last_name).to be false
+          expect(subject.new(test_case, match).result.similar_first_name).to eql true
+        end
+      end
+    end
   end
 end

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -245,6 +245,7 @@ describe EntityMatcher, :sphinx do
         end
 
         specify do
+          expect(subject.new(test_case, match).result.blurb_keyword).to be_nil
           expect(subject.new(test_case, match).result.same_suffix).to be_nil
           expect(subject.new(test_case, match).result.mismatched_suffix).to eql true
         end
@@ -297,6 +298,63 @@ describe EntityMatcher, :sphinx do
 
         specify do
           expect(subject.new(test_case, match).result.common_relationship).to eql false
+        end
+      end
+
+      describe 'searching blub and summary' do
+        context 'does not have keyword in blurb' do
+          let(:match_entity) do
+            create(:entity_person, blurb: 'blah blah. not a very interesting match')
+          end
+          let(:test_case) do
+            EntityMatcher::TestCase::Person
+              .new("#{Faker::Name.first_name} #{Faker::Name.last_name}",
+                   associated: '123',
+                   keywords: ['oil'])
+          end
+          let(:match) { EntityMatcher::TestCase::Person.new(match_entity) }
+
+          specify do
+            expect(subject.new(test_case, match).result.blurb_keyword).to eql false
+          end
+        end
+
+
+        context 'has keyword in blurb' do
+          let(:match_entity) do
+            create(:entity_person, blurb: 'oil executive')
+          end
+          let(:test_case) do
+            EntityMatcher::TestCase::Person
+              .new("#{Faker::Name.first_name} #{Faker::Name.last_name}",
+                   associated: '123',
+                   keywords: ['oil'])
+          end
+          let(:match) { EntityMatcher::TestCase::Person.new(match_entity) }
+
+          specify do
+            expect(subject.new(test_case, match).result.common_relationship).to eql false
+            expect(subject.new(test_case, match).result.blurb_keyword).to eql true
+          end
+        end
+
+        context 'has keyword in summary' do
+          let(:match_entity) do
+            create(:entity_person, summary: 'i am into ruining the planet by extracting oil!')
+          end
+
+          let(:test_case) do
+            EntityMatcher::TestCase::Person
+              .new("#{Faker::Name.first_name} #{Faker::Name.last_name}",
+                   associated: '123',
+                   keywords: ['oil'])
+          end
+          let(:match) { EntityMatcher::TestCase::Person.new(match_entity) }
+
+          specify do
+            expect(subject.new(test_case, match).result.common_relationship).to eql false
+            expect(subject.new(test_case, match).result.blurb_keyword).to eql true
+          end
         end
       end
     end

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -264,6 +264,41 @@ describe EntityMatcher, :sphinx do
           expect(subject.new(test_case, match).result.similar_first_name).to eql true
         end
       end
+
+      context 'relationship in common' do
+        let(:org) { create(:entity_org) }
+        let(:match_entity) do
+          create(:entity_person).tap do |entity|
+            Relationship.create!(category_id: 12, entity: entity, related: org)
+          end
+        end
+        let(:test_case) do
+          EntityMatcher::TestCase::Person.new("#{Faker::Name.first_name} #{Faker::Name.last_name}", associated: org.id)
+        end
+        let(:match) { EntityMatcher::TestCase::Person.new(match_entity) }
+
+        specify do
+          expect(subject.new(test_case, match).result.common_relationship).to eql true
+        end
+      end
+
+      context 'no relationship in common' do
+        let(:org) { create(:entity_org) }
+        let(:other_org) { create(:entity_org) }
+        let(:match_entity) do
+          create(:entity_person).tap do |entity|
+            Relationship.create!(category_id: 12, entity: entity, related: org)
+          end
+        end
+        let(:test_case) do
+          EntityMatcher::TestCase::Person.new("#{Faker::Name.first_name} #{Faker::Name.last_name}", associated: other_org.id)
+        end
+        let(:match) { EntityMatcher::TestCase::Person.new(match_entity) }
+
+        specify do
+          expect(subject.new(test_case, match).result.common_relationship).to eql false
+        end
+      end
     end
   end
 end

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -194,7 +194,7 @@ describe EntityMatcher, :sphinx do
       def generate_test_case(fields = {})
         EntityMatcher::TestCase::Person.new(build(:person, person: build(:a_person, **fields)))
       end
-      
+
       # EntityMatcher::TestCase::Person.new(
       #     build(:person, person: build(:a_person, fields))
       #   )
@@ -232,6 +232,25 @@ describe EntityMatcher, :sphinx do
 
           expect(subject.new(test_case, match).result.same_last_name)
             .to eql false
+        end
+      end
+
+      context 'same first, middle, and last name' do
+        let(:first_name) { Faker::Name.first_name }
+        let(:middle_name) { Faker::Name.first_name }
+        let(:last_name) { Faker::Name.last_name }
+        let(:test_case) do
+          EntityMatcher::TestCase::Person.new "#{first_name} #{middle_name} #{last_name}"
+        end
+
+        let(:match) do
+          generate_test_case name_first: first_name, name_middle: middle_name, name_last: last_name
+        end
+
+        specify do
+          expect(subject.new(test_case, match).result.same_first_name).to eql true
+          expect(subject.new(test_case, match).result.same_last_name).to eql true
+          expect(subject.new(test_case, match).result.same_middle_name).to eql true
         end
       end
 
@@ -273,8 +292,9 @@ describe EntityMatcher, :sphinx do
             Relationship.create!(category_id: 12, entity: entity, related: org)
           end
         end
+        let(:full_name) { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
         let(:test_case) do
-          EntityMatcher::TestCase::Person.new("#{Faker::Name.first_name} #{Faker::Name.last_name}", associated: org.id)
+          EntityMatcher::TestCase::Person.new(full_name, associated: org.id)
         end
         let(:match) { EntityMatcher::TestCase::Person.new(match_entity) }
 
@@ -318,7 +338,6 @@ describe EntityMatcher, :sphinx do
             expect(subject.new(test_case, match).result.blurb_keyword).to eql false
           end
         end
-
 
         context 'has keyword in blurb' do
           let(:match_entity) do

--- a/spec/utility/name_similarity_spec.rb
+++ b/spec/utility/name_similarity_spec.rb
@@ -9,6 +9,12 @@ describe NameSimilarity do
     expect(NameSimilarity.compare('xyz', 'abc')).to be_a NameSimilarity
   end
 
+  it 'class method #similar? as boolean shortcut ' do
+    expect(NameSimilarity.similar?('little', 'sis')).to eql false
+    expect(NameSimilarity.similar?('sandy', 'sandi')).to eql true
+    expect(NameSimilarity.similar?('ag', 'agatha', first_name: true)).to eql true
+  end
+
   context 'names are the same' do
     subject { NameSimilarity.new('alice', 'alice') }
     assert_attribute :equal, true

--- a/spec/utility/name_similarity_spec.rb
+++ b/spec/utility/name_similarity_spec.rb
@@ -19,7 +19,7 @@ describe NameSimilarity do
     subject { NameSimilarity.new('alice', 'alice') }
     assert_attribute :equal, true
     assert_attribute :similar, true
-    
+
     context 'with different capitalization' do
       subject { NameSimilarity.new('alIcE', 'alice') }
       assert_attribute :equal, true

--- a/spec/utility/name_similarity_spec.rb
+++ b/spec/utility/name_similarity_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe NameSimilarity do
+  it 'raises TypeError unless both arguments are strings' do
+    expect { NameSimilarity.new('hello', 123) }.to raise_error(TypeError)
+  end
+
+  it 'has factory class method "compare"' do
+    expect(NameSimilarity.compare('xyz', 'abc')).to be_a NameSimilarity
+  end
+
+  context 'names are the same' do
+    subject { NameSimilarity.new('alice', 'alice') }
+    assert_attribute :equal, true
+    assert_attribute :similar, true
+    
+    context 'with different capitalization' do
+      subject { NameSimilarity.new('alIcE', 'alice') }
+      assert_attribute :equal, true
+      assert_attribute :similar, true
+    end
+  end
+
+  context 'names are almost the same' do
+    subject { NameSimilarity.new('aice', 'alice') }
+    assert_attribute :equal, false
+    assert_attribute :similar, true
+    assert_attribute :levenshtein, 1
+    assert_attribute :first_name_alias, nil
+  end
+
+  context 'names are totally different' do
+    subject { NameSimilarity.new('bob', 'alice') }
+    assert_attribute :equal, false
+    assert_attribute :similar, false
+    assert_attribute :levenshtein, 5
+  end
+
+  context 'similar first names' do
+    subject { NameSimilarity.new('ag', 'agatha', first_name: true) }
+    assert_attribute :equal, false
+    assert_attribute :levenshtein, 4
+    assert_attribute :similar, true
+    assert_attribute :first_name_alias, true
+    context 'reversed' do
+      subject { NameSimilarity.new('agatha', 'ag', first_name: true) }
+      assert_attribute :similar, true
+      assert_attribute :first_name_alias, true
+    end
+  end
+end

--- a/spec/utility/type_check_spec.rb
+++ b/spec/utility/type_check_spec.rb
@@ -44,4 +44,3 @@ describe TypeCheck do
     end
   end
 end
-

--- a/spec/utility/type_check_spec.rb
+++ b/spec/utility/type_check_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe TypeCheck do
+  it 'return true if is valid input' do
+    expect { TypeCheck.check [1, 2, 3], Array }.not_to raise_error
+    expect(TypeCheck.check([1, 2, 3], Array)).to be true
+  end
+
+  it 'raises type error if provided invalid class' do
+    expect { TypeCheck.check [1, 2, 3], String }
+      .to raise_error(TypeError)
+  end
+
+  it 'can check multiple types' do
+    expect { TypeCheck.check [1, 2, 3], [String, Array] }
+      .not_to raise_error
+  end
+
+  it 'checks subclasses by default (using is_a?)' do
+    expect { TypeCheck.check Entity.new, ActiveRecord::Base }
+      .not_to raise_error
+  end
+
+  it 'does strict checking if enabled (using instance_of?)' do
+    expect { TypeCheck.check Entity.new, ActiveRecord::Base, allow_subclass: false }
+      .to raise_error(TypeError)
+  end
+
+  context 'as a mixin' do
+    class IAcceptOnlyIntegers
+      include TypeCheck
+
+      def initialize(this_better_be_an_int)
+        type_check this_better_be_an_int, Integer
+      end
+    end
+
+    it 'available as "type_check()" if included in a class' do
+      expect { IAcceptOnlyIntegers.new('123') }
+        .to raise_error(TypeError)
+
+      expect { IAcceptOnlyIntegers.new(123) }
+        .not_to raise_error
+    end
+  end
+end
+


### PR DESCRIPTION
This adds a complete way to compare two entity and/or test entities.

after comparing it produces a result object with 10 boolean flags:
  - same_last_name
  - same_first_name
  - same_middle_middle
  - same_prefix
   - same_suffix
   - mismatched_suffix
  - similar_last_name
  - similar_first_name
  - common_relationship
   - blurb_keyword

next step is to rank these comparisons!

adds one new gem, [text](https://github.com/threedaymonk/text).

creates two helper class/modules that might be useful in other parts of the code base:

- `TypeCheck` -- a simple way to check the types of arguments
- `NameSimilarity` - determines if names are similar