### PR TITLE
Update cmp org importer, determine if found entities can be automatched, add cmp people rake tasks

### DIFF
--- a/app/models/cmp_entity.rb
+++ b/app/models/cmp_entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CmpEntity < ApplicationRecord
   belongs_to :entity
   enum entity_type: [:org, :person]

--- a/app/utility/entity_matcher.rb
+++ b/app/utility/entity_matcher.rb
@@ -6,6 +6,7 @@ require_relative 'entity_matcher/evaluation_result'
 require_relative 'entity_matcher/evaluation'
 
 module EntityMatcher
+  # String, kwargs --> Array[EvaluateResult]
   def self.find_matches_for_person(name, **kwargs)
     test_case = TestCase::Person.new(name, **kwargs)
 
@@ -17,6 +18,7 @@ module EntityMatcher
     ).to_a
   end
 
+  # String, kwargs --> Array[EvaluateResult]
   def self.find_matches_for_org(name, **kwargs)
     test_case = TestCase::Org.new(name, **kwargs)
 

--- a/app/utility/entity_matcher/evaluation_result.rb
+++ b/app/utility/entity_matcher/evaluation_result.rb
@@ -85,6 +85,11 @@ module EntityMatcher
       attr_accessor :entity
       include Comparable
 
+      # Determines if the current match has enough critera to be automatched
+      def automatch?
+        raise NotImplementedError
+      end
+
       # by comparinng #values, we can ignore the attributes, entity, when testing for equality
       def eql?(other)
         (self.class == other.class) && (self.values == other.values)
@@ -141,9 +146,11 @@ module EntityMatcher
       TIER1 = [
         compute_name_sets(:same_last_name, :same_first_name, :common_relationship, :blurb_keyword),
         compute_name_sets(:same_last_name, :same_first_name, :common_relationship),
-        compute_name_sets(:same_last_name, :same_first_name, :blurb_keyword),
+
         compute_name_sets(:same_last_name, :similar_first_name, :common_relationship, :blurb_keyword),
         compute_name_sets(:same_last_name, :similar_first_name, :common_relationship),
+
+        compute_name_sets(:same_last_name, :same_first_name, :blurb_keyword),
         compute_name_sets(:same_last_name, :similar_first_name, :blurb_keyword),
         compute_name_sets(:same_last_name, :same_first_name),
         compute_name_sets(:same_last_name, :similar_first_name)
@@ -182,6 +189,10 @@ module EntityMatcher
 
       RANKINGS = (TIER1 + TIER2 + TIER3 + TIER4).freeze
 
+      AUTOMATCH_MINIMUM_SET = Set[:same_last_name, :similar_first_name, :common_relationship].freeze
+      AUTOMATCH_MINIMUM_RANK = RANKINGS.rindex { |s| s == AUTOMATCH_MINIMUM_SET }
+
+      # same_last_name, :similar_first_name, :common_relationship
       # Lower values are "better" matchers here
       def <=>(other)
         ##
@@ -201,6 +212,10 @@ module EntityMatcher
 
         # return 0 if self == other
         self.ranking <=> other.ranking
+      end
+
+      def automatch?
+        ranking <= AUTOMATCH_MINIMUM_RANK
       end
 
       def tier_one?
@@ -248,8 +263,15 @@ module EntityMatcher
         Set[:similar_root]
       ].flatten.freeze
 
+      AUTOMATCH_MINIMUM_SET = Set[:matches_alias].freeze
+      AUTOMATCH_MINIMUM_RANK = RANKINGS.rindex { |s| s == AUTOMATCH_MINIMUM_SET }
+
       def <=>(other)
         self.ranking <=> other.ranking
+      end
+
+      def automatch?
+        ranking <= AUTOMATCH_MINIMUM_RANK
       end
     end
   end

--- a/app/utility/entity_matcher/evaluation_result_set.rb
+++ b/app/utility/entity_matcher/evaluation_result_set.rb
@@ -18,6 +18,14 @@ module EntityMatcher
       @results
     end
 
+    # In order for the set to be considered automatachable
+    # the set must contain only one result that can be automatched.
+    # If there are two (or more) results, then there is no way to know which
+    # one is better without human intervention
+    def automatchable?
+      @results&.first&.automatch? && !@results&.second&.automatch?
+    end
+
     private
 
     def check_argument(evaluation_results)

--- a/app/utility/entity_matcher/search.rb
+++ b/app/utility/entity_matcher/search.rb
@@ -3,7 +3,7 @@
 module EntityMatcher
   module Search
     SEARCH_OPTS = {
-      :per_page => 500,
+      :per_page => 800,
       :ranker => :none,
       :populate => true,
       :with => { is_deleted: false }

--- a/app/utility/entity_matcher/search.rb
+++ b/app/utility/entity_matcher/search.rb
@@ -6,7 +6,6 @@ module EntityMatcher
       :per_page => 500,
       :ranker => :none,
       :populate => true,
-      :sql => { include: :links },
       :with => { is_deleted: false }
     }.freeze
 
@@ -33,9 +32,22 @@ module EntityMatcher
     # Search database for potential matches
     def self.search(query, primary_ext:)
       Entity.search("@(name,aliases,name_nick) ( #{query} )",
-                    SEARCH_OPTS.deep_merge(:with => { primary_ext: primary_ext }))
+                    SEARCH_OPTS
+                      .deep_merge(:sql => sql_include(primary_ext))
+                      .deep_merge(:with => { primary_ext: primary_ext }))
     end
 
-    private_class_method :search
+    def self.sql_include(primary_ext)
+      case primary_ext
+      when 'Person'
+        { :include => [:links, :person] }
+      when 'Org'
+        { :include => [:links, :org, :aliases] }
+      else
+        raise TypeError
+      end
+    end
+
+    private_class_method :search, :sql_include
   end
 end

