### PR TITLE
Editable business fields

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -261,7 +261,8 @@ class EntitiesController < ApplicationController
       :name, :blurb, :summary, :website, :start_date, :end_date, :is_current,
       person_attributes: [:name_first, :name_middle, :name_last, :name_prefix, :name_suffix, :name_nick, :birthplace, :gender_id, :id ],
       public_company_attributes: [:ticker, :id],
-      school_attributes: [:is_private, :id]
+      school_attributes: [:is_private, :id],
+      business_attributes: [:id, :annual_profit, :assets, :marketcap, :net_income]
     )
   end
 

--- a/app/models/concerns/entity_extensions.rb
+++ b/app/models/concerns/entity_extensions.rb
@@ -19,9 +19,7 @@ module EntityExtensions
     has_one :political_fundraising, inverse_of: :entity, dependent: :destroy
 
     ## extension nexted attributes
-    accepts_nested_attributes_for :person
-    accepts_nested_attributes_for :public_company
-    accepts_nested_attributes_for :school
+    accepts_nested_attributes_for :person, :public_company, :school, :business
   end
 
   class_methods do

--- a/app/views/entities/edit.html.erb
+++ b/app/views/entities/edit.html.erb
@@ -91,6 +91,35 @@
     <% end %>
   <% end %>
 
+  <% if @entity.has_extension?('Business') %>
+    <%= f.fields_for :business do |business_form| %>
+      <div class="<%= input_div_wrapper_class %>">
+	      <%= business_form.label(:marketcap, 'Market capitalization', class: label_class) %>
+        <div class="col-sm-4">
+	        <%= business_form.number_field(:marketcap) %>
+	      </div>
+      </div>
+      <div class="<%= input_div_wrapper_class %>">
+	      <%= business_form.label(:assets, 'Assets', class: label_class) %>
+	      <div class="col-sm-4">
+	        <%= business_form.number_field(:assets) %>
+	      </div>
+      </div>
+      <div class="<%= input_div_wrapper_class %>">
+	      <%= business_form.label(:net_income, 'Net income', class: label_class) %>
+	      <div class="col-sm-4">
+	        <%= business_form.number_field(:net_income) %>
+	      </div>
+      </div>
+      <div class="<%= input_div_wrapper_class %>">
+	      <%= business_form.label(:annual_profit, 'Annual profit', class: label_class) %>
+	      <div class="col-sm-4">
+	        <%= business_form.number_field(:annual_profit) %>
+	      </div>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @entity.has_extension?('School') %>
     <%= f.fields_for :school, @entity.school do |school_form| %>
       <div class="<%= input_div_wrapper_class %>">

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -483,28 +483,39 @@ describe EntitiesController, type: :controller do
     end
 
     describe 'updating a public company' do
-      before do
-        @org = create(:entity_org)
-        @org.add_extension('PublicCompany', ticker: 'XYZ')
-        @params = { id: @org.id,
-                    entity: {
-                      name: @org.name,
-                      public_company_attributes: {
-                        id: @org.public_company.id,
-                        ticker: 'ABC'
-                      }
-                    },
-                    reference: { 'url' => 'http://example.com', 'name' => 'new reference' } }
-      end
+      let(:public_company) { create(:public_company_entity) }
+      let(:params) {
+        { id: public_company.id,
+          entity: {
+            name: public_company.name,
+            public_company_attributes: {
+              id: public_company.public_company.id,
+              ticker: 'ABC'
+            },
+            business_attributes: {
+              id: public_company.business.id,
+              annual_profit: 999,
+              assets: 100,
+              marketcap: 200,
+              net_income: 300
+            },
+          },
+          reference: { 'url' => 'http://example.com', 'name' => 'new reference' } }
+      }
 
       it 'updates ticker' do
-        expect(Entity.find(@org.id).public_company.ticker).to eq 'XYZ'
-        expect { patch :update, params: @params }.to change { PublicCompany.find(@org.public_company.id).ticker }.to('ABC')
+        expect(Entity.find(public_company.id).public_company.ticker).to eq 'XYZ'
+        expect { patch :update, params: params }.to change { PublicCompany.find(public_company.public_company.id).ticker }.to('ABC')
+      end
+
+      it 'updates business fields' do
+        patch :update, params: params
+        expect(public_company.business.reload).to have_attributes(annual_profit: 999, assets: 100, marketcap: 200, net_income: 300)
       end
 
       it 'redirects to entity url' do
-        patch :update, params: @params
-        expect(response).to redirect_to entity_path(@org)
+        patch :update, params: params
+        expect(response).to redirect_to entity_path(public_company)
       end
     end
   end # end describe #update

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -110,9 +110,9 @@ describe EntitiesController, type: :controller do
   end
 
   describe '#create' do
-    let(:params) { {"entity"=>{"name"=>"new entity", "blurb"=>"a blurb goes here", "primary_ext"=>"Org" } } }
-    let(:params_missing_ext) { {"entity"=>{"name"=>"new entity", "blurb"=>"a blurb goes here", "primary_ext"=>"" } } }
-    let(:params_add_relationship_page) { params.merge({'add_relationship_page' => 'TRUE'}) }
+    let(:params) { { "entity" => { "name" => "new entity", "blurb" => "a blurb goes here", "primary_ext" => "Org" } } }
+    let(:params_missing_ext) { { "entity" => { "name" => "new entity", "blurb" => "a blurb goes here", "primary_ext" => "" } } }
+    let(:params_add_relationship_page) { params.merge({ 'add_relationship_page' => 'TRUE' }) }
     let(:params_missing_ext_add_relationship_page) { params_missing_ext.merge({ 'add_relationship_page' => 'TRUE' }) }
 
     context 'user is logged in' do
