### PR TITLE
Oligrapher assets overhaul

### DIFF
--- a/app/assets/javascripts/oligrapher-dev.js
+++ b/app/assets/javascripts/oligrapher-dev.js
@@ -1,3 +1,0 @@
-//= require oligrapher-dev/build/oligrapher
-//= require oligrapher-dev/build/LsDataConverter
-//= require oligrapher-dev/build/LsDataSource

--- a/app/assets/javascripts/oligrapher-dev.js.map
+++ b/app/assets/javascripts/oligrapher-dev.js.map
@@ -1,1 +1,0 @@
-//= require oligrapher-dev/build/oligrapher.js.map

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -60,15 +60,6 @@ class MapsController < ApplicationController
     render layout: 'embedded_oligrapher'
   end
 
-  def embedded_v2_dev
-    @dev_version = true
-
-    @header_pct = embedded_params.fetch(:header_pct, EMBEDDED_HEADER_PCT)
-    @annotation_pct = embedded_params.fetch(:annotation_pct, EMBEDDED_ANNOTATION_PCT)
-    response.headers.delete('X-Frame-Options')
-    render 'embedded_v2', layout: 'embedded_oligrapher'
-  end
-
   def embedded
     response.headers.delete('X-Frame-Options')
     render layout: 'fullscreen'
@@ -122,27 +113,6 @@ class MapsController < ApplicationController
     end
   end
 
-  def dev
-    check_permission 'admin'
-
-    if @map.is_private and !is_owner
-      unless params[:secret] and params[:secret] == @map.secret
-        raise Exceptions::PermissionError
-      end
-    end
-
-    @editable = false
-    @links = [
-      { text: 'embed', url: '#', id: 'oligrapherEmbedLink' },
-      { text: 'clone', url: clone_map_url(@map), method: 'POST' }
-    ]
-    @links.push({ text: 'edit', url: edit_map_url(@map) }) if is_owner
-    @links.push({ text: 'share link', url: share_map_url(id: @map.id, secret: @map.secret) }) if @map.is_private and is_owner
-
-    @dev_version = true
-    render 'story_map', layout: 'oligrapher'
-  end
-
   def raw
     # old map page for iframe embeds, forward to new embed page
     redirect_to embedded_map_path(@map)
@@ -182,15 +152,6 @@ class MapsController < ApplicationController
     ]
 
     @editable = true
-    render 'story_map', layout: 'oligrapher'
-  end
-
-  def dev_edit
-    check_owner
-    check_permission 'admin'
-    @links = [{ text: 'view', url: map_url(@map), target: '_blank' }]
-    @editable = true
-    @dev_version = true
     render 'story_map', layout: 'oligrapher'
   end
 

--- a/app/helpers/network_maps_helper.rb
+++ b/app/helpers/network_maps_helper.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module NetworkMapsHelper
+  def oligrapher_js_tags
+    content_tag(:script, nil, src: "/js/oligrapher/oligrapher-#{NetworkMap::OLIGRAPHER_VERSION}.js") +
+    content_tag(:script, nil, src: "/js/oligrapher/oligrapher_littlesis_bridge-#{NetworkMap::OLIGRAPHER_VERSION}.js")
+  end
+
   def smart_map_path(map)
     # map.annotations.empty? ? map_path(map) : story_map_path(map)
     map_path(map)

--- a/app/helpers/network_maps_helper.rb
+++ b/app/helpers/network_maps_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module NetworkMapsHelper
   def smart_map_path(map)
     # map.annotations.empty? ? map_path(map) : story_map_path(map)

--- a/app/models/network_map.rb
+++ b/app/models/network_map.rb
@@ -8,6 +8,8 @@ class NetworkMap < ApplicationRecord
 
   LS_DATA_SOURCE_BASE_URL = "#{Rails.application.default_url_options[:protocol]}://#{Rails.application.default_url_options[:host]}"
 
+  OLIGRAPHER_VERSION = APP_CONFIG['oligrapher_version']
+
   attribute :graph_data, OligrapherGraphData::Type.new
 
   has_paper_trail on: [:update, :destroy]

--- a/app/views/layouts/embedded_oligrapher.html.erb
+++ b/app/views/layouts/embedded_oligrapher.html.erb
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
 <html class="fullscreen">
-    <head>
-      <title><%= page_title %></title>
-      <%= javascript_pack_tag 'application' %> 
-	<%= javascript_include_tag "application" %>
-	<%= facebook_meta %>
-    </head>
-    <body>
-	<%= yield %>
-	<%= yield :body %>
-	<%= render 'shared/analytics' %>
-    </body>
+  <head>
+    <title><%= page_title %></title>
+    <%= javascript_pack_tag 'application' %> 
+    <%= javascript_include_tag "application" %>
+    <%= facebook_meta %>
+
+    <% if content_for?(:head) %>
+      <%= yield :head %>
+    <% end %>
+    
+  </head>
+  <body>
+    <%= yield %>
+    <%= yield :body %>
+    <%= render 'shared/analytics' %>
+  </body>
 </html>

