### PR TITLE
Editable Dashboard bulletins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -162,4 +162,8 @@ class ApplicationController < ActionController::Base
   def request_type
     request.headers['Littlesis-Request-Type']
   end
+
+  def redirect_to_dashboard
+    redirect_to home_dashboard_path
+  end
 end

--- a/app/controllers/dashboard_bulletins_controller.rb
+++ b/app/controllers/dashboard_bulletins_controller.rb
@@ -5,11 +5,22 @@ class DashboardBulletinsController < ApplicationController
   before_action :admins_only
 
   def new
-    @bulletin = DashboardBulletin.new
   end
 
   def create
     DashboardBulletin.create!(bulletin_params)
+    redirect_to home_dashboard_path
+  end
+
+  def edit
+    @bulletin = DashboardBulletin.find(params.require(:id))
+  end
+
+  def update
+    DashboardBulletin
+      .find(params.require(:id))
+      .update!(bulletin_params)
+
     redirect_to home_dashboard_path
   end
 

--- a/app/controllers/dashboard_bulletins_controller.rb
+++ b/app/controllers/dashboard_bulletins_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DashboardBulletinsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :admins_only
+
+  def new
+  end
+end

--- a/app/controllers/dashboard_bulletins_controller.rb
+++ b/app/controllers/dashboard_bulletins_controller.rb
@@ -5,5 +5,17 @@ class DashboardBulletinsController < ApplicationController
   before_action :admins_only
 
   def new
+    @bulletin = DashboardBulletin.new
+  end
+
+  def create
+    DashboardBulletin.create!(bulletin_params)
+    redirect_to home_dashboard_path
+  end
+
+  private
+
+  def bulletin_params
+    params.require(:dashboard_bulletin).permit(:title, :markdown).to_h
   end
 end

--- a/app/controllers/dashboard_bulletins_controller.rb
+++ b/app/controllers/dashboard_bulletins_controller.rb
@@ -3,28 +3,37 @@
 class DashboardBulletinsController < ApplicationController
   before_action :authenticate_user!
   before_action :admins_only
+  before_action :set_bulletin, only: %i[edit update destroy]
+
+  def index
+  end
 
   def new
   end
 
   def create
     DashboardBulletin.create!(bulletin_params)
-    redirect_to home_dashboard_path
+    redirect_to_dashboard
   end
 
   def edit
-    @bulletin = DashboardBulletin.find(params.require(:id))
   end
 
   def update
-    DashboardBulletin
-      .find(params.require(:id))
-      .update!(bulletin_params)
+    @bulletin.update!(bulletin_params)
+    redirect_to_dashboard
+  end
 
-    redirect_to home_dashboard_path
+  def destroy
+    @bulletin.destroy!
+    redirect_to_dashboard
   end
 
   private
+
+  def set_bulletin
+    @bulletin = DashboardBulletin.find(params.require(:id))
+  end
 
   def bulletin_params
     params.require(:dashboard_bulletin).permit(:title, :markdown).to_h

--- a/app/models/dashboard_bulletin.rb
+++ b/app/models/dashboard_bulletin.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class DashboardBulletin < ApplicationRecord
+  default_scope { order(created_at: :desc) }
+
+  def self.last_bulletin_updated_at
+    DashboardBulletin.limit(1).pluck('updated_at').first
+  end
 end

--- a/app/models/dashboard_bulletin.rb
+++ b/app/models/dashboard_bulletin.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DashboardBulletin < ApplicationRecord
+end

--- a/app/views/admin/home.html.erb
+++ b/app/views/admin/home.html.erb
@@ -5,5 +5,6 @@
 <div id="admin-links">
   <%= link_to 'users admin', admin_users_path %><br />
   <%= link_to 'tags admin', admin_tags_path %><br />
-  <%= link_to 'active users', admin_stats_path %>
+  <%= link_to 'active users', admin_stats_path %><br />
+  <%= link_to 'dashboard bulletins', dashboard_bulletins_path %><br />
 </div>

--- a/app/views/dashboard_bulletins/_bulletin.html.erb
+++ b/app/views/dashboard_bulletins/_bulletin.html.erb
@@ -1,0 +1,10 @@
+<%#=
+locals: bulletin
+
+This partial is the html of the actual bulletin, used
+on the home dashboard
+%>
+
+<%= dashboard_panel(bulletin.title) do %>
+  <%= raw EditablePagesController::MARKDOWN.render(bulletin.markdown) %>
+<% end %>