--- a/app/utility/entity_matcher/search.rb
+++ b/app/utility/entity_matcher/search.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module EntityMatcher
   module Search
     SEARCH_OPTS = {
-      :per_page => 200,
+      :per_page => 500,
       :ranker => :none,
       :populate => true,
       :sql => { include: :links },

--- a/app/utility/entity_matcher/test_case.rb
+++ b/app/utility/entity_matcher/test_case.rb
@@ -55,6 +55,10 @@ module EntityMatcher
     end
 
     class Person < Base
+      def self.validate_person_hash(h)
+        (h[:name_first] || h['name_first']) && (h[:name_last] || h['name_last'])
+      end
+
       BLANK_NAME_HASH = ActiveSupport::HashWithIndifferentAccess
                           .new(name_prefix: nil,
                                name_first: nil,
@@ -93,8 +97,8 @@ module EntityMatcher
       private
 
       def validate_input_hash(h)
-        unless (h[:name_first] || h['name_first']) && (h[:name_last] || h['name_last'])
-          raise InvalidPersonHash
+        unless self.class.validate_person_hash(h)
+          raise InvalidPersonHash, "Invalid Hash: #{h.inspect}"
         end
       end
     end

--- a/app/utility/org_name.rb
+++ b/app/utility/org_name.rb
@@ -24,6 +24,7 @@ module OrgName
     "LP",
     "PLC",
     "PA",
+    "SA",
     "Chtd",
     "GMBH",
     "Chartered",
@@ -51,6 +52,9 @@ module OrgName
     "Systems",
     "Group"
   ].freeze
+
+  SUFFIX_ACRONYMS = %w[LLP LLC LP PLC PA SA].freeze
+  SUFFIX_ACRONYMS_REGEX = Regexp.new "(?<=[ ])(#{SUFFIX_ACRONYMS.join('|')})$", Regexp::IGNORECASE
 
   SUFFIX_REGEX = Regexp.new "(?<=[ ])(#{COMMON_SUFFIXES.join('|')})(?:[,\.]*)$", Regexp::IGNORECASE
 
@@ -91,6 +95,16 @@ module OrgName
   ALL_COMMON_WORDS = (GRAMMAR_WORDS + COMMON_SUFFIXES + COMMON_WORDS).map(&:downcase).to_set
 
   Name = Struct.new(:original, :clean, :root, :suffix, :essential_words)
+
+  # String ---> String
+  def self.format(name)
+    name
+      .split(' ')
+      .map(&:capitalize)
+      .join(' ')
+      .gsub(/\w{3,}-\w{3,}/) { |x| x.split('-').map(&:capitalize).join('-') }
+      .gsub(SUFFIX_ACRONYMS_REGEX) { |x| x.upcase }
+  end
 
   # String ---> OrgName::Name
   def self.parse(name)

--- a/data/cmp_matches.yml
+++ b/data/cmp_matches.yml
@@ -119,6 +119,29 @@
   name: RENAULT
   cmpid: 5014957
   entity_id: 217475
-  
+-
+  name: BOEING COMPANY (THE)
+  cmpid: 5003068
+  entity_id: 27
+-
+  name: DOW CHEMICAL COMPANY (THE)
+  cmpid: 5003071
+  entity_id: 19192
+-
+  name: AIRBUS GROUP SE
+  cmpid: 5003085
+  entity_id: 261779
+-
+  name: LVMH MOET HENNESSY - LOUIS VUITTON SE
+  cmpid: 5003191
+  entity_id: 112999
+-
+  name: EXXONMOBIL PETROLEUM & CHEMICAL
+  cmpid: 5003195
+  entity_id: 111585
+-
+  name: COCA-COLA
+  cmpid: 5003260
+  entity_id: 84
 
   

--- a/lib/cmp.rb
+++ b/lib/cmp.rb
@@ -17,35 +17,8 @@ module Cmp
   CMP_SF_USER_ID = 8178
   CMP_TAG_ID = 11
 
-  ORG_FILE_PATH = Rails.root.join('data', 'CMPDatabase2_Organizations_2015-2016.xlsx').to_s
-  ORG_OUT_CSV_PATH = Rails.root.join('data', "cmp-orgs-#{Time.current.strftime('%F')}.csv").to_s
-
-  RELATIONSHIP_FILE_PATH = Rails.root.join('data', 'affiliations', 'affiliations.csv').to_s
-
-  def self.affliations
-    RelationshipSheet.new(RELATIONSHIP_FILE_PATH).to_a
-  end
-
-  def self.save_org_csv
-    Query.save_hash_array_to_csv ORG_OUT_CSV_PATH, orgs.map(&:to_h)
-  end
-
-  def self.save_person_csv
-    Query.save_hash_array_to_csv PERSON_OUT_CSV_PATH, people.map(&:to_h)
-  end
-
-  # -> [CmpOrg]
-  def self.orgs(file_path = ORG_FILE_PATH)
-    OrgSheet.new(file_path).to_a.map { |attrs| CmpOrg.new(attrs) }
-  end
-
   def self.import_orgs
-    orgs.each(&:import!)
-  end
-
-  # -> [CmpPerson]
-  def self.people(file_path = PERSON_FILE_PATH)
-    PersonSheet.new(file_path).to_a.map { |attrs| CmpPerson.new(attrs) }
+    Cmp::Datasets.orgs.each(&:import!)
   end
 
   def self.set_whodunnit

--- a/lib/cmp.rb
+++ b/lib/cmp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csv'
 require_relative 'cmp/excel_sheet'
 require_relative 'cmp/org_sheet'
@@ -13,6 +15,7 @@ require_relative 'cmp/datasets'
 module Cmp
   CMP_USER_ID = 1
   CMP_SF_USER_ID = 1
+  CMP_TAG_ID = 11
 
   ORG_FILE_PATH = Rails.root.join('data', 'CMPDatabase2_Organizations_2015-2016.xlsx').to_s
   ORG_OUT_CSV_PATH = Rails.root.join('data', "cmp-orgs-#{Time.current.strftime('%F')}.csv").to_s

--- a/lib/cmp.rb
+++ b/lib/cmp.rb
@@ -13,8 +13,8 @@ require_relative 'cmp/cmp_person'
 require_relative 'cmp/datasets'
 
 module Cmp
-  CMP_USER_ID = 1
-  CMP_SF_USER_ID = 1
+  CMP_USER_ID = 9948
+  CMP_SF_USER_ID = 8178
   CMP_TAG_ID = 11
 
   ORG_FILE_PATH = Rails.root.join('data', 'CMPDatabase2_Organizations_2015-2016.xlsx').to_s
@@ -46,5 +46,9 @@ module Cmp
   # -> [CmpPerson]
   def self.people(file_path = PERSON_FILE_PATH)
     PersonSheet.new(file_path).to_a.map { |attrs| CmpPerson.new(attrs) }
+  end
+
+  def self.set_whodunnit
+    PaperTrail.whodunnit(CMP_USER_ID.to_s) { yield }
   end
 end

--- a/lib/cmp/cmp_entity_importer.rb
+++ b/lib/cmp/cmp_entity_importer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cmp
   class CmpEntityImporter
     attr_reader :attributes
@@ -30,6 +32,5 @@ module Cmp
       e_path = Rails.application.routes.url_helpers.entity_path(entity).gsub('entities', primary_ext)
       "https://littlesis.org#{e_path}"
     end
-
   end
 end

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -44,7 +44,9 @@ module Cmp
           entity.org.update! attrs_for(:org)
           import_address(entity)
           import_ticker(entity)
-          entity.update_columns(last_user_id: Cmp::CMP_SF_USER_ID)
+          if entity.last_user_id != Cmp::CMP_SF_USER_ID
+            entity.update_columns(last_user_id: Cmp::CMP_SF_USER_ID)
+          end
         end
       end
     end

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -106,7 +106,7 @@ module Cmp
     def create_new_entity!
       Entity.create!(
         primary_ext: 'Org',
-        name: attributes[:cmpname],
+        name: OrgName.format(attributes[:cmpname]),
         last_user_id: Cmp::CMP_USER_ID
       )
     end

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -31,16 +31,19 @@ module Cmp
     end
 
     def import!
-      ApplicationRecord.transaction do
-        entity = find_or_create_entity
-        return if entity.nil?
-        create_cmp_entity(entity)
-        entity.update! attrs_for(:entity).with_last_user(CMP_SF_USER_ID)
-        add_extension(entity)
-        entity.add_tag(Cmp::CMP_TAG_ID)
-        entity.org.update! attrs_for(:org)
-        import_address(entity)
-        import_ticker(entity)
+      Cmp.set_whodunnit do
+        ApplicationRecord.transaction do
+          entity = find_or_create_entity
+          return if entity.nil?
+          create_cmp_entity(entity)
+          entity.update! attrs_for(:entity).with_last_user(Cmp::CMP_SF_USER_ID)
+          add_extension(entity)
+          entity.add_tag(Cmp::CMP_TAG_ID)
+          entity.org.update! attrs_for(:org)
+          import_address(entity)
+          import_ticker(entity)
+          entity.update_columns(last_user_id: Cmp::CMP_SF_USER_ID)
+        end
       end
     end
 
@@ -109,7 +112,7 @@ module Cmp
       Entity.create!(
         primary_ext: 'Org',
         name: OrgName.format(attributes[:cmpname]),
-        last_user_id: Cmp::CMP_USER_ID
+        last_user_id: Cmp::CMP_SF_USER_ID
       )
     end
   end

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -51,7 +51,11 @@ module Cmp
       if CmpEntity.find_by(cmp_id: cmpid)
         CmpEntity.find_by(cmp_id: cmpid).entity
       elsif preselected_match
-        Entity.find(preselected_match)
+        if preselected_match.to_s.casecmp('NEW').zero?
+          create_new_entity!
+        else
+          Entity.find(preselected_match)
+        end
       elsif entity_match
         if CmpEntity.find_by(entity_id: entity_match.id).present?
           Rails.logger.warn <<~ERROR

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -44,7 +44,7 @@ module Cmp
           entity.org.update! attrs_for(:org)
           import_address(entity)
           import_ticker(entity)
-          if entity.last_user_id != Cmp::CMP_SF_USER_ID
+          unless entity.reload.last_user_id == Cmp::CMP_SF_USER_ID
             entity.update_columns(last_user_id: Cmp::CMP_SF_USER_ID)
           end
         end

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -75,7 +75,7 @@ module Cmp
 
     def find_entity_match
       matches = EntityMatcher.find_matches_for_org(fetch(:cmpname))
-      return matches.first if matches&.first&.automatch?
+      return matches.first.entity if matches&.first&.automatch?
     end
 
     # Modifies fields as needed from CMP

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -44,6 +44,7 @@ module Cmp
         create_cmp_entity(entity)
         entity.update! attrs_for(:entity).with_last_user(CMP_SF_USER_ID)
         add_extension(entity)
+        entity.add_tag(Cmp::CMP_TAG_ID)
         entity.org.update! attrs_for(:org)
         import_address(entity)
         import_ticker(entity)

--- a/lib/cmp/cmp_org.rb
+++ b/lib/cmp/cmp_org.rb
@@ -31,6 +31,8 @@ module Cmp
     end
 
     def import!
+      Rails.logger.debug "Importing: #{cmpid}"
+
       Cmp.set_whodunnit do
         ApplicationRecord.transaction do
           entity = find_or_create_entity

--- a/lib/cmp/cmp_person.rb
+++ b/lib/cmp/cmp_person.rb
@@ -26,7 +26,19 @@ module Cmp
 
     def matches
       EntityMatcher
-        .find_matches_for_person(to_person_hash, associated: associated_entity_ids)
+        .find_matches_for_person(search_name_or_hash, associated: associated_entity_ids)
+    end
+
+    def search_name_or_hash
+      if EntityMatcher::TestCase::Person.validate_person_hash(to_person_hash)
+        to_person_hash
+      elsif fetch("lastname").present?
+        Rails.logger.debug "searching using last name #{fetch('lastname')} for #{cmpid}"
+        fetch("lastname")
+      else
+        Rails.logger.warn "invalid search for #{cmpid}"
+        raise StandardError, "Cannot find name to search for matches"
+      end
     end
 
     def to_person_hash

--- a/lib/cmp/cmp_person.rb
+++ b/lib/cmp/cmp_person.rb
@@ -6,6 +6,11 @@ module Cmp
       fullname: [:entity, :name]
     }.freeze
 
