### PR TITLE
Featured Maps

### DIFF
--- a/app/assets/stylesheets/base/helpers.scss
+++ b/app/assets/stylesheets/base/helpers.scss
@@ -136,3 +136,9 @@
 .no-border-top {
     border-top: 0;
 }
+
+.empty-button {
+    background: none;
+    border: none;
+    padding: 0;
+}

--- a/app/assets/stylesheets/base/helpers.scss
+++ b/app/assets/stylesheets/base/helpers.scss
@@ -51,6 +51,10 @@
   padding-right: 1em;
 }
 
+.pad-left-05em {
+  padding-left: 0.5em;
+}
+
 .pad-left-1em {
   padding-left: 1em;
 }
@@ -127,4 +131,8 @@
 
 .cursor-pointer {
     cursor: pointer;
+}
+
+.no-border-top {
+    border-top: 0;
 }

--- a/app/assets/stylesheets/styles/edits.scss
+++ b/app/assets/stylesheets/styles/edits.scss
@@ -50,7 +50,7 @@ form.alias-form {
 	border-spacing: 0.3em;
 
 	td {
-	    border-top: 0;
+	    @extend .no-border-top;
 	}
     }
 

--- a/app/assets/stylesheets/styles/maps.scss
+++ b/app/assets/stylesheets/styles/maps.scss
@@ -1,3 +1,40 @@
+.feature-map-form-container {
+    margin-left: 5px;
+    form {
+	display: inline;
+    }
+
+}
+
+.featured-map-star-button {
+    @extend .empty-button;
+    
+    > span {
+	@extend .glyphicon;
+	font-size: 15px;
+    }
+
+    &:hover > span {
+	color: $link_blue_hover;
+    }
+
+    &:hover > .featured-map-star {
+	@extend .glyphicon-star-empty;
+    }
+
+    &:hover > .not-featured-map-star {
+	@extend .glyphicon-star;
+    }
+}
+
+.featured-map-star {
+    @extend .glyphicon-star;
+}
+
+.not-featured-map-star {
+    @extend .glyphicon-star-empty;
+}
+
 
 /* map pages */
 

--- a/app/assets/stylesheets/styles/users.scss
+++ b/app/assets/stylesheets/styles/users.scss
@@ -55,3 +55,19 @@
 .permission-boolean {
   padding-left: 20px;
 }
+
+.user-page-table {
+    width: 100%;
+    
+    a {
+    	@extend .link-blue;
+    }
+ 
+    td {
+	@extend .no-border-top;
+	padding: 0;
+	em {
+	    font-size: 12px;
+	}
+    }
+}

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MapsController < ApplicationController
   include NetworkMapsHelper
 
@@ -42,20 +44,12 @@ class MapsController < ApplicationController
   end
 
   def search
-    order = 'updated_at DESC, id DESC'
-    if user_signed_in?
-      @maps = NetworkMap.search(
-        Riddle::Query.escape(params.fetch(:q, '')),
-        order: order,
-        with: { visible_to_user_ids: [0, current_user.sf_guard_user_id] }
-      ).page(params[:page]).per(20)
-    else
-      @maps = NetworkMap.search(
-        Riddle::Query.escape(params.fetch(:q, '')),
-        order: order,
-        with: { visible_to_user_ids: [0] }
-      ).page(params[:page]).per(20)
-    end
+    page = params[:page].presence || 1
+    @maps = NetworkMap
+              .search(ThinkingSphinx::Query.escape(params.fetch(:q, '')),
+                      order: 'updated_at DESC, id DESC',
+                      with: { is_private: false })
+              .page(page).per(20)
   end
 
   def embedded_v2

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class MapsController < ApplicationController
-  include NetworkMapsHelper
-
   before_action :set_map,
                 except: [:featured, :all, :new, :create, :search, :find_nodes, :node_with_edges, :edges_with_nodes, :interlocks]
   before_action :authenticate_user!,
@@ -301,8 +299,8 @@ class MapsController < ApplicationController
 
     is_json = request.path_info.match(/\.json$/)
 
