### PR TITLE
signed in users can make API requests without a token

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,8 +6,8 @@ module Api
     protect_from_forgery with: :null_session
 
     unless Rails.env.development?
-      before_action :verify_api_token
-      skip_before_action :verify_api_token, only: [:index]
+      before_action :api_authenticate!
+      skip_before_action :api_authenticate!, only: [:index]
     end
 
     rescue_from ActiveRecord::RecordNotFound do
@@ -40,10 +40,21 @@ module Api
 
     protected
 
-    def verify_api_token
-      api_token = request.headers['Littlesis-Api-Token']
+    def api_authenticate!
+      return if api_token.blank? && user_signed_in?
+
+      verify_api_token!
+    end
+
+    def verify_api_token!
       raise Exceptions::MissingApiTokenError if api_token.blank?
       raise Exceptions::PermissionError unless ApiToken.valid_token?(api_token)
+    end
+
+    private
+
+    def api_token
+      request.headers['Littlesis-Api-Token']
     end
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Users::PasswordsController < Devise::PasswordsController
   # GET /resource/password/new
   # def new

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -15,6 +15,31 @@ describe Api, :pagination_helper do
 
   let(:meta) { Api::META }
 
+  describe 'access control' do
+    let(:api_request) do
+      -> { get api_entity_path(create(:entity_person)) }
+    end
+
+    context 'when no api token provided' do
+      before { api_request.call }
+
+      specify { expect(response).to have_http_status :unauthorized }
+    end
+
+    context 'when no api token provided, but user is logged in' do
+      let(:user) { create_really_basic_user }
+
+      before do
+        login_as(user, :scope => :user)
+        api_request.call
+      end
+
+      after { logout(:user) }
+
+      specify { expect(response).to have_http_status :ok }
+    end
+  end
+
   describe 'entities' do
     let(:lawyer) do
       create(:entity_person).tap { |e| e.add_extension('Lawyer') }


### PR DESCRIPTION
resolves #837 

It don't solve the situation of  non-signed in users (aka anyone normally browsing our site) to be able to access the api. Perhaps down the line we might want to use our own AP on public pages, but that's not not needed at the moment. 