--- a/app/views/dashboard_bulletins/_bulletins.html.erb
+++ b/app/views/dashboard_bulletins/_bulletins.html.erb
@@ -1,0 +1,5 @@
+<% DashboardBulletin.all.each do |bulletin| %>
+  <%= cache(bulletin) do %>
+    <%= render partial: 'dashboard_bulletins/bulletin', locals: { bulletin: bulletin } %>
+  <% end %>
+<% end %>

--- a/app/views/dashboard_bulletins/_form.html.erb
+++ b/app/views/dashboard_bulletins/_form.html.erb
@@ -1,0 +1,26 @@
+<%#=
+Required locals: bulletin, title, method, url, submit_text
+%>
+
+<%= stylesheet_link_tag "markdown_editor" %>
+<%= javascript_include_tag "markdown_editor" %>
+
+<div class="row">
+  <div class="col-sm-8 nopadding">
+    <h1><%= title %></h1>
+
+    <%= form_for bulletin, method: method, url: url do |f| %>
+
+      <div class="form-group">
+	<%= f.label :title, 'Title' %>
+	<%= f.text_field :title, class: 'form-control', required: true %>
+      </div>
+
+      <%= f.text_area :markdown, size: "10x10", id: 'editable-markdown' %>
+      <br />
+      <%= f.submit submit_text,  class: 'btn btn-primary' %>
+      <%= link_to 'Cancel', '/admin', class: 'btn btn-default' %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/dashboard_bulletins/edit.html.erb
+++ b/app/views/dashboard_bulletins/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:page_title, 'Dashboard Bulletin Update') %>
+
+<%= render partial: 'form', locals: {
+  bulletin: @bulletin,
+  title: 'Update a dashboard bulletin',
+  method: :patch,
+  url: dashboard_bulletin_path(@bulletin),
+  submit_text: 'Update'
+} %>

--- a/app/views/dashboard_bulletins/index.html.erb
+++ b/app/views/dashboard_bulletins/index.html.erb
@@ -1,0 +1,32 @@
+<style>
+  #dashboard-bulletins-table tr > th:nth-child(2) { 
+    width: 40px;
+  }
+</style>
+  
+
+<div class="row">
+  <table class="table" id="dashboard-bulletins-table">
+    <thead>
+      <tr>
+	<th>Title</th>
+	<th>Delete</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% DashboardBulletin.order('created_at desc').all.each do |bulletin| %>
+	<tr>
+	  <td><%= link_to bulletin.title, edit_dashboard_bulletin_path(bulletin)  %></td>
+	  <td>
+	    <%= form_for bulletin, method: :delete do |f| %>
+	      <button type="submit" class="btn btn-default" aria-label="delete bulletin">
+		<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+	      </button>
+	    <% end %>
+	  </td>
+	</tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+    

--- a/app/views/dashboard_bulletins/index.html.erb
+++ b/app/views/dashboard_bulletins/index.html.erb
@@ -3,7 +3,6 @@
     width: 40px;
   }
 </style>
-  
 
 <div class="row">
   <table class="table" id="dashboard-bulletins-table">

--- a/app/views/dashboard_bulletins/index.html.erb
+++ b/app/views/dashboard_bulletins/index.html.erb
@@ -28,4 +28,7 @@
     </tbody>
   </table>
 </div>
-    
+
+<div class="row">
+  <h3><%= link_to 'Create new bulletin', new_dashboard_bulletin_path  %></h3>
+</div>

--- a/app/views/dashboard_bulletins/new.html.erb
+++ b/app/views/dashboard_bulletins/new.html.erb
@@ -1,0 +1,2 @@
+<h1>DashboardBulletins#new</h1>
+<p>Find me in app/views/dashboard_bulletins/new.html.erb</p>

--- a/app/views/dashboard_bulletins/new.html.erb
+++ b/app/views/dashboard_bulletins/new.html.erb
@@ -1,2 +1,24 @@
-<h1>DashboardBulletins#new</h1>
-<p>Find me in app/views/dashboard_bulletins/new.html.erb</p>
+<% content_for(:page_title, 'New Dashboard Bulletin') %>
+<%= stylesheet_link_tag "markdown_editor" %>
+<%= javascript_include_tag "markdown_editor" %>
+
+<div class="row">
+  <div class="col-sm-8 nopadding">
+    <h1>Create a new Dashboard Bulletin</h1>
+
+    <%= form_for @bulletin, method: :post, url: dashboard_bulletins_path do |f| %>
+
+      <div class="form-group">
+	<%= f.label :title, 'Bulletin Title' %>
+	<%= f.text_field :title, class: 'form-control', required: true %>
+      </div>
+
+      <%= f.text_area :markdown, size: "10x10", id: 'editable-markdown' %>
+      <br />
+      <%= f.submit "Create",  class: 'btn btn-primary' %>
+      <%= link_to 'Cancel', '/admin', class: 'btn btn-default' %>
+    <% end %>
+  </div>
+</div>
+
+

