### PR TITLE
improve ExternalDatasetService::Iapd#validate_match

### DIFF
--- a/spec/models/edited_entity_spec.rb
+++ b/spec/models/edited_entity_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 describe EditedEntity, type: :model do
   let(:entity_id) { create(:entity_person, last_user_id: 1).id }
   let(:version_id) { Faker::Number.unique.number(8).to_i }
@@ -15,7 +14,14 @@ describe EditedEntity, type: :model do
   end
 
   let(:versions) do
-    [entity_version, relationship_version, create(:page_version)]
+    [].tap do |arr|
+      arr << entity_version
+      sleep 0.01
+      arr << relationship_version
+      sleep 0.01
+      arr << create(:page_version)
+    end
+    # [entity_version, relationship_version, create(:page_version)]
   end
 
   it { is_expected.to have_db_column(:user_id).of_type(:integer) }

--- a/spec/services/external_dataset_service_spec.rb
+++ b/spec/services/external_dataset_service_spec.rb
@@ -92,16 +92,17 @@ describe ExternalDatasetService do
     describe '#validate_match!' do
       let(:person) { create(:entity_person) }
       let(:org) { create(:entity_org) }
+      let(:another_org) { create(:entity_org) }
       let(:service_person) { ExternalDatasetService::Iapd.new(entity: person, external_dataset: external_dataset_owner) }
       let(:service_org) { ExternalDatasetService::Iapd.new(entity: org, external_dataset: external_dataset_advisor) }
 
       it 'raises error if person has crd number' do
-        person.add_extension('BusinessPerson', crd_number: crd_number)
+        person.add_extension('BusinessPerson', crd_number: Faker::Number.unique.number(5).to_i)
         expect { service_person.validate_match! }.to raise_error(ExternalDatasetService::InvalidMatchError)
       end
 
       it 'rasies error if org has a crd number' do
-        org.add_extension('Business', crd_number: crd_number)
+        org.add_extension('Business', crd_number: Faker::Number.unique.number(5).to_i)
         expect { service_org.validate_match! }.to raise_error(ExternalDatasetService::InvalidMatchError)
       end
 
@@ -115,7 +116,15 @@ describe ExternalDatasetService do
         expect { service_person.validate_match! }.not_to raise_error
       end
 
-      it 'raises error if another entity already has crd number'
+      it 'ok if business has the same crd number' do
+        org.add_extension('Business', crd_number: 126_188) # see factories/iapd_data
+        expect { service_org.validate_match! }.not_to raise_error
+      end
+
+      it 'raises error if another entity already has crd number' do
+        another_org.add_extension('Business', crd_number: 126_188)
+        expect { service_org.validate_match! }.to raise_error(ExternalDatasetService::InvalidMatchError)
+      end
     end
 
     describe 'match' do


### PR DESCRIPTION
- handle case where matching with entity that already has a crd
  number

- check that no other entity has claimed the crd number already