### PR TITLE
Remove networks

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -54,7 +54,7 @@ class HomeController < ApplicationController
     @lists = current_user.lists
       .select("ls_list.*, COUNT(DISTINCT(ls_list_entity.entity_id)) AS entity_count")
       .joins(:list_entities)
-      .where(is_network: false, is_admin: false)
+      .where(is_admin: false)
       .group("ls_list.id")
       .order("entity_count DESC")
       .page(params[:page]).per(20)

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -33,7 +33,7 @@ class ListsController < ApplicationController
     List
       .select("ls_list.*, COUNT(DISTINCT(ls_list_entity.entity_id)) AS entity_count")
       .joins(:list_entities)
-      .where(is_network: false, is_admin: false)
+      .where(is_admin: false)
       .group("ls_list.id")
       .order("entity_count DESC")
       .page(page).per(20)
@@ -55,7 +55,7 @@ class ListsController < ApplicationController
       is_admin = (current_user and current_user.has_legacy_permission('admin')) ? [0, 1] : 0
       list_ids = List.search(
         Riddle::Query.escape(params[:q]),
-        with: { is_deleted: 0, is_admin: is_admin, is_network: 0 }
+        with: { is_deleted: 0, is_admin: is_admin }
       ).map(&:id)
       @lists = @lists.where(id: list_ids).reorder('')
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -71,7 +71,7 @@ class SearchController < ApplicationController
     list_is_admin = current_user&.admin? ? [0, 1] : 0
     @lists = List.search("@(name,description) #{q}",
                          per_page: 50,
-                         with: { is_deleted: false, is_admin: list_is_admin, is_network: false },
+                         with: { is_deleted: false, is_admin: list_is_admin },
                          without: { access: Permissions::ACCESS_PRIVATE })
   end
 

--- a/app/helpers/entities_helper.rb
+++ b/app/helpers/entities_helper.rb
@@ -189,7 +189,7 @@ module EntitiesHelper
   # skip deleted lists, private lists (unless current_user has access), and skip lists that are networks
   def show_list(list_entity)
     list = list_entity.list
-    return false if list.nil? || list.is_network?
+    return false if list.nil?
     list.user_can_access?(current_user)
   end
 

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ListsHelper
 
   def link_tab_url(tab, list)
@@ -56,10 +58,6 @@ module ListsHelper
 
   def list_name_class(tags)
     tags.count.positive? ? "col-sm-8 col-md-9" : "col-sm-12"
-  end
-
-  def network_link(list)
-    link_to(list.name, list.legacy_network_url)
   end
 
   def nil_string(maybe_nil)

--- a/app/indices/entity_index.rb
+++ b/app/indices/entity_index.rb
@@ -9,6 +9,5 @@ ThinkingSphinx::Index.define :entity, :with => :active_record, :delta => Thinkin
   has is_deleted, facet: true
   has last_user_id, facet: true
   has updated_at
-  has networks.id, as: :network_ids
   has link_count
 end

--- a/app/indices/list_index.rb
+++ b/app/indices/list_index.rb
@@ -5,7 +5,6 @@ ThinkingSphinx::Index.define :list, :with => :active_record, :delta => ThinkingS
 
   has is_deleted, facet: true
   has is_admin, facet: true
-  has is_network, facet: true
   has access, facet: true
   has updated_at
 end

--- a/app/indices/note_index.rb
+++ b/app/indices/note_index.rb
@@ -12,7 +12,6 @@ ThinkingSphinx::Index.define :note, :with => :active_record, :delta => ThinkingS
   has entities.id, as: :entity_ids
   # has relationships.id, as: :relationship_ids
   has lists.id, as: :list_ids
-  has networks.id, as: :network_ids
   has groups.id, as: :group_ids
   has is_private
   has created_at

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -26,8 +26,8 @@ class Entity < ApplicationRecord
   has_many :aliases, inverse_of: :entity, dependent: :destroy
   has_many :images, inverse_of: :entity, dependent: :destroy
   has_many :list_entities, inverse_of: :entity, dependent: :destroy
-  has_many :lists, -> { where(is_network: false) }, through: :list_entities
-  has_many :networks, -> { where(is_network: true) }, class_name: "List", through: :list_entities, source: :list
+  has_many :lists, through: :list_entities
+  # has_many :networks, -> { where(is_network: true) }, class_name: "List", through: :list_entities, source: :list
   has_many :links, foreign_key: "entity1_id", inverse_of: :entity, dependent: :destroy
   has_many :reverse_links, class_name: "Link", foreign_key: "entity2_id", inverse_of: :related, dependent: :destroy
   has_many :relationships, through: :links