+    def import!
+    end
+
+    # utilites to find matches
+
     def cmp_relationships
       @cmp_relationships ||= Cmp::Datasets
                                .relationships
@@ -25,20 +30,13 @@ module Cmp
     end
 
     def matches
-      EntityMatcher
-        .find_matches_for_person(search_name_or_hash, associated: associated_entity_ids)
-    end
-
-    def search_name_or_hash
-      if EntityMatcher::TestCase::Person.validate_person_hash(to_person_hash)
-        to_person_hash
-      elsif fetch("lastname").present?
-        Rails.logger.debug "searching using last name #{fetch('lastname')} for #{cmpid}"
-        fetch("lastname")
-      else
-        Rails.logger.warn "invalid search for #{cmpid}"
-        raise StandardError, "Cannot find name to search for matches"
+      unless EntityMatcher::TestCase::Person.validate_person_hash(to_person_hash)
+        Rails.logger.warn "#{cmpid} is missing a first or last name!"
+        return EntityMatcher::EvaluationResultSet.new([])
       end
+
+      EntityMatcher
+        .find_matches_for_person(to_person_hash, associated: associated_entity_ids)
     end
 
     def to_person_hash

--- a/lib/cmp/cmp_person.rb
+++ b/lib/cmp/cmp_person.rb
@@ -6,12 +6,27 @@ module Cmp
       fullname: [:entity, :name]
     }.freeze
 
-    def attributes_with_matches
-      attributes.merge(
-        Array.new(2) { |n| potential_matches[n] }
-          .map.with_index(1) { |entity, n| format_match(entity, n) }
-          .each_with_object({}) { |match, obj| obj.merge!(match) }
-      )
+    def cmp_relationships
+      @cmp_relationships ||= Cmp::Datasets
+                               .relationships
+                               .select { |r| r['cmp_person_id'] == cmpid }
+    end
+
+    def related_cmp_org_ids
+      cmp_relationships.map { |r| r['cmp_org_id'].to_i }
+    end
+
+    def associated_entity_ids
+      return [] if related_cmp_org_ids.empty?
+      CmpEntity
+        .where(cmp_id: related_cmp_org_ids)
+        .distinct
+        .pluck('entity_id')
+    end
+
+    def matches
+      EntityMatcher
+        .find_matches_for_person(to_person_hash, associated: associated_entity_ids)
     end
 
     def to_person_hash