@@ -244,7 +244,7 @@ describe EntitiesController, type: :controller do
           expect(controller).to receive(:check_permission).and_call_original
           d1 = create(:os_donation, fec_cycle_id: 'unique_id_1')
           d2 = create(:os_donation, fec_cycle_id: 'unique_id_2')
-          post :match_donation, params: { id: @entity.id , payload: [d1.id, d2.id] }
+          post :match_donation, params: { id: @entity.id, payload: [d1.id, d2.id] }
         end
 
         it { should respond_with(200) }

--- a/spec/factories/entities.rb
+++ b/spec/factories/entities.rb
@@ -20,6 +20,15 @@ FactoryBot.define do
     primary_ext { 'Org' }
   end
 
+  factory :public_company_entity, class: Entity do
+    name { 'org' }
+    primary_ext { 'Org' }
+    after :create do |entity|
+      entity.add_extension('PublicCompany', ticker: 'XYZ')
+      entity.add_extension('Business')
+    end
+  end
+
   factory :elected, class: Entity do
     name { 'Elected Representative' }
     primary_ext { 'Person' }

--- a/spec/features/edit_entity_spec.rb
+++ b/spec/features/edit_entity_spec.rb
@@ -1,4 +1,4 @@
-describe 'edit enity page', type: :feature do
+describe 'edit entity page', type: :feature do
   let(:user) { create_really_basic_user }
   let(:entity) { create(:public_company_entity, last_user_id: user.sf_guard_user.id) }
 
@@ -16,7 +16,7 @@ describe 'edit enity page', type: :feature do
     end
     after { logout(user) }
 
-    feature 'Viewing the edit entity page' do
+    feature 'viewing the edit entity page' do
       scenario 'displays header, action buttons, and edit references panel' do
         expect(page.status_code).to eq 200
         expect(page).to have_current_path edit_entity_path(entity)
@@ -29,7 +29,7 @@ describe 'edit enity page', type: :feature do
       end
     end
 
-    feature "Updating an entity's fields" do
+    feature "updating an entity's fields" do
       let(:new_short_description) { Faker::Lorem.sentence }
 
       context "selecting 'just cleaning up' " do
@@ -43,7 +43,7 @@ describe 'edit enity page', type: :feature do
         end
       end
 
-      context 'Filling out business data' do
+      context 'filling out business data' do
         scenario 'user adds business financial details' do
           expect(entity.business).to be_a(Business)
 
@@ -68,7 +68,7 @@ describe 'edit enity page', type: :feature do
         end
       end
 
-      context 'Adding a new reference' do
+      context 'adding a new reference' do
         let(:url) { Faker::Internet.unique.url }
         let(:ref_name) { 'reference-name' }
         let(:start_date) { '1950-01-01' }
@@ -92,7 +92,7 @@ describe 'edit enity page', type: :feature do
             .to eql({ 'referenceable_id' => entity.id, 'referenceable_type' => 'Entity' })
         end
 
-        context 'When the url does not exist as a document' do
+        context 'when the url does not exist as a document' do
           before do
             @document_count = Document.count
             update_entity.call
@@ -105,7 +105,7 @@ describe 'edit enity page', type: :feature do
           end
         end
 
-        context 'When the url already exists as a document' do
+        context 'when the url already exists as a document' do
           before do
             Document.create!(url: url)
             @document_count = Document.count

--- a/spec/features/edit_entity_spec.rb
+++ b/spec/features/edit_entity_spec.rb
@@ -1,6 +1,6 @@
 describe 'edit enity page', type: :feature do
   let(:user) { create_really_basic_user }
-  let(:entity) { create(:entity_org, last_user_id: user.sf_guard_user.id) }
+  let(:entity) { create(:public_company_entity, last_user_id: user.sf_guard_user.id) }
 
   context 'user is not logged in' do
     before { visit edit_entity_path(entity) }
@@ -40,6 +40,31 @@ describe 'edit enity page', type: :feature do
 
           expect(page).to have_current_path entity_path(entity)
           expect(entity.reload.blurb).to eql new_short_description
+        end
+      end
+
+      context 'Filling out business data' do
+        scenario 'user adds business financial details' do
+          expect(entity.business).to be_a(Business)
+
+          within ".edit_entity" do
+            check 'reference_just_cleaning_up'
+            fill_in 'Market capitalization', with: 123
+            fill_in 'Assets', with: 432
+            fill_in 'Net income', with: 999
+            fill_in 'Annual profit', with: 10101
+            click_button 'Update'
+          end
+
+          within "#action-buttons" do
+            click_on "edit"
+          end
+
+          expect(page).to have_current_path edit_entity_path(entity)
+          expect(page).to have_field('Market capitalization', with: 123)
+          expect(page).to have_field('Assets', with: 432)
+          expect(page).to have_field('Net income', with: 999)
+          expect(page).to have_field('Annual profit', with: 10101)
         end
       end
 

--- a/spec/features/new_entity_spec.rb
+++ b/spec/features/new_entity_spec.rb
@@ -18,7 +18,7 @@ describe '/entities/new', type: :feature do
 
   describe 'creating a new entity' do
     let(:name) { Faker::Name.name }
-    let(:blurb) { Faker::Quotes::Shakespeare.hamlet_quote }
+    let(:blurb) { Faker::Quotes::Shakespeare.hamlet_quote.truncate(200) }
 
     context 'when user is confirmed over 10 minutes  ago' do
       before do


### PR DESCRIPTION
Implements #501. 

I have added only the fields specified in #501, but we could also add `revenue` from the `org` object if that is useful.