@@ -93,7 +93,7 @@ class Entity < ApplicationRecord
 
   before_validation :trim_name_whitespace
   before_create :set_last_user_id
-  after_create :create_primary_alias, :create_primary_ext, :add_to_default_network
+  after_create :create_primary_alias, :create_primary_ext
 
   def set_last_user_id
     self.last_user_id = Lilsis::Application.config.system_user_id unless self.last_user_id.present?
@@ -119,9 +119,9 @@ class Entity < ApplicationRecord
     add_extension(primary_ext, fields)
   end
 
-  def add_to_default_network
-    self.lists << List.default_network unless lists.count > 0
-  end
+  # def add_to_default_network
+  #   self.lists << List.default_network unless lists.count > 0
+  # end
 
   def to_param
     # return nil unless persisted?

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -119,10 +119,6 @@ class Entity < ApplicationRecord
     add_extension(primary_ext, fields)
   end
 
-  # def add_to_default_network
-  #   self.lists << List.default_network unless lists.count > 0
-  # end
-
   def to_param
     # return nil unless persisted?
     "#{id}-#{self.class.parameterize_name(name)}"

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,4 @@
 class Group < ApplicationRecord
-	belongs_to :default_network, class_name: "List", inverse_of: :groups
 	belongs_to :sf_guard_group, foreign_key: "slug", primary_key: "name"
 	
 	has_many :group_users, inverse_of: :group, dependent: :destroy

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -23,10 +23,6 @@ class List < ApplicationRecord
   has_many :sf_guard_group_lists, inverse_of: :list, dependent: :destroy
   has_many :sf_guard_groups, through: :sf_guard_group_lists, inverse_of: :lists
 
-  # TODO: remove these
-  has_many :note_networks, inverse_of: :network
-  has_many :network_notes, through: :note_networks, inverse_of: :networks
-
   validates :name, presence: true
   validates :short_description, length: { maximum: 255 }
 
@@ -118,10 +114,6 @@ class List < ApplicationRecord
   def clear_cache(host = nil)
     touch
   end
-
-  # def self.default_network
-  #   find(Lilsis::Application.config.default_network_id)
-  # end
 
   # [Entity|Ids]
   def add_entities(entities_or_ids)

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class List < ApplicationRecord
-  self.table_name = "ls_list"
+  self.table_name = 'ls_list'
 
   include SoftDelete
   include Referenceable
@@ -8,34 +10,36 @@ class List < ApplicationRecord
 
   has_paper_trail
 
-  belongs_to :user, foreign_key: "creator_user_id", inverse_of: :lists
+  belongs_to :user, foreign_key: 'creator_user_id', inverse_of: :lists
 
   has_many :list_entities, inverse_of: :list, dependent: :destroy
   has_many :entities, through: :list_entities
   has_many :images, through: :entities
 
   has_many :users, inverse_of: :default_network
+
+  # Groups
   has_many :default_groups, inverse_of: :default_network
   has_many :featured_in_groups, class_name: "Group", inverse_of: :featured_list
-
   has_many :group_lists, inverse_of: :list
   has_many :groups, through: :group_lists, inverse_of: :lists
-
-  has_many :note_networks, inverse_of: :network
-  has_many :network_notes, through: :note_networks, inverse_of: :networks
-
   has_many :sf_guard_group_lists, inverse_of: :list, dependent: :destroy
   has_many :sf_guard_groups, through: :sf_guard_group_lists, inverse_of: :lists
 
-  validates_presence_of :name
+  # TODO: remove these
+  has_many :note_networks, inverse_of: :network
+  has_many :network_notes, through: :note_networks, inverse_of: :networks
+
+  validates :name, presence: true
   validates :short_description, length: { maximum: 255 }
+
   scope :public_scope, -> { where("access <> #{Permissions::ACCESS_PRIVATE}") }
   scope :private_scope, -> { where(access: Permissions::ACCESS_PRIVATE) }
 
   def destroy
     soft_delete
   end
-  
+
   def to_param
     "#{id}-#{name.parameterize}"
   end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -75,7 +75,7 @@ class List < ApplicationRecord
   end
 
   def interlocks_hash