--- a/app/views/dashboard_bulletins/new.html.erb
+++ b/app/views/dashboard_bulletins/new.html.erb
@@ -1,24 +1,9 @@
 <% content_for(:page_title, 'New Dashboard Bulletin') %>
-<%= stylesheet_link_tag "markdown_editor" %>
-<%= javascript_include_tag "markdown_editor" %>
 
-<div class="row">
-  <div class="col-sm-8 nopadding">
-    <h1>Create a new Dashboard Bulletin</h1>
-
-    <%= form_for @bulletin, method: :post, url: dashboard_bulletins_path do |f| %>
-
-      <div class="form-group">
-	<%= f.label :title, 'Bulletin Title' %>
-	<%= f.text_field :title, class: 'form-control', required: true %>
-      </div>
-
-      <%= f.text_area :markdown, size: "10x10", id: 'editable-markdown' %>
-      <br />
-      <%= f.submit "Create",  class: 'btn btn-primary' %>
-      <%= link_to 'Cancel', '/admin', class: 'btn btn-default' %>
-    <% end %>
-  </div>
-</div>
-
-
+<%= render partial: 'form', locals: {
+  bulletin: DashboardBulletin.new,
+  title: 'Create a new dashboard bulletin',
+  method: :post,
+  url: dashboard_bulletins_path,
+  submit_text: 'Create'
+} %>

--- a/app/views/home/_list_alerts.html.erb
+++ b/app/views/home/_list_alerts.html.erb
@@ -1,8 +1,0 @@
-<%= dashboard_panel('Sign up for a training!') do %>
-  <p>
-    Join us on <strong>Wednesday, May 16th at 6pm ET</strong> for our next LittleSis 2.0 research tool training: Mapping Power with <%= link_to "Oligrapher", "https://littlesis.org/oligrapher" %> and Bulk Uploading Data!
-  </p>
-  <p>
-    <%= link_to "Register here!", "https://zoom.us/meeting/register/033d356980146a34d746f627e8486654" %>
-  </p>
-<% end %>

--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -42,8 +42,10 @@
 
     </div> <!-- end  col -->
     
-    <div class="col-sm-5 col-sm-offset-1">
-	<%= render partial: 'list_alerts' %>
+    <div class="col-sm-5 col-sm-offset-1" id="dashboard-bulletins">
+      <%= cache ['home_dashboard_bulletins', DashboardBulletin.last_bulletin_updated_at ] do %>
+	<%= render partial: 'dashboard_bulletins/bulletins' %>
+      <% end %>
     </div>
 
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Lilsis::Application.routes.draw do
     get '/stats', action: :stats
   end
 
-  get 'dashboard_bulletins/new'
+  resources :dashboard_bulletins, only: [:new, :create]
 
   resources :groups do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Lilsis::Application.routes.draw do
     get '/stats', action: :stats
   end
 
-  resources :dashboard_bulletins, only: [:new, :create]
+  resources :dashboard_bulletins, only: [:new, :create, :update, :edit]
 
   resources :groups do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,17 @@ Lilsis::Application.routes.draw do
   get '/bug_report' => 'errors#bug_report'
   post '/bug_report' => 'errors#file_bug_report'
 
+  #########
+  # ADMIN #
+  #########
+
   scope :admin, controller: 'admin', as: 'admin' do
     get '/', action: :home
     get '/tags', action: :tags
     get '/stats', action: :stats
   end
+
+  get 'dashboard_bulletins/new'
 
   resources :groups do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Lilsis::Application.routes.draw do
     get '/stats', action: :stats
   end
 
-  resources :dashboard_bulletins, only: [:new, :create, :update, :edit]
+  resources :dashboard_bulletins, except: [:show]
 
   resources :groups do
     member do