-    if !is_json and @map.title.present? and !request.env['PATH_INFO'].match(Regexp.new(@map.to_param, true))
-      redirect_to smart_map_path(@map)
+    if !is_json && @map.title.present? && !request.env['PATH_INFO'].match(Regexp.new(@map.to_param, true))
+      redirect_to map_path(@map)
     end
   end
 

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -205,7 +205,6 @@ class MapsController < ApplicationController
 
       @map.title = params[:title] if params[:title].present?
       @map.description = params[:description] if params[:title].present?
-      @map.is_featured = params[:is_featured] if params[:is_featured].present?
       @map.is_private = params[:is_private] if params[:is_private].present?
       @map.is_cloneable = params[:is_cloneable] if params[:is_cloneable].present?
       @map.width = params[:width] if params[:width].present?
@@ -317,14 +316,12 @@ class MapsController < ApplicationController
   end
 
   def map_params
-    params.require(:map).permit(
-      :is_featured, :is_private, :title, :description, :data,
-       :height, :width, :user_id, :zoom
-    )
+    params.require(:map)
+      .permit(:is_private, :title, :description, :data, :height, :width, :user_id, :zoom)
   end
 
   def oligrapher_params
-    params.permit(:graph_data, :annotations_data, :annotations_count, :title, :is_private, :is_featured, :is_cloneable, :list_sources)
+    params.permit(:graph_data, :annotations_data, :annotations_count, :title, :is_private, :is_cloneable, :list_sources)
   end
 
   def embedded_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
 
   # GET /users/:username
   def show
-    @user = UserPresenter.new(@user)
+    @user = UserPresenter.new(@user, current_user: current_user)
   end
 
   # GET /users/:username/edits

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit_permissions, :add_permission, :delete_permission, :destroy, :restrict, :edits]
   before_action :authenticate_user!, except: [:success]
@@ -18,12 +20,7 @@ class UsersController < ApplicationController
 
   # GET /users/:username
   def show
-    @maps = @user.network_maps.order("created_at DESC, id DESC")
-    @groups = @user.groups.order(:name)
-    @lists = @user.lists.order("created_at DESC, id DESC")
-    @recent_updates = @user.edited_entities.includes(last_user: :user).order("updated_at DESC").limit(10)
-    @permissions = @user.permissions.instance_variable_get(:@sf_permissions)
-    @all_permissions = Permissions::ALL_PERMISSIONS
+    @user = UserPresenter.new(@user)
   end
 
   # GET /users/:username/edits

--- a/app/helpers/network_maps_helper.rb
+++ b/app/helpers/network_maps_helper.rb
@@ -10,4 +10,12 @@ module NetworkMapsHelper
     return link unless map.is_private
     link + content_tag('span', nil, class: "glyphicon glyphicon-lock private-network-map-icon pad-left-05em")
   end
+
+  def network_map_feature_btn(map)
+    icon_class = map.is_featured ? 'featured-map-star' : 'not-featured-map-star'
+    form_tag(feature_map_path(map), id: "feature-map-form-#{map.id}") do
+      hidden_field_tag('map[feature_action]', (map.is_featured ? 'REMOVE' : 'ADD')) +
+        button_tag(type: 'submit', class: 'featured-map-star-button') { content_tag :span, nil, class: icon_class }
+    end
+  end
 end

--- a/app/helpers/network_maps_helper.rb
+++ b/app/helpers/network_maps_helper.rb
@@ -4,7 +4,10 @@ module NetworkMapsHelper
     map_path(map)
   end
 
+  # used on /maps and user pages
   def network_map_link(map)
-    link_to(raw(map.name), smart_map_path(map))
+    link = link_to(raw(map.name), smart_map_path(map))
+    return link unless map.is_private
+    link + content_tag('span', nil, class: "glyphicon glyphicon-lock private-network-map-icon pad-left-05em")
   end
 end

--- a/app/indices/network_map_index.rb
+++ b/app/indices/network_map_index.rb
@@ -3,7 +3,6 @@ ThinkingSphinx::Index.define :network_map, :with => :active_record, :delta => Th
   indexes description
   indexes index_data
 
-  has [is_private, user_id], as: :visible_to_user_ids, multi: true, type: :integer
   has is_private, facet: true
   has is_featured, facet: true
   has is_deleted, facet: true

--- a/app/models/network_map.rb
+++ b/app/models/network_map.rb
@@ -361,4 +361,15 @@ class NetworkMap < ApplicationRecord
       JSON.parse(annotations_data).concat([legacy_description_as_annotation])
     )
   end