@@ -21,46 +36,6 @@ module Cmp
         name_middle: fetch("middlename"),
         name_last: fetch("lastname"),
         name_suffix: fetch("suffix")
-      }
-    end
-
-    def associated_entities
-      CmpEntity
-        .where(cmp_id: Cmp::Datasets.relationships
-                 .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == fetch(:cmpid, "ATTR_ID") }
-                 .map { |r| r.fetch(:cmp_org_id) })
-        .map(&:entity)
-    end
-
-    def potential_matches
-      EntityMatcher::Search.by_name(fetch('lastname')).map do |entity|
-        test_case = EntityMatcher::TestCase::Person
-                      .new(to_person_hash, associated: associated_entities)
-
-        match = EntityMatcher::TestCase::Person.new(entity)
-        EntityMatcher.evaluate(test_case, match)
-      end
-    end
-
-    # def potential_matches
-    #   @_potential_matches ||=
-    #     EntityMatch.new(name: entity_name, primary_ext: 'Person', cmpid: cmpid).search_results
-    # end
-
-    private
-
-    def entity_name
-      name = "#{fetch(:firstname)} "
-      name << "#{fetch(:middlename)} " if fetch(:middlename, nil).present?
-      name << fetch(:lastname)
-      name
-    end
-
-    def format_match(entity, n)
-      {
-        "match#{n}_name" => entity.present? ? "#{entity.name} (#{entity.id})" : '',
-        "match#{n}_blurb" => entity&.blurb,
-        "match#{n}_url" => entity.present? ? entity_url(entity) : ''
       }
     end
   end

--- a/lib/cmp/cmp_relationship.rb
+++ b/lib/cmp/cmp_relationship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @relationships = [ relationship ]
 # @person = {
 #     'cmpid' -> `cmp_person`
@@ -25,7 +27,7 @@
 module Cmp
   class CmpRelationship
     attr_reader :attributes
-    delegate :fetch, to: :attributes
+    delegate :[], :fetch, to: :attributes
 
     def initialize(attrs)
       @attributes = LsHash.new(attrs)

--- a/lib/cmp/datasets.rb
+++ b/lib/cmp/datasets.rb
@@ -3,7 +3,7 @@ module Cmp
     RELATIONSHIP_FILE_PATH = Rails.root.join('data', 'affiliations', 'affiliations.csv').to_s
     PERSON_FILE_PATH = Rails.root.join('data', 'CMP_Individuals.csv').to_s
     ORG_FILE_PATH = Rails.root.join('data', 'CMPDatabase2_Organizations_2015-2016.xlsx').to_s
-    
+
     %I[people relationships orgs].each do |dataset_name|
       define_singleton_method(dataset_name) { dataset(dataset_name) }
     end
@@ -37,7 +37,5 @@ module Cmp
     private_class_method def self.load_orgs
       OrgSheet.new(ORG_FILE_PATH).to_a.map { |attrs| CmpOrg.new(attrs) }
     end
-
-    
   end
 end

--- a/lib/cmp/datasets.rb
+++ b/lib/cmp/datasets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cmp
   module Datasets
     RELATIONSHIP_FILE_PATH = Rails.root.join('data', 'affiliations', 'affiliations.csv').to_s

--- a/lib/cmp/entity_match.rb
+++ b/lib/cmp/entity_match.rb
@@ -9,52 +9,5 @@ module Cmp
         memo.store(h['cmpid'].to_s, h)
       end
     end
-
-    # delegate :count, :empty?, :to => :search_results
-    # delegate :matches, :to => :class
-
-    # def initialize(name:, primary_ext:, cmpid:)
-    #   raise ArgumentError, "Invalid primary_ext" unless %w[Org Person].include? primary_ext
-    #   @name = name
-    #   @primary_ext = primary_ext
-    #   @search_options = { :with => { primary_ext: "'#{primary_ext}'", is_deleted: false } }.freeze
-    #   @cmpid = cmpid.to_s
-    #   search_results
-    # end
-
-    # def match
-    #   return nil unless has_match?
-    #   if matches.key?(@cmpid)
-    #     entity_id = self.class.matches.dig(@cmpid, 'entity_id')
-    #     return create_new_entity if entity_id == 'NEW'
-    #     return Entity.find(entity_id)
-    #   end
-    #   return first
-    # end
-
-    # def first
-    #   search_results.first unless empty?
-    # end
-
-    # def second
-    #   search_results.second unless count < 2
-    # end
-
-    # def has_match? # rubocop:disable PredicateName
-    #   matches.key?(@cmpid) || search_results.present?
-    # end
-
-    # def search_results
-    #   return @search_results if defined? @search_results
-    #   @search_results = Entity::Search.search(@name, @search_options)
-    # end
-
-
-
-    # private
-
-    # def create_new_entity
-    #   Entity.create!(name: @name, primary_ext: @primary_ext, last_user_id: Cmp::CMP_SF_USER_ID)
-    # end
   end
 end

--- a/lib/cmp/entity_match.rb
+++ b/lib/cmp/entity_match.rb
@@ -3,55 +3,58 @@
 module Cmp
   class EntityMatch
     MATCHES = YAML.load_file(Rails.root.join('data', 'cmp_matches.yml'))
-    delegate :count, :empty?, :to => :search_results
-    delegate :matches, :to => :class
-
-    def initialize(name:, primary_ext:, cmpid:)
-      raise ArgumentError, "Invalid primary_ext" unless %w[Org Person].include? primary_ext
-      @name = name
-      @primary_ext = primary_ext
-      @search_options = { :with => { primary_ext: "'#{primary_ext}'", is_deleted: false } }.freeze
-      @cmpid = cmpid.to_s
-      search_results
-    end
-
-    def match
-      return nil unless has_match?
-      if matches.key?(@cmpid)
-        entity_id = self.class.matches.dig(@cmpid, 'entity_id')
-        return create_new_entity if entity_id == 'NEW'
-        return Entity.find(entity_id)
-      end
-      return first
-    end
-
-    def first
-      search_results.first unless empty?
-    end
-
-    def second
-      search_results.second unless count < 2
-    end
-
-    def has_match? # rubocop:disable PredicateName
-      matches.key?(@cmpid) || search_results.present?
-    end
-
-    def search_results
-      return @search_results if defined? @search_results
-      @search_results = Entity::Search.search(@name, @search_options)
-    end
 
     def self.matches
-      @_matches ||= MATCHES.each_with_object({}) do |h, memo|
+      @matches ||= MATCHES.each_with_object({}) do |h, memo|
         memo.store(h['cmpid'].to_s, h)
       end
     end
 
-    private
+    # delegate :count, :empty?, :to => :search_results
+    # delegate :matches, :to => :class
 