--- a/db/migrate/20180522142905_create_dashboard_bulletins.rb
+++ b/db/migrate/20180522142905_create_dashboard_bulletins.rb
@@ -1,0 +1,12 @@
+class CreateDashboardBulletins < ActiveRecord::Migration[5.1]
+  def change
+    create_table :dashboard_bulletins do |t|
+      t.text :markdown
+      t.string :title
+
+      t.timestamps
+    end
+
+    add_index :dashboard_bulletins, :created_at, order: { created_at: :desc }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517154454) do
+ActiveRecord::Schema.define(version: 20180522142905) do
 
   create_table "address", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "entity_id", null: false
@@ -240,6 +240,14 @@ ActiveRecord::Schema.define(version: 20180517154454) do
     t.index ["object_model", "object_id", "name", "value"], name: "object_name_value_idx", unique: true, length: { value: 100 }
     t.index ["object_model", "object_id", "name"], name: "object_name_idx", unique: true
     t.index ["object_model", "object_id"], name: "object_idx"
+  end
+
+  create_table "dashboard_bulletins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.text "markdown"
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_dashboard_bulletins_on_created_at"
   end
 
   create_table "degree", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/spec/controllers/dashboard_bulletins_controller_spec.rb
+++ b/spec/controllers/dashboard_bulletins_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 describe DashboardBulletinsController, type: :controller do
   it { is_expected.to route(:get, '/dashboard_bulletins/new').to(action: :new) }
+  it { is_expected.to route(:post, '/dashboard_bulletins').to(action: :create) }
 end

--- a/spec/controllers/dashboard_bulletins_controller_spec.rb
+++ b/spec/controllers/dashboard_bulletins_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe DashboardBulletinsController, type: :controller do
+  it { is_expected.to route(:get, '/dashboard_bulletins').to(action: :index) }
   it { is_expected.to route(:get, '/dashboard_bulletins/new').to(action: :new) }
   it { is_expected.to route(:post, '/dashboard_bulletins').to(action: :create) }
   it do
@@ -10,5 +11,10 @@ describe DashboardBulletinsController, type: :controller do
   it do
     is_expected.to route(:patch, '/dashboard_bulletins/123')
                      .to(action: :update, id: '123')
+  end
+
+  it do
+    is_expected.to route(:delete, '/dashboard_bulletins/123')
+                     .to(action: :destroy, id: '123')
   end
 end

--- a/spec/controllers/dashboard_bulletins_controller_spec.rb
+++ b/spec/controllers/dashboard_bulletins_controller_spec.rb
@@ -3,4 +3,12 @@ require 'rails_helper'
 describe DashboardBulletinsController, type: :controller do
   it { is_expected.to route(:get, '/dashboard_bulletins/new').to(action: :new) }
   it { is_expected.to route(:post, '/dashboard_bulletins').to(action: :create) }
+  it do
+    is_expected.to route(:get, '/dashboard_bulletins/123/edit')
+                     .to(action: :edit, id: '123')
+  end
+  it do
+    is_expected.to route(:patch, '/dashboard_bulletins/123')
+                     .to(action: :update, id: '123')
+  end
 end

--- a/spec/controllers/dashboard_bulletins_controller_spec.rb
+++ b/spec/controllers/dashboard_bulletins_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe DashboardBulletinsController, type: :controller do
+  it { is_expected.to route(:get, '/dashboard_bulletins/new').to(action: :new) }
+end

--- a/spec/factories/dashboard_bulletins.rb
+++ b/spec/factories/dashboard_bulletins.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :dashboard_bulletin do
+    markdown "MyText"
+    title "MyString"
+  end
+end

--- a/spec/features/admin_pages_spec.rb
+++ b/spec/features/admin_pages_spec.rb
@@ -19,7 +19,7 @@ describe 'Admin Only Pages', :pagination_helper, :tag_helper, :type => :feature 
       scenario 'displays the admin page' do
         successfully_visits_page '/admin'
         expect(page).to have_content 'Rails Admin'
-        page_has_selector '#admin-links a', count: 3
+        page_has_selector '#admin-links a', count: 4
       end
     end
 

--- a/spec/features/dashboard_bulletins_spec.rb
+++ b/spec/features/dashboard_bulletins_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+feature 'DashboardBulletins', type: :feature do
+  before { login_as(user, :scope => :user) }
+  after { logout(:user) }
+
+  context 'as a regular user' do
+    let(:user) { create_really_basic_user }
+    before { visit '/dashboard_bulletins/new' }
+    denies_access
+  end
+
+  context 'as an admin user' do
+    let(:user) { create_admin_user }
+    before { visit '/dashboard_bulletins/new' }
+    successfully_visits_page('/dashboard_bulletins/new')
+  end
+end