+
+  ###
+
+  # input: <User> --> NetworkMap::ActiveRecord_Relation
+  def self.scope_for_user(user)
+    where_condition = <<~SQL
+      `network_map`.`is_private` = 0
+      OR (`network_map`.`is_private` = 1 AND `network_map`.`user_id` = ?)
+    SQL
+    where(where_condition, user.sf_guard_user_id)
+  end
 end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 class UserPresenter < SimpleDelegator
+  attr_internal :current_user
+
+  def initialize(user, current_user: nil)
+    super(user)
+    @_current_user = current_user
+  end
+
   # Only the user's themselves and admins can view
   # certain sections of the profile page such as the permission section
-  def show_private?(current_user)
-    user == current_user || current_user.admin?
+  def show_private?
+    user == current_user || (current_user.present? && current_user.admin?)
   end
 
   def groups

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class UserPresenter < SimpleDelegator
+  # Only the user's themselves and admins can view
+  # certain sections of the profile page such as the permission section
+  def show_private?(current_user)
+    user == current_user || current_user.admin?
+  end
+
+  def groups
+    return @_groups if defined?(@_groups)
+    @_groups = super().order(:name)
+  end
+
+  def lists
+    super().order("created_at DESC, id DESC")
+  end
+
+  def recent_updates
+    edited_entities.includes(last_user: :user).order("updated_at DESC").limit(10)
+  end
+
+  # string ---> string
+  def permisison_display(p)
+    permissions.include?(p) ? "Yes" : "No"
+  end
+
+  def permissions
+    return @_permissions if defined?(@_permissions)
+    @_permissions = super().instance_variable_get(:@sf_permissions)
+  end
+
+  def maps
+    network_maps.order("created_at DESC, id DESC")
+  end
+
+  private
+
+  def user
+    __getobj__
+  end
+end

--- a/app/views/maps/_table.html.erb
+++ b/app/views/maps/_table.html.erb
@@ -6,6 +6,9 @@
       <th>Title</th>
       <th>Author</th>
       <th>Updated</th>
+      <% if current_user&.admin? %>
+	<th>Feature</th>
+      <% end %>
     </tr>
   </thead>
 
@@ -17,6 +20,15 @@
           <%= user_link(map.user) %>
         </td>
         <td><%= time_ago_in_words(map.updated_at) %> ago</td>
+
+	<% if current_user&.admin? %>
+	  <td>
+	    <% unless map.is_private %>
+	      <%= network_map_feature_btn(map) %>
+	    <% end %>
+	  </td>
+	<% end %>
+
       </tr>
     <% end %>
   </tbody>

--- a/app/views/maps/_table.html.erb
+++ b/app/views/maps/_table.html.erb
@@ -1,11 +1,11 @@
 <%= paginate maps %>
 
-<table class="table">
+<table class="table" id="maps-table">
   <thead>
     <tr>
       <th>Title</th>
       <th>Author</th>
-      <th>Created</th>
+      <th>Updated</th>
     </tr>
   </thead>
 
@@ -16,7 +16,7 @@
         <td>
           <%= user_link(map.user) %>
         </td>
-        <td><%= time_ago_in_words(map.created_at) %> ago</td>
+        <td><%= time_ago_in_words(map.updated_at) %> ago</td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/maps/_table.html.erb
+++ b/app/views/maps/_table.html.erb
@@ -12,12 +12,7 @@
   <tbody>
     <% maps.each do |map| %>
       <tr>
-        <td>
-          <%= network_map_link(map) %>
-          <% if map.is_private %>
-            &nbsp;<span class="glyphicon glyphicon-lock"></span>
-          <% end %>
-        </td>
+        <td><%= network_map_link(map) %></td>
         <td>
           <%= user_link(map.user) %>
         </td>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -2,34 +2,34 @@
 
 <%= centered_content do %>
 
