### PR TITLE
add title, message to history pages

### DIFF
--- a/app/assets/stylesheets/base/globals.scss
+++ b/app/assets/stylesheets/base/globals.scss
@@ -15,3 +15,5 @@ $small_header_image_size: 80px;
 $red: #CC5454;
 $red_light: #CC8585;
 $red_lighter: rgba(204,133,133,0.4);
+$gray: #555;
+$light_gray: #f4f4f4;

--- a/app/assets/stylesheets/base/helpers.scss
+++ b/app/assets/stylesheets/base/helpers.scss
@@ -1,9 +1,8 @@
 /* helper css utilities */
 @import "base/globals";
 
-.link-blue {
-  color: $link_blue;
-}
+
+// Padding and margins
 
 .top-1em {
   padding-top: 1em;
@@ -46,7 +45,6 @@
     margin-bottom: 1em;
 }
 
-
 .pad-right-1em {
   padding-right: 1em;
 }
@@ -63,31 +61,8 @@
   padding-right: 0.8em;
 }
 
-.thin-grey-bottom-border {
-  border-bottom: 1px solid #e7e7e7;
-}
-
-.gray-img-border {
-  border: 1px solid #ddd;
-}
-
-.big-text {
-  font-size: 42px;
-}
-
-.small-text {
-    font-size: 10px;
-} 
-
-.borderless {
-   th, td { 
-    border-top: none !important; 
-  }
-}
-
-.icon-link {
-    color: black;
-    text-decoration: none;
+.no-border-top {
+    border-top: 0;
 }
 
 .nopadding {
@@ -99,6 +74,43 @@
     padding-left: 30px;
 }
 
+
+// font size and typography
+
+.big-text {
+  font-size: 42px;
+}
+
+.small-text {
+    font-size: 10px;
+} 
+
+// Colors
+
+.grey-text {
+    color: $gray;
+}
+
+
+// link helpers
+
+.link-blue {
+  color: $link_blue;
+}
+
+
+.icon-link {
+    color: black;
+    text-decoration: none;
+}
+
+.cursor-pointer {
+    cursor: pointer;
+}
+
+
+// Position
+
 .position-relative {
   position: relative;
 }
@@ -107,6 +119,52 @@
     position: absolute;
 }
 
+
+.red-button {
+    /* background-color: #A04040; */
+    background-color: $red;
+    color: #fff;
+}
+
+
+.empty-button {
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+// Borders and boxes
+
+.light-gray-box {
+    background-color: $light_gray;
+    padding: 0.3em;
+}
+
+.light-gray-box-rounded {
+    @extend .light-gray-box;
+    border-radius: 3px;
+}
+
+.grey-bottom-border {
+    border-bottom: 1.2px solid $gray;
+}
+
+.thin-grey-bottom-border {
+  border-bottom: 1px solid #e7e7e7;
+}
+
+.gray-img-border {
+  border: 1px solid #ddd;
+}
+
+.borderless {
+   th, td { 
+    border-top: none !important; 
+  }
+}
+
+
+// Animate
 
 .animate-glyphicon {
     -animation: spin .7s infinite linear;
@@ -121,24 +179,4 @@
 @keyframes spin {
     from { transform: scale(1) rotate(0deg);}
     to { transform: scale(1) rotate(360deg);}
-}
-
-.red-button {
-    /* background-color: #A04040; */
-    background-color: $red;
-    color: #fff;
-}
-
-.cursor-pointer {
-    cursor: pointer;
-}
-
-.no-border-top {
-    border-top: 0;
-}
-
-.empty-button {
-    background: none;
-    border: none;
-    padding: 0;
 }

--- a/app/assets/stylesheets/styles/edits.scss
+++ b/app/assets/stylesheets/styles/edits.scss
@@ -51,7 +51,9 @@ form.alias-form {
 
 	td {
 	    @extend .no-border-top;
+	    padding-left: 0;
 	}
+
     }
 
     .pagination {

--- a/app/views/edits/entity.html.erb
+++ b/app/views/edits/entity.html.erb
@@ -9,6 +9,12 @@
   <div class="row">
     <div class="col-sm-12 nopadding">
       <div id="entity-history-container">
+	<div>
+	  <h4 class="">
+	    <span class="light-gray-box-rounded">Revision history for <em><%= @entity.name %></em>:</span>
+	  </h4>
+	</div>
+	
 	<table class="table table-hover">
 	  <tbody>
 	    <%= render partial: 'entity_version', collection: versions, as: :version %>
@@ -16,7 +22,10 @@
 	</table>
 	<%= paginate versions %>
       </div>
-    </div>
+      <% if @entity.created_at.year < 2017 %>
+	<span id="entity-history-date-caveat" style="font-size: 10px">Changes before <em>2017</em> may not be reflected on this page</span>
+      <% end %>
+    </div> <%# end of col-sm %>
   </div>
 
 <% end %>


### PR DESCRIPTION
add title and notice to entity history pages:

resolves #537 

![history_title](https://user-images.githubusercontent.com/8505044/37989876-9e8f2b9a-31d2-11e8-9ceb-7654ed9cd98f.png)
___________

![history_message](https://user-images.githubusercontent.com/8505044/37989887-a3675a2a-31d2-11e8-9b56-666e50713d88.png)