-    def create_new_entity
-      Entity.create!(name: @name, primary_ext: @primary_ext, last_user_id: Cmp::CMP_SF_USER_ID)
-    end
+    # def initialize(name:, primary_ext:, cmpid:)
+    #   raise ArgumentError, "Invalid primary_ext" unless %w[Org Person].include? primary_ext
+    #   @name = name
+    #   @primary_ext = primary_ext
+    #   @search_options = { :with => { primary_ext: "'#{primary_ext}'", is_deleted: false } }.freeze
+    #   @cmpid = cmpid.to_s
+    #   search_results
+    # end
+
+    # def match
+    #   return nil unless has_match?
+    #   if matches.key?(@cmpid)
+    #     entity_id = self.class.matches.dig(@cmpid, 'entity_id')
+    #     return create_new_entity if entity_id == 'NEW'
+    #     return Entity.find(entity_id)
+    #   end
+    #   return first
+    # end
+
+    # def first
+    #   search_results.first unless empty?
+    # end
+
+    # def second
+    #   search_results.second unless count < 2
+    # end
+
+    # def has_match? # rubocop:disable PredicateName
+    #   matches.key?(@cmpid) || search_results.present?
+    # end
+
+    # def search_results
+    #   return @search_results if defined? @search_results
+    #   @search_results = Entity::Search.search(@name, @search_options)
+    # end
+
+
+
+    # private
+
+    # def create_new_entity
+    #   Entity.create!(name: @name, primary_ext: @primary_ext, last_user_id: Cmp::CMP_SF_USER_ID)
+    # end
   end
 end

--- a/lib/query.rb
+++ b/lib/query.rb
@@ -1,8 +1,8 @@
 require 'csv'
 
 module Query
-  def self.save_hash_array_to_csv(file_path, data)
-    CSV.open(file_path, "wb") do |csv|
+  def self.save_hash_array_to_csv(file_path, data, mode: 'wb')
+    CSV.open(file_path, mode) do |csv|
       csv << data.first.keys
       data.each { |hash| csv << hash.values }
     end

--- a/lib/tasks/cmp.rake
+++ b/lib/tasks/cmp.rake
@@ -13,7 +13,7 @@ namespace :cmp do
         match2_name: nil, match2_id: nil, match2_values: nil
       }
 
-      sheet = Cmp.orgs.map do |cmp_org|
+      sheet = Cmp::Datsets.orgs.map do |cmp_org|
         attrs = cmp_org.attributes.merge(blank_match_values)
 
         EntityMatcher
@@ -41,29 +41,29 @@ namespace :cmp do
   end
 
   namespace :people do
-    desc 'save individuals with potential match information as csvs'
-    task matches_as_csv: :environment do
-      Cmp::Datasets.people
-      Cmp::Datasets.relationships
-      Cmp::Datasets.orgs
+    desc 'saves spreadsheet of people matches'
+    task save_people_matches: :environment do
+      file_path = Rails.root
+                    .join('data', "cmp_people_matched_#{Time.current.strftime('%F')}.csv").to_s
 
-      file_path = Rails.root.join('data', 'cmp_individuals_with_match_info.csv').to_s
+      blank_match_values = {
+        match1_name: nil, match1_id: nil, match1_values: nil,
+        match2_name: nil, match2_id: nil, match2_values: nil
+      }
 
-      people = Cmp::Datasets.people.values.map do |cmp_person|
-        attrs = LsHash.new(littlesis_entity_id: '').merge!(cmp_person.attributes)
+      sheet = Cmp::Datasets.people.to_a.map(&:second).map do |cmp_person|
+        attrs = cmp_person.attributes.merge(blank_match_values)
 
-        # attrs['littlesis_entity_id'] = 'new' if attrs['match1_name'].blank?
-
-        associated = CmpEntity
-                       .where(cmp_id:Cmp::Datasets.relationships
-                                .select { |r| r.fetch(:cmp_person_id, 'REL_ID') == attrs.fetch(:cmpid, "ATTR_ID") }
-                                .map { |r| r.fetch(:cmp_org_id) })
-                       .map(&:entity)
-
-        attrs.merge!('associated_corps' => org_names)
+        cmp_person.matches.first(2).each.with_index do |match, idx|
+          attrs["match#{idx + 1}_name".to_sym] = match.entity.name
+          attrs["match#{idx + 1}_id".to_sym] = match.entity.id
+          attrs["match#{idx + 1}_values".to_sym] = match.values.to_a.join('|')
+        end
+        attrs
       end
 
-      Query.save_hash_array_to_csv file_path, people
+      Query.save_hash_array_to_csv file_path, sheet
+      puts "Saved people to: #{file_path}"
     end
   end
 end

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -17,6 +17,15 @@ describe Cmp::CmpOrg do
 
   subject { Cmp::CmpOrg.new(attributes.merge(override)) }
 
+  before(:all) do
+    @cmp_tag = Tag.create!("id" => Cmp::CMP_TAG_ID,
+                           "restricted" => true,
+                           "name" => "cmp",
+                           "description" => "Data from the Corporate Mapping Project")
+  end
+
+  after(:all) { @cmp_tag.delete }
+
   describe 'import!' do
     context 'Entity is not already in the database' do
       before do
@@ -46,6 +55,11 @@ describe Cmp::CmpOrg do
 
       it 'creates an extension' do
         expect { subject.import! }.to change { Business.count }.by(1)
+      end
+
+      it 'adds CMP tag' do
+        expect { subject.import! }.to change { Tagging.count }.by(1)
+        expect(Entity.last.tags.last).to eql @cmp_tag
       end
 
       context 'entity is a research institute' do

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -68,7 +68,7 @@ describe Cmp::CmpOrg do
 
       it 'sets last user id to cmp sf user' do
         subject.import!
-        expect(Entity.last.last_user_id).to eql @cmp_user.sf_guard_user_id
+        expect(CmpEntity.last.entity.last_user_id).to eql Cmp::CMP_SF_USER_ID
       end
 
       context 'entity is a research institute' do
@@ -157,8 +157,6 @@ describe Cmp::CmpOrg do
     end
 
     describe 'records history attributed to the CMP USER' do
-      let(:user) { create_basic_user }
-
       with_versioning do
         before do
           expect(subject).to receive(:entity_match).and_return(nil)

--- a/spec/lib/cmp_org_spec.rb
+++ b/spec/lib/cmp_org_spec.rb
@@ -191,7 +191,7 @@ describe Cmp::CmpOrg do
       end
       it 'creates a new entity' do
         expect { subject.find_or_create_entity }.to change { Entity.count }.by(1)
-        expect(Entity.last.name).to eql attributes[:cmpname]
+        expect(Entity.last.name).to eql "Big Oil Inc"
       end
     end
   end