--- a/spec/features/dashboard_bulletins_spec.rb
+++ b/spec/features/dashboard_bulletins_spec.rb
@@ -15,19 +15,39 @@ feature 'DashboardBulletins', type: :feature do
     let(:title) { Faker::Book.title }
     let(:markdown) { Faker::Markdown.headers }
 
-    before { visit '/dashboard_bulletins/new' }
+    feature 'creating a bulletin' do
+      before { visit '/dashboard_bulletins/new' }
 
-    successfully_visits_page('/dashboard_bulletins/new')
+      successfully_visits_page('/dashboard_bulletins/new')
 
-    scenario 'adding a new bulletins' do
-      fill_in 'dashboard_bulletin_title', :with => title
-      fill_in 'editable-markdown', :with => markdown
-      click_button 'Create'
+      scenario 'admin adds a new bulletins' do
+        fill_in 'dashboard_bulletin_title', :with => title
+        fill_in 'editable-markdown', :with => markdown
+        click_button 'Create'
 
-      expect(DashboardBulletin.count).not_to eql 0
-      expect(DashboardBulletin.last.markdown).to eql markdown
+        expect(DashboardBulletin.count).not_to eql 0
+        expect(DashboardBulletin.last.markdown).to eql markdown
 
-      successfully_visits_page('/home/dashboard')
+        successfully_visits_page('/home/dashboard')
+      end
     end
+
+    feature 'modifying existing bulletins' do
+      let(:bulletin) { DashboardBulletin.create!(title: title, markdown: Faker::Markdown.emphasis) }
+
+      before do
+        visit edit_dashboard_bulletin_path(bulletin)
+      end
+
+      scenario 'updating the bulletin\'s content' do
+        successfully_visits_page edit_dashboard_bulletin_path(bulletin)
+        fill_in 'editable-markdown', :with => markdown
+        click_button 'Update'
+
+        expect(bulletin.reload.markdown).to eql markdown
+        successfully_visits_page('/home/dashboard')
+      end
+    end
+
   end
 end

--- a/spec/features/dashboard_bulletins_spec.rb
+++ b/spec/features/dashboard_bulletins_spec.rb
@@ -12,7 +12,22 @@ feature 'DashboardBulletins', type: :feature do
 
   context 'as an admin user' do
     let(:user) { create_admin_user }
+    let(:title) { Faker::Book.title }
+    let(:markdown) { Faker::Markdown.headers }
+
     before { visit '/dashboard_bulletins/new' }
+
     successfully_visits_page('/dashboard_bulletins/new')
+
+    scenario 'adding a new bulletins' do
+      fill_in 'dashboard_bulletin_title', :with => title
+      fill_in 'editable-markdown', :with => markdown
+      click_button 'Create'
+
+      expect(DashboardBulletin.count).not_to eql 0
+      expect(DashboardBulletin.last.markdown).to eql markdown
+
+      successfully_visits_page('/home/dashboard')
+    end
   end
 end

--- a/spec/models/dashboard_bulletin_spec.rb
+++ b/spec/models/dashboard_bulletin_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+describe DashboardBulletin, type: :model do
+  it { is_expected.to have_db_column(:markdown) }
+  it { is_expected.to have_db_column(:title) }
+  it { is_expected.to have_db_index(:created_at) }
+end

--- a/spec/support/feature_macros.rb
+++ b/spec/support/feature_macros.rb
@@ -17,6 +17,12 @@ module FeatureGroupMacros
     end
   end
 
+  def successfully_visits_page(path)
+    it "successfully visits #{path}" do
+      successfully_visits_page(path)
+    end
+  end
+
   def redirects_to_login_page
     it 'redirects to /login' do
       expect(page.current_path).to eql '/login'


### PR DESCRIPTION
Replace existing hard-coded panels on dashboard with editable bulletins. Admins can compose bulletins in markdown.  Bulletins can easily be edited and deleted. 

viewing list of current bulletins (admin-only): 

![view_bulletins](https://user-images.githubusercontent.com/8505044/40385993-7e69e4a6-5dd6-11e8-9008-cbe125b50a0a.png)

add a new bulletin (admin-only):

![create_new_bulletin](https://user-images.githubusercontent.com/8505044/40386011-8c32b98c-5dd6-11e8-82a5-8522e5d44b8a.png)

displayed on dashboard (all users):

![dashboard_bulletins](https://user-images.githubusercontent.com/8505044/40386104-c6d73428-5dd6-11e8-86a0-29244c25b086.png)