-    list_entities = ListEntity.joins(:list).where(entity_id: entity_ids, is_deleted: false, ls_list: { is_network: false, is_deleted: false, is_admin: false }).where.not(list_id: id).limit(50000)
+    list_entities = ListEntity.joins(:list).where(entity_id: entity_ids, is_deleted: false, ls_list: { is_deleted: false, is_admin: false }).where.not(list_id: id).limit(50000)
     list_entities.reduce({}) do |hash, le| 
       hash[le.list_id] = hash.fetch(le.list_id, []).push(le.entity_id).uniq
       hash
@@ -119,9 +119,9 @@ class List < ApplicationRecord
     touch
   end
 
-  def self.default_network
-    find(Lilsis::Application.config.default_network_id)
-  end
+  # def self.default_network
+  #   find(Lilsis::Application.config.default_network_id)
+  # end
 
   # [Entity|Ids]
   def add_entities(entities_or_ids)

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -41,16 +41,6 @@ class List < ApplicationRecord
     is_admin || access == Permissions::ACCESS_PRIVATE
   end
 
-  def name_to_legacy_slug
-    name.gsub(" ", "_").gsub("/", "~").gsub('+', '_')
-  end
-
-  def legacy_url(action = nil)
-    url = "/list/" + id.to_s + "/" + name_to_legacy_slug
-    url += "/" + action if action.present?
-    url
-  end
-
   def user_can_access?(user_or_id = nil)
     return true unless access == Permissions::ACCESS_PRIVATE
     user = nil if user_or_id.nil?
@@ -58,10 +48,6 @@ class List < ApplicationRecord
     user = user_or_id if user_or_id.is_a? User
     return false if user.nil?
     user.permissions.list_permissions(self)[:viewable]
-  end
-
-  def legacy_network_url
-    "/#{display_name}"
   end
 
   def entities_with_couples

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -17,7 +17,6 @@ class List < ApplicationRecord
   has_many :images, through: :entities
 
   # Groups
-  has_many :default_groups, inverse_of: :default_network
   has_many :featured_in_groups, class_name: "Group", inverse_of: :featured_list
   has_many :group_lists, inverse_of: :list
   has_many :groups, through: :group_lists, inverse_of: :lists

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -16,8 +16,6 @@ class List < ApplicationRecord
   has_many :entities, through: :list_entities
   has_many :images, through: :entities
 
-  has_many :users, inverse_of: :default_network
-
   # Groups
   has_many :default_groups, inverse_of: :default_network
   has_many :featured_in_groups, class_name: "Group", inverse_of: :featured_list
@@ -44,12 +42,8 @@ class List < ApplicationRecord
     "#{id}-#{name.parameterize}"
   end
 
-  def network?
-    @is_network
-  end
-
   def restricted?
-    is_admin || access == Permissions::ACCESS_PRIVATE || is_network
+    is_admin || access == Permissions::ACCESS_PRIVATE
   end
 
   def name_to_legacy_slug

--- a/app/models/list_entity.rb
+++ b/app/models/list_entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ListEntity < ApplicationRecord
   self.table_name = "ls_list_entity"
   include Api::Serializable

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -20,9 +20,6 @@ class Note < ApplicationRecord
   has_many :note_lists, inverse_of: :note, dependent: :destroy
   has_many :lists, through: :note_lists
 
-  has_many :note_networks, inverse_of: :note, dependent: :destroy
-  has_many :networks, class_name: "List", through: :note_networks, inverse_of: :network_notes
-
   has_many :note_groups, inverse_of: :note, dependent: :destroy
   has_many :groups, through: :note_groups
 

--- a/app/models/note_network.rb
+++ b/app/models/note_network.rb
@@ -1,4 +1,0 @@
-class NoteNetwork < ApplicationRecord
-	belongs_to :note, inverse_of: :note_networks
-	belongs_to :network, class_name: "List", inverse_of: :note_networks
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,8 +33,6 @@ class User < ApplicationRecord
 
   alias :image_url :image_path
 
-  belongs_to :default_network, class_name: "List"
-
   has_many :group_users, inverse_of: :user, dependent: :destroy
   has_many :groups, through: :group_users, inverse_of: :users
   has_many :campaigns, through: :groups, inverse_of: :users

--- a/app/utility/relationships_datatable.rb
+++ b/app/utility/relationships_datatable.rb
@@ -31,7 +31,7 @@ class RelationshipsDatatable
     end
 
     if lists?