--- a/spec/lib/cmp_person_spec.rb
+++ b/spec/lib/cmp_person_spec.rb
@@ -5,11 +5,12 @@ describe Cmp::CmpPerson do
   let(:attributes) do
     {
       cmpid: Faker::Number.number(6),
-      fullname: 'Oil Executive',
+      fullname: 'Mr. Oil Executive',
       nationality: 'Canada',
       firstname: 'oil',
       lastname: 'Executive',
       middlename: nil,
+      salutation: 'Mr.',
       suffix: nil,
       dob_2015: '',
       dob_2016: '1960',
@@ -19,10 +20,43 @@ describe Cmp::CmpPerson do
 
   subject { Cmp::CmpPerson.new(attributes.merge(override)) }
 
+  before(:all) do
+    ThinkingSphinx::Callbacks.suspend!
+    @cmp_user = create_basic_user_with_ids(Cmp::CMP_USER_ID, Cmp::CMP_SF_USER_ID)
+    @cmp_tag = Tag.create!("id" => Cmp::CMP_TAG_ID,
+                           "restricted" => true,
+                           "name" => "cmp",
+                           "description" => "Data from the Corporate Mapping Project")
+  end
+
+  after(:all) do
+    @cmp_tag.delete
+    @cmp_user.sf_guard_user.delete
+    @cmp_user.delete
+    SfGuardUserPermission.delete_all
+    ThinkingSphinx::Callbacks.resume!
+  end
+
+  describe 'import!' do
+    context 'Entity is not already in the database' do
+      before do
+        allow(subject). to receive(:preselected_match).and_return(nil)
+        expect(EntityMatcher)
+          .to receive(:find_matches_for_person).and_return(EntityMatcher::EvaluationResultSet.new([]))
+      end
+
+      it 'creates a new entity' do
+        expect { subject.import! }.to change { Entity.count }.by(1)
+        expect(Entity.last.name).to eql "Mr. Oil Executive"
+      end
+    end
+  end
+  
+
   describe '#attrs_for' do
     specify do
       expect(subject.send(:attrs_for, :entity))
-        .to eql LsHash.new(name: 'Oil Executive')
+        .to eql LsHash.new(name: 'Mr. Oil Executive')
     end
   end
 end

--- a/spec/lib/cmp_person_spec.rb
+++ b/spec/lib/cmp_person_spec.rb
@@ -40,9 +40,12 @@ describe Cmp::CmpPerson do
   describe 'import!' do
     context 'Entity is not already in the database' do
       before do
-        allow(subject). to receive(:preselected_match).and_return(nil)
+        allow(subject).to receive(:preselected_match).and_return(nil)
+        allow(Cmp::Datasets).to receive(:relationships).and_return([])
+
         expect(EntityMatcher)
-          .to receive(:find_matches_for_person).and_return(EntityMatcher::EvaluationResultSet.new([]))
+          .to receive(:find_matches_for_person)
+                .and_return(EntityMatcher::EvaluationResultSet.new([]))
       end
 
       it 'creates a new entity' do
@@ -51,7 +54,6 @@ describe Cmp::CmpPerson do
       end
     end
   end
-  
 
   describe '#attrs_for' do
     specify do

--- a/spec/lib/cmp_spec.rb
+++ b/spec/lib/cmp_spec.rb
@@ -41,84 +41,9 @@ describe Cmp do
   end
 
   describe Cmp::EntityMatch do
-    # let(:entity_match) { Cmp::EntityMatch.new(name: 'test name', primary_ext: 'Person', cmpid: 123) }
-
     it 'EntityMatch.matches return hash of all manual matches' do
       expect(Cmp::EntityMatch.matches).to be_a Hash
       expect(Cmp::EntityMatch::MATCHES.length).to be > 25
     end
-
-    # it 'raises error if passed invalid type' do
-    #   expect do
-    #     Cmp::EntityMatch.new(name: 'name', primary_ext: 'invalid primary ext')
-    #   end.to raise_error(ArgumentError)
-    # end
-
-    # it 'sets @name, @search_options, @primary_ext, and @cmpid' do
-    #   expect(Entity::Search).to receive(:search).and_return([])
-    #   expect(entity_match.instance_variable_get(:@name)).to eql 'test name'
-    #   expect(entity_match.instance_variable_get(:@cmpid)).to eql '123'
-    #   expect(entity_match.instance_variable_get(:@primary_ext)).to eql 'Person'
-    #   expect(entity_match.instance_variable_get(:@search_options))
-    #     .to eql(:with => { primary_ext: "'Person'", is_deleted: false })
-    # end
-
-    # context 'with no search results' do
-    #   before { expect(Entity::Search).to receive(:search).and_return([]) }
-    #   specify { expect(entity_match.empty?).to be true }
-    #   specify { expect(entity_match.has_match?).to be false }
-    #   specify { expect(entity_match.count).to eql 0 }
-    #   specify { expect(entity_match.first).to be nil }
-    #   specify { expect(entity_match.second).to be nil }
-    # end
-
-    # context 'with one search results' do
-    #   let(:person) { build(:person) }
-    #   before { expect(Entity::Search).to receive(:search).and_return(Array.wrap(person)) }
-    #   specify { expect(entity_match.empty?).to be false }
-    #   specify { expect(entity_match.has_match?).to be true }
-    #   specify { expect(entity_match.count).to eql 1 }
-    #   specify { expect(entity_match.match).to eql person }
-    #   specify { expect(entity_match.first).to eql person }
-    #   specify { expect(entity_match.second).to be nil }
-    # end
-
-    # context 'with one search results AND a match in the file' do
-    #   let(:entity_match) { Cmp::EntityMatch.new(name: 'test name', primary_ext: 'Org', cmpid: '2400012') }
-    #   let(:org) { build(:org) }
-    #   let(:file_match) { build(:org, name: "McGill University") }
-    #   before do
-    #     allow(Entity::Search).to receive(:search).and_return(Array.wrap(org))
-    #     allow(Entity).to receive(:find).with(15_062).and_return(file_match)
-    #   end
-    #   specify { expect(entity_match.empty?).to be false }
-    #   specify { expect(entity_match.has_match?).to be true }
-    #   specify { expect(entity_match.count).to eql 1 }
-    #   specify { expect(entity_match.match).to eql file_match }
-    #   specify { expect(entity_match.first).to eql org }
-    #   specify { expect(entity_match.second).to be nil }
-    # end
-
-    # context 'file indicates that a new entity should be created' do
-    #   let(:org) { build(:org) }
-    #   let(:name) { 'TRANSCONTINENTAL INC.' }
-    #   let(:entity_match) { Cmp::EntityMatch.new(name: name, primary_ext: 'Org', cmpid: '5000518') }
-    #   before { allow(Entity::Search).to receive(:search).and_return(Array.wrap(org)) }
-    #   specify { expect(entity_match.has_match?).to be true }
-    #   specify do
-    #     expect { entity_match.match }.to change { Entity.count }.by(1)
-    #   end
-    #   specify { expect(entity_match.match.primary_ext).to eql 'Org' }
-    #   specify { expect(entity_match.match.name).to eql name }
-    # end
-
-    # context 'with three search results' do
-    #   let(:people) { Array.new(3) { build(:person) } }
-    #   before { expect(Entity::Search).to receive(:search).and_return(people) }
-    #   specify { expect(entity_match.empty?).to be false }
-    #   specify { expect(entity_match.count).to eql 3 }
-    #   specify { expect(entity_match.first).to eql people[0] }
-    #   specify { expect(entity_match.second).to be people[1] }
-    # end
   end
 end

--- a/spec/lib/cmp_spec.rb
+++ b/spec/lib/cmp_spec.rb
@@ -41,84 +41,84 @@ describe Cmp do
   end
 
   describe Cmp::EntityMatch do
-    let(:entity_match) { Cmp::EntityMatch.new(name: 'test name', primary_ext: 'Person', cmpid: 123) }
+    # let(:entity_match) { Cmp::EntityMatch.new(name: 'test name', primary_ext: 'Person', cmpid: 123) }
 
     it 'EntityMatch.matches return hash of all manual matches' do
       expect(Cmp::EntityMatch.matches).to be_a Hash
       expect(Cmp::EntityMatch::MATCHES.length).to be > 25
     end
 
-    it 'raises error if passed invalid type' do
-      expect do
-        Cmp::EntityMatch.new(name: 'name', primary_ext: 'invalid primary ext')
-      end.to raise_error(ArgumentError)
-    end
+    # it 'raises error if passed invalid type' do
+    #   expect do
+    #     Cmp::EntityMatch.new(name: 'name', primary_ext: 'invalid primary ext')
+    #   end.to raise_error(ArgumentError)
+    # end
 
-    it 'sets @name, @search_options, @primary_ext, and @cmpid' do
-      expect(Entity::Search).to receive(:search).and_return([])
-      expect(entity_match.instance_variable_get(:@name)).to eql 'test name'
-      expect(entity_match.instance_variable_get(:@cmpid)).to eql '123'
-      expect(entity_match.instance_variable_get(:@primary_ext)).to eql 'Person'
-      expect(entity_match.instance_variable_get(:@search_options))
-        .to eql(:with => { primary_ext: "'Person'", is_deleted: false })
-    end
+    # it 'sets @name, @search_options, @primary_ext, and @cmpid' do
+    #   expect(Entity::Search).to receive(:search).and_return([])
+    #   expect(entity_match.instance_variable_get(:@name)).to eql 'test name'
+    #   expect(entity_match.instance_variable_get(:@cmpid)).to eql '123'
+    #   expect(entity_match.instance_variable_get(:@primary_ext)).to eql 'Person'
+    #   expect(entity_match.instance_variable_get(:@search_options))
+    #     .to eql(:with => { primary_ext: "'Person'", is_deleted: false })
+    # end
 
-    context 'with no search results' do
-      before { expect(Entity::Search).to receive(:search).and_return([]) }
-      specify { expect(entity_match.empty?).to be true }
-      specify { expect(entity_match.has_match?).to be false }
-      specify { expect(entity_match.count).to eql 0 }
-      specify { expect(entity_match.first).to be nil }
-      specify { expect(entity_match.second).to be nil }
-    end
+    # context 'with no search results' do
+    #   before { expect(Entity::Search).to receive(:search).and_return([]) }
+    #   specify { expect(entity_match.empty?).to be true }
+    #   specify { expect(entity_match.has_match?).to be false }
+    #   specify { expect(entity_match.count).to eql 0 }
+    #   specify { expect(entity_match.first).to be nil }
+    #   specify { expect(entity_match.second).to be nil }
+    # end
 
-    context 'with one search results' do
-      let(:person) { build(:person) }
-      before { expect(Entity::Search).to receive(:search).and_return(Array.wrap(person)) }
-      specify { expect(entity_match.empty?).to be false }
-      specify { expect(entity_match.has_match?).to be true }
-      specify { expect(entity_match.count).to eql 1 }
-      specify { expect(entity_match.match).to eql person }
-      specify { expect(entity_match.first).to eql person }
-      specify { expect(entity_match.second).to be nil }
-    end
+    # context 'with one search results' do
+    #   let(:person) { build(:person) }
+    #   before { expect(Entity::Search).to receive(:search).and_return(Array.wrap(person)) }
+    #   specify { expect(entity_match.empty?).to be false }
+    #   specify { expect(entity_match.has_match?).to be true }
+    #   specify { expect(entity_match.count).to eql 1 }
+    #   specify { expect(entity_match.match).to eql person }
+    #   specify { expect(entity_match.first).to eql person }
+    #   specify { expect(entity_match.second).to be nil }
+    # end
 
-    context 'with one search results AND a match in the file' do
-      let(:entity_match) { Cmp::EntityMatch.new(name: 'test name', primary_ext: 'Org', cmpid: '2400012') }
-      let(:org) { build(:org) }
-      let(:file_match) { build(:org, name: "McGill University") }
-      before do
-        allow(Entity::Search).to receive(:search).and_return(Array.wrap(org))
-        allow(Entity).to receive(:find).with(15_062).and_return(file_match)
-      end
-      specify { expect(entity_match.empty?).to be false }
-      specify { expect(entity_match.has_match?).to be true }
-      specify { expect(entity_match.count).to eql 1 }
-      specify { expect(entity_match.match).to eql file_match }
-      specify { expect(entity_match.first).to eql org }
-      specify { expect(entity_match.second).to be nil }
-    end
+    # context 'with one search results AND a match in the file' do
+    #   let(:entity_match) { Cmp::EntityMatch.new(name: 'test name', primary_ext: 'Org', cmpid: '2400012') }
+    #   let(:org) { build(:org) }
+    #   let(:file_match) { build(:org, name: "McGill University") }
+    #   before do
+    #     allow(Entity::Search).to receive(:search).and_return(Array.wrap(org))
+    #     allow(Entity).to receive(:find).with(15_062).and_return(file_match)
+    #   end
+    #   specify { expect(entity_match.empty?).to be false }
+    #   specify { expect(entity_match.has_match?).to be true }
+    #   specify { expect(entity_match.count).to eql 1 }
+    #   specify { expect(entity_match.match).to eql file_match }
+    #   specify { expect(entity_match.first).to eql org }
+    #   specify { expect(entity_match.second).to be nil }
+    # end
 
-    context 'file indicates that a new entity should be created' do
-      let(:org) { build(:org) }
-      let(:name) { 'TRANSCONTINENTAL INC.' }
-      let(:entity_match) { Cmp::EntityMatch.new(name: name, primary_ext: 'Org', cmpid: '5000518') }
-      before { allow(Entity::Search).to receive(:search).and_return(Array.wrap(org)) }
-      specify { expect(entity_match.has_match?).to be true }
-      specify do
-        expect { entity_match.match }.to change { Entity.count }.by(1)
-      end
-      specify { expect(entity_match.match.primary_ext).to eql 'Org' }
-      specify { expect(entity_match.match.name).to eql name }
-    end
+    # context 'file indicates that a new entity should be created' do
+    #   let(:org) { build(:org) }
+    #   let(:name) { 'TRANSCONTINENTAL INC.' }
+    #   let(:entity_match) { Cmp::EntityMatch.new(name: name, primary_ext: 'Org', cmpid: '5000518') }
+    #   before { allow(Entity::Search).to receive(:search).and_return(Array.wrap(org)) }
+    #   specify { expect(entity_match.has_match?).to be true }
+    #   specify do
+    #     expect { entity_match.match }.to change { Entity.count }.by(1)
+    #   end
+    #   specify { expect(entity_match.match.primary_ext).to eql 'Org' }
+    #   specify { expect(entity_match.match.name).to eql name }
+    # end
 
-    context 'with three search results' do
-      let(:people) { Array.new(3) { build(:person) } }
-      before { expect(Entity::Search).to receive(:search).and_return(people) }
-      specify { expect(entity_match.empty?).to be false }
-      specify { expect(entity_match.count).to eql 3 }
-      specify { expect(entity_match.first).to eql people[0] }
-      specify { expect(entity_match.second).to be people[1] }
-    end
+    # context 'with three search results' do
+    #   let(:people) { Array.new(3) { build(:person) } }
+    #   before { expect(Entity::Search).to receive(:search).and_return(people) }
+    #   specify { expect(entity_match.empty?).to be false }
+    #   specify { expect(entity_match.count).to eql 3 }
+    #   specify { expect(entity_match.first).to eql people[0] }
+    #   specify { expect(entity_match.second).to be people[1] }
+    # end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -55,10 +55,18 @@ module RspecExampleHelpers
     user
   end
 
-
   def create_really_basic_user
     sf_user = FactoryBot.create(:sf_guard_user)
     FactoryBot.create(:user, sf_guard_user_id: sf_user.id)
+  end
+
+  def create_basic_user_with_ids(user_id, sf_user_id)
+    sf_user = FactoryBot.create(:sf_guard_user, id: sf_user_id)
+    user = FactoryBot.create(:user, id: user_id, sf_guard_user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 2, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 3, user_id: sf_user.id)
+    SfGuardUserPermission.create!(permission_id: 6, user_id: sf_user.id)
+    user
   end
 
   def create_basic_user

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -542,7 +542,7 @@ describe EntityMatcher, :sphinx do
         end
       end
 
-      describe 'automatch?' do
+      describe 'automatchable? and automatch?' do
         context 'for a person' do
           context 'can be automatch' do
             subject { result_person(:same_first_name, :same_last_name, :common_relationship, :same_middle_name) }
@@ -565,6 +565,44 @@ describe EntityMatcher, :sphinx do
             subject { result_org(:same_root) }
             specify { expect(subject.automatch?).to be false }
           end
+        end
+
+        it 'set is not automatchable if it has too many matches' do
+          results = [
+            result_person(:similar_first_name, :similar_last_name),
+            result_person(:same_first_name, :same_last_name, :common_relationship, :same_middle_name),
+            result_person(:similar_first_name, :same_last_name, :common_relationship)
+          ]
+          expect(EntityMatcher::EvaluationResultSet.new(results).automatchable?).to be false
+        end
+
+        it 'set is not automatchable if it has no matches' do
+          results = [
+            result_org(:similar_name), result_org(:same_root, :blurb_keyword), result_org(:same_root)
+          ]
+          expect(EntityMatcher::EvaluationResultSet.new(results).automatchable?).to be false
+        end
+
+        it 'set is not automatchable if it has no matches' do
+          results = [
+            result_org(:similar_name), result_org(:same_root, :blurb_keyword), result_org(:same_root)
+          ]
+          expect(EntityMatcher::EvaluationResultSet.new(results).automatchable?).to be false
+        end
+
+        it 'works with zero or one matches' do
+          expect(EntityMatcher::EvaluationResultSet.new([result_org(:same_name)]).automatchable?).to be true
+          expect(EntityMatcher::EvaluationResultSet.new([result_org(:same_name), result_org(:same_name)]).automatchable?).to be false
+          expect(EntityMatcher::EvaluationResultSet.new([]).automatchable?).to be nil
+        end
+
+        it 'set is automatachable if it only one match' do
+          results = [
+            result_org(:same_name, :common_relationship),
+            result_org(:same_root, :blurb_keyword),
+            result_org(:same_root)
+          ]
+          expect(EntityMatcher::EvaluationResultSet.new(results).automatchable?).to be true
         end
       end
 

--- a/spec/utility/entity_matcher_spec.rb
+++ b/spec/utility/entity_matcher_spec.rb
@@ -245,9 +245,6 @@ describe EntityMatcher, :sphinx do
         EntityMatcher::TestCase::Person.new(build(:person, person: build(:a_person, **fields)))
       end
 
-      # EntityMatcher::TestCase::Person.new(
-      #     build(:person, person: build(:a_person, fields))
-      #   )
       context 'same last names' do
         let(:test_case) do
           EntityMatcher::TestCase::Person.new('jane doe')
@@ -542,6 +539,32 @@ describe EntityMatcher, :sphinx do
           person2.entity = entity2
           expect(person1 == person2).to be true
           expect(person1.eql? person2).to be true
+        end
+      end
+
+      describe 'automatch?' do
+        context 'for a person' do
+          context 'can be automatch' do
+            subject { result_person(:same_first_name, :same_last_name, :common_relationship, :same_middle_name) }
+            specify { expect(subject.automatch?).to be true }
+          end
+
+          context 'can not be automatch' do
+            subject { result_person(:same_first_name, :same_last_name, :blurb_keyword) }
+            specify { expect(subject.automatch?).to be false }
+          end
+        end
+
+        context 'for an org' do
+          context 'can be automatch' do
+            subject { result_org(:matches_alias) }
+            specify { expect(subject.automatch?).to be true }
+          end
+
+          context 'can not be automatch' do
+            subject { result_org(:same_root) }
+            specify { expect(subject.automatch?).to be false }
+          end
         end
       end
 

--- a/spec/utility/org_name_spec.rb
+++ b/spec/utility/org_name_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 describe OrgName do
+  describe 'format' do
+    specify do
+      expect(OrgName.format("TWENTY-FIRST CENTURY FOX, INC."))
+        .to eql "Twenty-First Century Fox, Inc."
+    end
+
+    specify do
+      expect(OrgName.format("blah blah llc")).to eql "Blah Blah LLC"
+    end
+
+    specify do
+      expect(OrgName.format("blahllc")).to eql "Blahllc"
+    end
+
+    specify do
+      expect(OrgName.format("no suffix, here")).to eql "No Suffix, Here"
+    end
+  end
+
   describe 'parse' do
     specify { expect(OrgName.parse('ABC')).to be_a OrgName::Name }
 


### PR DESCRIPTION
- ` EntityMatcher::EvaluationResult ` has method #automatch? which determined if it matches enough criteria to be auto-matched. 

- when importing, the edits are attributed to a CMP user

- ` OrgName.format ` formats an organizational name

-  EntityMatcher  is used instead of specific cmp matcher: Cmp::EntityMatch 