--- a/app/views/layouts/fullscreen.html.erb
+++ b/app/views/layouts/fullscreen.html.erb
@@ -7,6 +7,11 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= facebook_meta %>
+
+  <% if content_for?(:head) %>
+    <%= yield :head %>
+  <% end %>
+  
   <% if Lilsis::Application.config.respond_to?(:google_site_verification) %>
     <meta name="google-site-verification" content="<%= Lilsis::Application.config.google_site_verification %>" />
   <% end %>

--- a/app/views/layouts/oligrapher.html.erb
+++ b/app/views/layouts/oligrapher.html.erb
@@ -7,6 +7,10 @@
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= facebook_meta %>
+
+    <% if content_for?(:head) %>
+      <%= yield :head %>
+    <% end %>
   </head>
   <body>
     <div id="top">

--- a/app/views/maps/embedded.html.erb
+++ b/app/views/maps/embedded.html.erb
@@ -1,8 +1,11 @@
 <%= render 'shared/facebook_sdk' %>
 
+<%= content_for(:head) do %>
+  <%= oligrapher_js_tags %>
+<% end %>
+
 <%= cache_if !user_signed_in?, [ 'embedded', @map ] do %>
 
-<%= javascript_include_tag "oligrapher" %>
 <% content_for(:page_title, raw(@map.name)) %>
 <% content_for(:facebook_title, @map.name) %>
 <% content_for(:facebook_image, @map.thumbnail) %>

--- a/app/views/maps/embedded_v2.html.erb
+++ b/app/views/maps/embedded_v2.html.erb
@@ -1,10 +1,7 @@
 <%= render 'shared/facebook_sdk' %>
 
-<% if @dev_version %>
-  <%= javascript_include_tag "oligrapher-dev" %>
-  <%= javascript_include_tag "oligrapher-dev.js.map" %>
-<% else %>
-  <%= javascript_include_tag "oligrapher" %>
+<%= content_for(:head) do %>
+  <%= oligrapher_js_tags %>
 <% end %>
 
 <%= cache_if !user_signed_in?, [ 'embedded', @map ] do %>

--- a/app/views/maps/story_map.html.erb
+++ b/app/views/maps/story_map.html.erb
@@ -4,16 +4,13 @@
 <% content_for(:facebook_type, "website") %>
 <% content_for(:facebook_url, map_url(@map)) %>
 
+<%= content_for(:head) do %>
+  <%= oligrapher_js_tags %>
+<% end %>
+
 <%= content_for(:body) do %>
 
 <%= render 'shared/facebook_sdk' %>
-
- <% if @dev_version %>
-    <%= javascript_include_tag "oligrapher-dev" %>
-<% else %>
-    <%= javascript_include_tag "oligrapher" %>
-<% end %>
-
 <%= cache_if @cacheable, @map do %>
 
 <div id="oligrapher"></div>

--- a/config/lilsis.yml.sample
+++ b/config/lilsis.yml.sample
@@ -51,6 +51,7 @@ defaults: &defaults
   donation_banner_display: false  # use 'everywhere' to display on all pages and 'homepage' for just the homepage
   donation_banner_html: |
     Today is #GivingTuesday. Please <a href="https://littlesis.org/donate/">make a tax-deductible donation</a><span class="d-sm-none d-md-inline">  to support our efforts to develop and maintain LittleSis.org
+  oligrapher_version: 0.4.1
   
 
 test:
@@ -60,6 +61,7 @@ test:
   asset_host: assets.example.net
   image_asset_host: images.example.net
   donation_banner_display: false
+  oligrapher_version: 0.0.1
 
 development:
   <<: *defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,10 +207,7 @@ Lilsis::Application.routes.draw do
       post 'feature'
       get 'embedded'
       get 'map_json'
-      get 'dev'
-      get 'edit/dev' => 'maps#dev_edit'
       get 'embedded/v2' => 'maps#embedded_v2'
-      get 'embedded/v2/dev' => 'maps#embedded_v2_dev'
     end
 
     collection do

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -22,10 +22,7 @@ describe MapsController, type: :controller do
     it { should route(:delete, '/maps/1706-colorado-s-terrible-ten').to(action: :destroy, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/embedded').to(action: :embedded, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/embedded/v2').to(action: :embedded_v2, id: '1706-colorado-s-terrible-ten') }