-      list_entities = ListEntity.select(:list_id, :entity_id).includes(:list).where(entity_id: @related_ids).where(ls_list: { is_network: false, is_admin: false }).map { |le| [le.list_id, le.entity_id] }.uniq
+      list_entities = ListEntity.select(:list_id, :entity_id).includes(:list).where(entity_id: @related_ids).where(ls_list: { is_admin: false }).map { |le| [le.list_id, le.entity_id] }.uniq
       list_hash = list_entities.reduce({}) do |hash, item|
         hash[item[0]] = hash.fetch(item[0], []).push(item[1])
         hash

--- a/app/views/lists/_list_actions.html.erb
+++ b/app/views/lists/_list_actions.html.erb
@@ -7,9 +7,6 @@
     
     <% if has_legacy_permission('bulker') %>
       <%= link_to('add bulk', entities_bulk_list_path(list), class: 'btn btn-default') %>
-      <% if person_count > 0 %>
-	<%= link_to('match donors', list.legacy_url('matchRelated'), class: 'btn btn-default') %>
-      <% end %>
     <% end %>
     
     <input id="add-entity-input" type="text" class="form-control" placeholder="add entity">

--- a/db/migrate/20180424164740_drop_is_network_from_ls_list.rb
+++ b/db/migrate/20180424164740_drop_is_network_from_ls_list.rb
@@ -1,0 +1,5 @@
+class DropIsNetworkFromLsList < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :ls_list, :is_network
+  end
+end