-<h1>
-  <% if @featured %>
-    Featured Maps
-    <%= link_to 'All', maps_path, class: 'btn btn-default btn-sm' %>
-  <% else %>
-    Network Maps
-    <%= link_to 'Featured', featured_maps_path, class: 'btn btn-default btn-sm' %>
-  <% end %>
-  <% if current_user and controller_name != 'home' %>
-    <%= link_to 'Your Maps', home_maps_path, class: 'btn btn-default btn-sm' %>
-  <% end %>
-  <%= link_to 'Create', new_map_path, class: 'btn btn-default btn-sm' %>
-</h1>
+  <h1>
+    <% if @featured %>
+      Featured Maps
+      <%= link_to 'All', all_maps_path, class: 'btn btn-default btn-sm' %>
+    <% else %>
+      Network Maps
+      <%= link_to 'Featured', featured_maps_path, class: 'btn btn-default btn-sm' %>
+    <% end %>
+    <% if current_user && controller_name != 'home' %>
+      <%= link_to 'Your Maps', home_maps_path, class: 'btn btn-default btn-sm' %>
+    <% end %>
+    <%= link_to 'Create', new_map_path, class: 'btn btn-default btn-sm' %>
+  </h1>
 
-<% unless @featured %>
-<%= form_tag search_maps_path, method: :get do %>
-  <div class="input-group col-xs-4 maps_search">
-    <%= text_field_tag :q, params[:q], class: "form-control", placeholder: "Search maps" %>
-    <span class="input-group-btn">
-      <button type="submit" class="btn btn-default">
-        <span class="glyphicon glyphicon-search"></span>
+  <% unless @featured %>
+    <%= form_tag search_maps_path, method: :get do %>
+      <div class="input-group col-xs-4 maps_search">
+	<%= text_field_tag :q, params[:q], class: "form-control", placeholder: "Search maps" %>
+	<span class="input-group-btn">
+	  <button type="submit" class="btn btn-default">
+            <span class="glyphicon glyphicon-search"></span>
       </input>
-    </span>
-  </div>
-<% end %>
-<br>
-<% end %>
+	</span>
+      </div>
+    <% end %>
+    <br>
+  <% end %>
 
-<%= render partial: 'maps/table', locals: { maps: @maps } %>
+  <%= render partial: 'maps/table', locals: { maps: @maps } %>
 
 <% end %>

--- a/app/views/maps/search.html.erb
+++ b/app/views/maps/search.html.erb
@@ -6,7 +6,7 @@
   Network Maps
   <%= link_to 'featured maps', featured_maps_path, class: 'btn btn-default btn-sm' %>
   <% if params[:q].present? %>
-    <%= link_to 'all maps', maps_path, class: 'btn btn-default btn-sm' %>
+    <%= link_to 'all maps', all_maps_path, class: 'btn btn-default btn-sm' %>
   <% end %>
 </h1>
 

--- a/app/views/maps/story_map.html.erb
+++ b/app/views/maps/story_map.html.erb
@@ -88,8 +88,7 @@
              annotations_count: annotations.length,
              title: data.title,
              is_private: data.settings.is_private,