-    it { should route(:get, '/maps/1706-colorado-s-terrible-ten/embedded/v2/dev').to(action: :embedded_v2_dev, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/1706-colorado-s-terrible-ten/edit').to(action: :edit, id: '1706-colorado-s-terrible-ten') }
-    it { should route(:get, '/maps/1706-colorado-s-terrible-ten/dev').to(action: :dev, id: '1706-colorado-s-terrible-ten') }
-    it { should route(:get, '/maps/1706-colorado-s-terrible-ten/edit/dev').to(action: :dev_edit, id: '1706-colorado-s-terrible-ten') }
     it { should route(:get, '/maps/featured').to(action: :featured) }
     it { is_expected.to route(:get, '/maps/all').to(action: :all) }
     it { should route(:get, '/maps/search').to(action: :search) }
@@ -117,24 +114,6 @@ describe MapsController, type: :controller do
       expect(NetworkMap).to receive(:find).with('10').and_return(@map)
       get :show, params: { id: '10' }
       expect(response.status).to eql 302
-    end
-  end
-
-  describe '#dev' do
-    login_user
-
-    before do
-      @map = build(:network_map, is_private: false, title: 'a map')
-      expect(NetworkMap).to receive(:find).with('10-a-map').and_return(@map)
-      expect(controller).to receive(:check_permission).with('admin')
-      get :dev, params: { id: '10-a-map' }
-    end
-
-    it { should respond_with :success }
-    it { should render_template 'story_map' }
-
-    it 'sets dev_version' do
-      expect(assigns(:dev_version)).to eql true
     end
   end
 

--- a/spec/features/maps_spec.rb
+++ b/spec/features/maps_spec.rb
@@ -15,11 +15,12 @@ feature 'maps index page' do
     before { visit map_path(regular_map) }
 
     it 'has oligrapher js with username and link' do
+      expect(page.html).to include "/js/oligrapher/oligrapher-#{NetworkMap::OLIGRAPHER_VERSION}.js"
+      expect(page.html).to include "/js/oligrapher/oligrapher_littlesis_bridge-#{NetworkMap::OLIGRAPHER_VERSION}.js"
       expect(page.html).to include "{ name: \"#{user.username}\""
       expect(page.html).to include "url: \"https://littlesis.org/user/#{user.username}\" }"
     end
   end
-
 
   feature 'navigating to "/maps"' do
     before { visit '/maps' }

--- a/spec/helpers/network_maps_helper_spec.rb
+++ b/spec/helpers/network_maps_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe NetworkMapsHelper do
+  describe 'network_map_feature_btn' do
+    context 'when map is featured' do
+      let(:map) { build(:network_map, is_featured: true) }
+
+      it 'contains featured icon' do
+        expect(helper.network_map_feature_btn(map)).to include 'class="featured-map-star"'
+      end
+    end
+
+    context 'when map is not featured' do
+      let(:map) { build(:network_map, is_featured: false) }
+
+      it 'contains not featured icon' do
+        expect(helper.network_map_feature_btn(map)).to include 'class="not-featured-map-star"'
+      end
+    end
+  end
+end

--- a/spec/helpers/network_maps_helper_spec.rb
+++ b/spec/helpers/network_maps_helper_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 describe NetworkMapsHelper do
+  describe 'oligrapher_js_tags' do
+    specify do
+      expect(helper.oligrapher_js_tags)
+        .to eq '<script src="/js/oligrapher/oligrapher-0.0.1.js"></script><script src="/js/oligrapher/oligrapher_littlesis_bridge-0.0.1.js"></script>'
+    end
+  end
+
   describe 'network_map_feature_btn' do
     context 'when map is featured' do
       let(:map) { build(:network_map, is_featured: true) }

--- a/spec/models/network_map_spec.rb
+++ b/spec/models/network_map_spec.rb
@@ -7,6 +7,10 @@ describe NetworkMap, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to validate_presence_of(:title) }
 
+  describe 'OLIGRAPHER_VERSION constant' do
+    specify { expect(NetworkMap::OLIGRAPHER_VERSION).to eq '0.0.1' }
+  end
+
   describe '#generate_index_data' do
     let(:e1) { create(:person, :with_person_name, blurb: 'xyz') }
     let(:e2) { create(:person, :with_person_name, blurb: nil) }


### PR DESCRIPTION
- No longer compile oligrapher with sprockets
- oligrapher is now versioned based on the git tag and served via our web server (outside of rails)
- paths to oligrapher: ` /js/oligrapher/oligrpaher-VERSION.js ` and ` /js/oligrapher/oligrapher_littlesis_bridge-VERSION.js `
- dev version of oligrapher is removed and instead support for source maps have been added