--- a/db/migrate/20180424165127_remove_network_lists_and_list_entities.rb
+++ b/db/migrate/20180424165127_remove_network_lists_and_list_entities.rb
@@ -1,0 +1,22 @@
+class RemoveNetworkListsAndListEntities < ActiveRecord::Migration[5.1]
+  def up
+    list_ids = [78, 79, 96, 132, 133, 198]
+    list_ids.each { |list_id| List.find_by(id: list_id)&.delete }
+
+    list_ids.each do |list_id|
+      ListEntity.unscoped.where(list_id: list_id).delete_all
+    end
+    
+  end
+
+  def down
+    List.create!([
+                   {name: "Buffalo", description: "Powerful individuals in Buffalo, NY, including business, political, and social leaders.", is_ranked: false, is_admin: true, is_featured: false, display_name: "buffalo", featured_list_id: nil,last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
+                   {name: "United States", description: "People and organizations with significant influence on the policies of the United States.", is_ranked: false, is_admin: true, is_featured: false, display_name: "us", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
+                   {name: "United Kingdom", description: "People and organizations with significant influence on the policies of the United Kingdom.", is_ranked: false, is_admin: true, is_featured: false, display_name: "uk", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
+                   {name: "Baltimore", description: "Powerful individuals in Baltimore, MD, including business, political, and social leaders.", is_ranked: false, is_admin: true, is_featured: false, display_name: "baltimore", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
+                   {name: "New York State", description: "Powerful individuals in New York State, including business, political, and social leaders.", is_ranked: false, is_admin: true, is_featured: false, display_name: "nys", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
+                   {name: "Oakland", description: "Powerful individuals in Oakland, CA, including business, political, and social leaders.", is_ranked: false, is_admin: true, is_featured: false, display_name: "oakland", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false}
+                 ])
+  end
+end

--- a/db/migrate/20180424181848_drop_table_note_networks.rb
+++ b/db/migrate/20180424181848_drop_table_note_networks.rb
@@ -1,0 +1,5 @@
+class DropTableNoteNetworks < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :note_networks
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424165127) do
+ActiveRecord::Schema.define(version: 20180424181848) do
 
   create_table "address", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "entity_id", null: false
@@ -726,13 +726,6 @@ ActiveRecord::Schema.define(version: 20180424165127) do
     t.integer "list_id"
     t.index ["list_id"], name: "index_note_lists_on_list_id"
     t.index ["note_id", "list_id"], name: "index_note_lists_on_note_id_and_list_id", unique: true
-  end
-
-  create_table "note_networks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "note_id"
-    t.integer "network_id"
-    t.index ["network_id"], name: "index_note_networks_on_network_id"
-    t.index ["note_id", "network_id"], name: "index_note_networks_on_note_id_and_network_id", unique: true
   end
 
   create_table "note_relationships", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424164740) do
+ActiveRecord::Schema.define(version: 20180424165127) do
 
   create_table "address", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "entity_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180418185245) do
+ActiveRecord::Schema.define(version: 20180424164740) do
 
   create_table "address", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "entity_id", null: false
@@ -568,7 +568,6 @@ ActiveRecord::Schema.define(version: 20180418185245) do
     t.boolean "is_ranked", default: false, null: false
     t.boolean "is_admin", default: false, null: false
     t.boolean "is_featured", default: false, null: false
-    t.boolean "is_network", default: false, null: false
     t.string "display_name", limit: 50
     t.bigint "featured_list_id"
     t.datetime "created_at"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,14 +52,6 @@ User.create!({id: 1, email: "system@littlesis.org", username: 'system', default_
               sf_guard_user_id: 1,
               password: '$2a$10$Q2tSw2llUagw1KRNTtLD4.JiYgFA.9pxgV5aPOs/IxFsddZGa8jgO'})
 
-List.create!([
-  {name: "Buffalo", description: "Powerful individuals in Buffalo, NY, including business, political, and social leaders.", is_ranked: false, is_admin: false, is_featured: false, is_network: true, display_name: "buffalo", featured_list_id: nil,last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
-  {id: 79, name: "United States", description: "People and organizations with significant influence on the policies of the United States.", is_ranked: false, is_admin: false, is_featured: false, is_network: true, display_name: "us", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
-  {name: "United Kingdom", description: "People and organizations with significant influence on the policies of the United Kingdom.", is_ranked: false, is_admin: false, is_featured: false, is_network: true, display_name: "uk", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
-  {name: "Baltimore", description: "Powerful individuals in Baltimore, MD, including business, political, and social leaders.", is_ranked: false, is_admin: false, is_featured: false, is_network: true, display_name: "baltimore", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
-  {name: "New York State", description: "Powerful individuals in New York State, including business, political, and social leaders.", is_ranked: false, is_admin: false, is_featured: false, is_network: true, display_name: "nys", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false},
-  {name: "Oakland", description: "Powerful individuals in Oakland, CA, including business, political, and social leaders.", is_ranked: false, is_admin: false, is_featured: false, is_network: true, display_name: "oakland", featured_list_id: nil, last_user_id: 1, is_deleted: false, custom_field_name: nil, delta: false}
-])
 
 SfGuardPermission.create!([
                             {id: 1, name: "admin", description: "Administrator permission"},

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,6 +65,7 @@ SfGuardPermission.create!([
                             {id: 10, name: "talker", description: "allows user to use web-based chat"},
                             {id: 11, name: "contacter", description: nil}
                           ])
+
 RelationshipCategory.create!([
   {id: 1, name: "Position", display_name: "Position", default_description: "Position", entity1_requirements: "Person", entity2_requirements: nil, has_fields: true},
   {id: 2, name: "Education", display_name: "Education", default_description: "Student", entity1_requirements: "Person", entity2_requirements: "Org", has_fields: true},

--- a/spec/factories/list.rb
+++ b/spec/factories/list.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     is_ranked true
     is_admin false
     is_featured false
-    is_network false
   end
 
   factory :open_list, class: List do
@@ -13,7 +12,6 @@ FactoryBot.define do
     description "open list"
     access Permissions::ACCESS_OPEN
     is_admin false
-    is_network false
   end
 
   factory :closed_list, class: List do
@@ -21,7 +19,6 @@ FactoryBot.define do
     description "closed list"
     access Permissions::ACCESS_CLOSED
     is_admin false
-    is_network false
   end
 
   factory :private_list, class: List do
@@ -29,7 +26,6 @@ FactoryBot.define do
     description "private list"
     access Permissions::ACCESS_PRIVATE
     is_admin false
-    is_network false
   end
 
   factory :list_entity, class: ListEntity do

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -104,10 +104,10 @@ describe Entity, :tag_helper  do
       expect { org.soft_delete }.to change { ExtensionRecord.count }.by(-1)
     end
 
-    it 'soft deletes list entities (including removing from network)' do
+    it 'soft deletes list entities' do
       list = create(:list)
       list_entity = ListEntity.create!(list_id: list.id, entity_id: org.id)
-      expect { org.soft_delete }.to change { ListEntity.count }.by(-2)
+      expect { org.soft_delete }.to change { ListEntity.count }.by(-1)
       expect(ListEntity.find_by_id(list_entity.id)).to be nil
     end
 

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -8,20 +8,17 @@ describe List do
   it { is_expected.to validate_length_of(:short_description).is_at_most(255) }
 
   it { is_expected.to have_db_column(:access) }
+  it { is_expected.not_to have_db_column(:is_network) }
 
   context 'active relationship' do
     it 'joins entities via ListEntity' do
-      list_entity_count = ListEntity.count
       list = create(:list)
       inc = create(:mega_corp_inc)
       llc = create(:mega_corp_llc)
-      # Every time you create an entity you create a ListEntity because all entites
-      # are in a network and all networks are lists joined via the list_entities table.
-      # This is why there are 2 list_entities to start with.
-      expect(ListEntity.count).to eql (list_entity_count + 2)
+      expect(ListEntity.count).to eql 0
       ListEntity.find_or_create_by(list_id: list.id, entity_id: inc.id)
       ListEntity.find_or_create_by(list_id: list.id, entity_id: llc.id)
-      expect(ListEntity.count).to eql (list_entity_count + 4)
+      expect(ListEntity.count).to eql 2
       expect(list.list_entities.count).to eql 2
     end
 
@@ -120,8 +117,6 @@ describe List do
       expect(user2).to receive(:permissions)
                        .and_return(double(:list_permissions => {:viewable => false}))
       l = build(:list, access: Permissions::ACCESS_PRIVATE, creator_user_id: user.id)
-      
-      
 
       expect(l.user_can_access?(user)).to be true
       expect(l.user_can_access?(user.id)).to be true
@@ -132,10 +127,10 @@ describe List do
   end
 
   describe 'restricted?' do
-    it 'restricts access to network lists' do
-      l = build(:list, is_network: true)
-      expect(l.restricted?).to be true
-    end
+    # it 'restricts access to network lists' do
+    #   l = build(:list, is_network: true)
+    #   expect(l.restricted?).to be true
+    # end
   end
 
   context 'Using paper_trail for versioning' do

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,22 +1,15 @@
 require 'rails_helper'
 
 describe List do
-  before(:all)  { DatabaseCleaner.start }
-  after(:all) { DatabaseCleaner.clean }
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:list_entities) }
+  it { is_expected.to have_many(:entities) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_length_of(:short_description).is_at_most(255) }
 
-  it { should belong_to(:user) }
+  it { is_expected.to have_db_column(:access) }
 
-  it 'validates name' do
-    l = List.new
-    expect(l).not_to be_valid
-    l.name = "bad politicians"
-    expect(l).to be_valid
-  end
-
-  it { should validate_length_of(:short_description).is_at_most(255) }
-  it { should have_db_column(:access) }
-
-  context "active relationships" do
+  context 'active relationship' do
     it 'joins entities via ListEntity' do
       list_entity_count = ListEntity.count
       list = create(:list)
@@ -40,7 +33,7 @@ describe List do
       expect(list.images.count).to eq 1
     end
 
-    it 'has groups' do 
+    it 'has groups' do
       list = create(:list)
       grp = create(:group)
       expect(list.groups.count).to eq (0)
@@ -50,8 +43,8 @@ describe List do
       expect(grp.lists.first).to eq(list)
       expect(list.groups.first).to eq(grp)
     end
-
   end
+
   context 'methods' do
     it 'name_to_legacy_slug' do
       l = build(:list, name: 'my/cool+name')

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -42,18 +42,6 @@ describe List do
     end
   end
 
-  context 'methods' do
-    it 'name_to_legacy_slug' do
-      l = build(:list, name: 'my/cool+name')
-      expect(l.name_to_legacy_slug).to eq("my~cool_name")
-    end
-    it 'leagacy_url' do
-      list = build(:list, id: 8)
-      expect(list.legacy_url).to eq("/list/8/Fortune_1000_Companies")
-      expect(list.legacy_url('bam')).to eq("/list/8/Fortune_1000_Companies/bam")
-    end
-  end
-
   context 'SoftDelete' do
     it 'removes item from the count but not he unscoped count' do
       l = create(:list)
@@ -127,10 +115,9 @@ describe List do
   end
 
   describe 'restricted?' do
-    # it 'restricts access to network lists' do
-    #   l = build(:list, is_network: true)
-    #   expect(l.restricted?).to be true
-    # end
+    it 'restricts access to admin lists' do
+      expect(build(:list, is_admin: true).restricted?).to be true
+    end
   end
 
   context 'Using paper_trail for versioning' do


### PR DESCRIPTION
removes entirely the network functionality from lists, including removing the list entities from our database.