-             is_featured: data.settings.is_featured,
-	     is_cloneable: data.settings.is_cloneable,  
+	     is_cloneable: data.settings.is_cloneable,
              list_sources: data.settings.list_sources
 	 },
 	 success: function(data) { 
@@ -123,7 +122,6 @@
      links: <%= raw(JSON.dump(@links || [])) %>,
      settings: {
 	 is_private: <%= @map.is_private.to_s %>,
-	 is_featured: <%= @map.is_featured.to_s %>,
 	 is_cloneable: <%= @map.is_cloneable.to_s %>,
 	 list_sources: <%= @map.list_sources.to_s %>
      },

--- a/app/views/users/_maps_table.html.erb
+++ b/app/views/users/_maps_table.html.erb
@@ -1,0 +1,10 @@
+<%# Table of network maps for user page. Assumes presence of @user where @user is a UserPresenter %>
+<!-- class="table table-condensed" -->
+
+<table class="user-page-table" id="user-page-network-maps-table">
+  <% @user.maps.each do |map|  %>
+    <tr>
+      <td><%= network_map_link(map) %> &nbsp;<em>updated <%= time_ago_in_words(map.updated_at) %> ago</em></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@
 
 <h3>
   Edits
-  <% if @user.show_private?(current_user) %>
+  <% if @user.show_private? %>
     <small>
       <%= link_to 'view all edits', user_edits_path(@user), class: 'm-left-1em' %>
     </small>
@@ -45,7 +45,13 @@
   <% end %>
 </div>
 
-<% if @user.show_private?(current_user) %>
+<% if @user.show_private? %>
+  <h3>Maps</h3>
+  <div>
+  </div>
+<% end %>
+
+  <% if @user.show_private? %>
   <h3>
     Permissions
   </h3>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,8 +19,8 @@
   Groups
 </h3>
 <div>
-  <% if @groups.present? %>
-    <% @groups.each do |group| %>
+  <% if @user.groups.present? %>
+    <% @user.groups.each do |group| %>
       <%= group_link(group) %><br />
     <% end %>
   <% else %>
@@ -30,7 +30,7 @@
 
 <h3>
   Edits
-  <% if @user == current_user || current_user.admin? %>
+  <% if @user.show_private?(current_user) %>
     <small>
       <%= link_to 'view all edits', user_edits_path(@user), class: 'm-left-1em' %>
     </small>
@@ -38,23 +38,23 @@
 </h3>
 
 <div>
-  <% @recent_updates.each do |entity| %>
+  <% @user.recent_updates.each do |entity| %>
     <div class="dashboard-entity">
       <span class="dashboard-entity-link"><%= entity_link(entity) %></span> &nbsp;<em><%= highlight((entity.blurb or ""), params[:q]) %></em>
     </div>
   <% end %>
 </div>
 
-<% if @user == current_user || current_user.admin? %>
+<% if @user.show_private?(current_user) %>
   <h3>
     Permissions
   </h3>
   <div>
     <table>
-      <% @all_permissions.each do |p| %>
+      <% Permissions::ALL_PERMISSIONS.each do |p| %>
 	<tr>
 	  <td class="permission-name"><%= p.capitalize %></td>
-	  <td class="permission-boolean"><%= @permissions.include?(p) ? "Yes" : "No" %></td>
+	  <td class="permission-boolean"><%= @user.permisison_display(p) %></td>
 	</tr>
       <% end %>
     </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,23 +1,17 @@
 <p id="notice"><%= notice %></p>
 
-<h1>
-  <%= @user.username %>
-</h1>
+<h1><%= @user.username %></h1>
 
 <div class="entity-profile-image">
   <%= user_profile_image %>
 </div>
 
-<h3>
-  About
-</h3>
-<div>
-  <%= @user.about_me %>
-</div>
+<h3>About</h3>
 
-<h3>
-  Groups
-</h3>
+<div><%= @user.about_me %></div>
+
+<h3>Groups</h3>
+
 <div>
   <% if @user.groups.present? %>
     <% @user.groups.each do |group| %>
@@ -38,20 +32,25 @@
 </h3>
 
 <div>
-  <% @user.recent_updates.each do |entity| %>
-    <div class="dashboard-entity">
-      <span class="dashboard-entity-link"><%= entity_link(entity) %></span> &nbsp;<em><%= highlight((entity.blurb or ""), params[:q]) %></em>
-    </div>
-  <% end %>
+  <table class="user-page-table" id="user-page-recent-updates-table">
+    <% @user.recent_updates.each do |entity| %>
+      <tr>
+	<td><%= entity_link(entity) %></span> &nbsp;<em><%= (entity.blurb || "") %></em></td>
+      </tr>
+    <% end %>
+  </table>
 </div>
 
 <% if @user.show_private? %>
   <h3>Maps</h3>
-  <div>
-  </div>
+  <% if @user.maps.empty? %>
+    <div><em>No maps</em></div>
+  <% else %>
+    <%= render partial: 'maps_table' %>
+  <% end %>
 <% end %>
 
-  <% if @user.show_private? %>
+<% if @user.show_private? %>
   <h3>
     Permissions
   </h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,6 +197,7 @@ Lilsis::Application.routes.draw do
     member do
       get 'raw'
       post 'clone'
+      post 'feature'
       get 'embedded'
       get 'map_json'
       get 'dev'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,12 +191,9 @@ Lilsis::Application.routes.draw do
     end
   end
 
-  get "/story_maps/:id",
-    controller: 'story_maps',
-    action: 'story_map',
-    as: "story_map"
+  get '/maps', to: redirect('/maps/featured')
 
-  resources :maps do
+  resources :maps, except: [:index] do
     member do
       get 'raw'
       post 'clone'
@@ -211,13 +208,13 @@ Lilsis::Application.routes.draw do
     collection do
       get 'search'
       get 'featured'
+      get 'all'
       get 'find_nodes'
       get 'node_with_edges'
       get 'edges_with_nodes'
       get 'interlocks'
     end
   end
-
 
   get "/maps/:id/:slide",
     controller: 'maps',

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe MapsController do
+  it { is_expected.to route(:get, '/maps/123-oligrapher').to(action: :show, id: '123-oligrapher') }
+  it { is_expected.to route(:post, '/maps/123-oligrapher/feature').to(action: :feature, id: '123-oligrapher') }
   it { is_expected.to route(:get, '/maps/find_nodes').to(action: :find_nodes) }
   it { is_expected.to route(:get, '/maps/node_with_edges').to(action: :node_with_edges) }
   it { is_expected.to route(:get, '/maps/edges_with_nodes').to(action: :edges_with_nodes) }

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -5,4 +5,6 @@ describe MapsController do
   it { is_expected.to route(:get, '/maps/node_with_edges').to(action: :node_with_edges) }
   it { is_expected.to route(:get, '/maps/edges_with_nodes').to(action: :edges_with_nodes) }
   it { is_expected.to route(:get, '/maps/interlocks').to(action: :interlocks) }
+  it { is_expected.to route(:get, '/maps/featured').to(action: :featured) }
+  it { is_expected.to route(:get, '/maps/all').to(action: :all) }
 end

--- a/spec/features/maps_spec.rb
+++ b/spec/features/maps_spec.rb
@@ -22,6 +22,8 @@ feature 'maps index page' do
     scenario 'visiting /maps/all' do
       successfully_visits_page '/maps/all'
       page_has_selector '#maps-table'
+      page_has_selector '#maps-table thead th', count: 3
+      expect(page).not_to have_selector '.featured-map-star' # non-admins don't have this option
       page_has_selector '#maps-table tbody tr', count: 2 # skips private maps
     end
   end
@@ -49,6 +51,8 @@ feature 'maps index page' do
 
     scenario 'visiting /maps/all as an admin' do
       successfully_visits_page '/maps/all'
+      page_has_selector '.featured-map-star', count: 1
+      page_has_selector '.not-featured-map-star', count: 1
       page_has_selector '#maps-table tbody tr', count: 2 # skips private maps
     end
   end
@@ -65,6 +69,29 @@ feature 'maps index page' do
     scenario 'visiting /maps/all' do
       successfully_visits_page '/maps/all'
       page_has_selector '#maps-table tbody tr', count: 3 # includes private maps
+    end
+  end
+
+  feature 'setting and removing featured maps' do
+    context 'as an admin' do
+      before { login_as(admin, scope: :user) }
+      after { logout(admin) }
+
+      scenario 'adding feature a map' do
+        visit '/maps/all'
+        page_has_selector '.featured-map-star', count: 1
+        page.find('.not-featured-map-star').first(:xpath,".//..").click
+        successfully_visits_page '/maps/all'
+        page_has_selector '.featured-map-star', count: 2
+      end
+
+      scenario 'removing is featured from a map' do
+        visit '/maps/all'
+        page_has_selector '.featured-map-star', count: 1
+        page.find('.featured-map-star').first(:xpath,".//..").click
+        successfully_visits_page '/maps/all'
+        expect(page).not_to have_selector '.featured-map-star'
+      end
     end
   end
 end

--- a/spec/features/maps_spec.rb
+++ b/spec/features/maps_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+feature 'maps index page' do
+  let(:other_user) { create_really_basic_user }
+  let(:user) { create_really_basic_user }
+  let(:admin) { create_admin_user }
+  let(:regular_map) { create(:network_map, user_id: user.sf_guard_user_id) }
+  let(:private_map) { create(:network_map, is_private: true, user_id: user.sf_guard_user_id) }
+  let(:featured_map) { create(:network_map, is_featured: true, user_id: user.sf_guard_user_id) }
+  let!(:maps) { [regular_map, private_map, featured_map] }
+
+  feature 'navigating to "/maps"' do
+    before { visit '/maps' }
+    scenario 'redirecting to /maps/featured' do
+      successfully_visits_page '/maps/featured'
+    end
+  end
+
+  feature 'viewing all maps' do
+    before { visit '/maps/all'; }
+
+    scenario 'visiting /maps/all' do
+      successfully_visits_page '/maps/all'
+      page_has_selector '#maps-table'
+      page_has_selector '#maps-table tbody tr', count: 2 # skips private maps
+    end
+  end
+
+  feature 'viewing featured maps' do
+    before do
+      # create a featured, yet private map which should be exluded
+      create(:network_map, is_featured: true, is_private: true, user_id: user.sf_guard_user_id)
+      visit '/maps/featured'
+    end
+
+    scenario 'visiting /maps/featured' do
+      successfully_visits_page '/maps/featured'
+      page_has_selector '#maps-table'
+      page_has_selector '#maps-table tbody tr', count: 1 # only one featured map
+    end
+  end
+
+  feature 'admins cannot view private maps' do
+    before do
+      login_as(admin, scope: :user)
+      visit '/maps/all'
+    end
+    after { logout(admin) }
+
+    scenario 'visiting /maps/all as an admin' do
+      successfully_visits_page '/maps/all'
+      page_has_selector '#maps-table tbody tr', count: 2 # skips private maps
+    end
+  end
+
+  feature 'viewing private maps in list if logged in' do
+    before do
+      login_as(user, scope: :user)
+      # create a network map of a different
+      create(:network_map, is_private: true, user_id: create_really_basic_user.sf_guard_user_id)
+      visit '/maps/all'
+    end
+    after { logout(user) }
+
+    scenario 'visiting /maps/all' do
+      successfully_visits_page '/maps/all'
+      page_has_selector '#maps-table tbody tr', count: 3 # includes private maps
+    end
+  end
+end

--- a/spec/features/user_page_spec.rb
+++ b/spec/features/user_page_spec.rb
@@ -33,10 +33,12 @@ feature 'User Pages' do
       page_has_selector 'div.dashboard-entity', count: 1
       expect(page).not_to have_selector 'h3', text: 'Permissions'
       expect(page).not_to have_selector 'h3 small a', text: 'view all edits'
+      expect(page).not_to have_selector 'h3', text: 'Maps'
     end
 
     context 'logged in as the user' do
       let(:user) { user_for_page }
+
       scenario 'visiting your own user page' do
         visit "/users/#{user.id}"
         successfully_visits_page "/users/#{user.id}"
@@ -44,6 +46,20 @@ feature 'User Pages' do
         page_has_selector 'h3', text: 'Permissions'
         expect(page).to have_selector 'h3 small a', text: 'view all edits'
       end
+
+      context 'maps section' do
+        before do
+          create(:network_map, user_id: user_for_page.sf_guard_user_id)
+        end
+
+        scenario 'viewing maps section of the users page' do
+          visit "/users/#{user.id}"
+          successfully_visits_page "/users/#{user.id}"
+          page_has_selector 'h3', text: 'Maps'
+        end
+        
+      end
+      
     end
 
     context 'user is restricted' do

--- a/spec/presenters/user_presenter_spec.rb
+++ b/spec/presenters/user_presenter_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe UserPresenter do
+  describe 'show_private?' do
+    let(:user) { create(:really_basic_user) }
+    let(:current_user) { create(:really_basic_user) }
+    let(:admin_user) { create(:admin_user) }
+
+    context 'as same user' do
+      specify do
+        expect(UserPresenter.new(user, current_user: user).show_private?).to be true
+      end
+    end
+
+    context 'as another user' do
+      specify do
+        expect(UserPresenter.new(user, current_user: current_user).show_private?).to be false
+      end
+    end
+
+    context 'as admin' do
+      specify do
+        expect(UserPresenter.new(user, current_user: admin_user).show_private?).to be true
+      end
+    end
+
+    context 'current_user is nil' do
+      specify do
+        expect(UserPresenter.new(user).show_private?).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/maps_spec.rb
+++ b/spec/requests/maps_spec.rb
@@ -1,42 +1,53 @@
 require 'rails_helper'
 
 describe 'Maps', :sphinx, type: :request do
-  before(:all) do
-    setup_sphinx 'entity_core' do
-      @apple_corp = create(:entity_org, name: 'apple corp')
-      @banana_corp = create(:entity_org, name: 'banana! corp')
+  describe 'featuring maps' do
+    as_basic_user do
+      let(:map) { create(:network_map, user_id: SfGuardUser.last.id) }
+      let(:url) { Rails.application.routes.url_helpers.feature_map_path(map) }
+      before { post url, params: { action: 'ADD' } }
+      denies_access
     end
   end
 
-  after(:all) do
-    teardown_sphinx { delete_entity_tables }
-  end
-
-  describe 'find nodes' do
-    describe 'missing param q' do
-      before { get '/maps/find_nodes' }
-      specify { expect(response).to have_http_status 400 }
-    end
-
-    describe 'searching for "apple"' do
-      before { get '/maps/find_nodes', params: { q: 'apple' } }
-
-      it 'finds one entity and returns search results as json' do
-        expect(response).to have_http_status 200
-        expect(json.length).to eql(1)
-        expect(ActiveSupport::HashWithIndifferentAccess.new(json.first))
-          .to eql ActiveSupport::HashWithIndifferentAccess.new(Oligrapher.entity_to_node(@apple_corp))
+  describe 'oligrapher search api' do
+    before(:all) do
+      setup_sphinx 'entity_core' do
+        @apple_corp = create(:entity_org, name: 'apple corp')
+        @banana_corp = create(:entity_org, name: 'banana! corp')
       end
     end
 
-    describe 'searching for "banana!"' do
-      before { get '/maps/find_nodes', params: { q: 'banana!' } }
+    after(:all) do
+      teardown_sphinx { delete_entity_tables }
+    end
 
-      it 'finds one entity and returns search results as json' do
-        expect(response).to have_http_status 200
-        expect(json.length).to eql(1)
-        expect(ActiveSupport::HashWithIndifferentAccess.new(json.first))
-          .to eql ActiveSupport::HashWithIndifferentAccess.new(Oligrapher.entity_to_node(@banana_corp))
+    describe 'find nodes' do
+      describe 'missing param q' do
+        before { get '/maps/find_nodes' }
+        specify { expect(response).to have_http_status 400 }
+      end
+
+      describe 'searching for "apple"' do
+        before { get '/maps/find_nodes', params: { q: 'apple' } }
+
+        it 'finds one entity and returns search results as json' do
+          expect(response).to have_http_status 200
+          expect(json.length).to eql(1)
+          expect(ActiveSupport::HashWithIndifferentAccess.new(json.first))
+            .to eql ActiveSupport::HashWithIndifferentAccess.new(Oligrapher.entity_to_node(@apple_corp))
+        end
+      end
+
+      describe 'searching for "banana!"' do
+        before { get '/maps/find_nodes', params: { q: 'banana!' } }
+
+        it 'finds one entity and returns search results as json' do
+          expect(response).to have_http_status 200
+          expect(json.length).to eql(1)
+          expect(ActiveSupport::HashWithIndifferentAccess.new(json.first))
+            .to eql ActiveSupport::HashWithIndifferentAccess.new(Oligrapher.entity_to_node(@banana_corp))
+        end
       end
     end
   end

--- a/spec/support/request_macros.rb
+++ b/spec/support/request_macros.rb
@@ -5,6 +5,15 @@ module RequestExampleMacros
 end
 
 module RequestGroupMacros
+  def as_basic_user
+    let(:basic_user) { create_really_basic_user }
+    before(:each) { login_as(basic_user, :scope => :user) }
+    context 'when logged in as a basic user' do
+      yield
+    end
+    after(:each) { logout(:user) }
+  end
+
   def denies_access
     it 'denies access' do
       expect(response).to have_http_status(403)


### PR DESCRIPTION
This changes how featured maps are handled. only admins can feature/unfeature a map. They do so by click a star on the maps index page.

changes:

#### explore maps defaults to featured

going to */maps* now redirects to */maps/featured*

to view all maps you can either click the button 'All' or go to /maps/all

Private maps are now hidden from admins

#### There is a "maps" section on user pages:

![maps_on_user_page](https://user-images.githubusercontent.com/8505044/37306456-2b589da2-260e-11e8-888a-0172034a5798.png)


#### stars let admin feature a map

![map_stars_on_map_index_page](https://user-images.githubusercontent.com/8505044/37306558-757206ee-260e-11e8-86c7-700c09681fad.png)



closes #540 
closes #541 
closes #543 