### PR TITLE
Client side entity name validation

### DIFF
--- a/app/assets/javascripts/pages/entity.js
+++ b/app/assets/javascripts/pages/entity.js
@@ -1,64 +1,62 @@
-var entity = {}; 
+var entity = {} 
 
 // Toggles visibility of entity summary
 entity.summaryToggle = function(){
-  $('.summary-excerpt').toggle();
-  $('.summary-full').toggle();
-  $('.summary-show-more').toggle();
-  $('.summary-show-less').toggle();
-};
+  $('.summary-excerpt').toggle()
+  $('.summary-full').toggle()
+  $('.summary-show-more').toggle()
+  $('.summary-show-less').toggle()
+}
 
 // Toggles visibility of a related entity's additional relationships on a profile page
 entity.relationshipsToggle = function(e) {
-  $(e.target).closest('.relationship-section').find('.collapse').collapse('toggle');
-};
-
-
+  $(e.target).closest('.relationship-section').find('.collapse').collapse('toggle')
+}
 
 /* Editable blurb */
 
 entity._submitBlurb = function(newBlurb, original) {
   if (newBlurb !== original) {
-    api.addBlurbToEntity(newBlurb, utility.entityInfo('entityid'));
+    api.addBlurbToEntity(newBlurb, utility.entityInfo('entityid'))
   }
 
-  $('#entity-blurb-text').html(newBlurb);
-  $('#entity-blurb-pencil').show();
-};
+  $('#entity-blurb-text').html(newBlurb)
+  $('#entity-blurb-pencil').show()
+}
 
 entity._editableBlurbInput = function(text) {
   function handleKeyup(e) {
     if ((e.keyCode || e.which) === 13) {
-      entity._submitBlurb($(this).val(), text);
+      entity._submitBlurb($(this).val(), text)
     } else if ( (e.keyCode || e.which) === 27) {
-      $('#entity-blurb-text').html(text);
-      $('#entity-blurb-pencil').show();
+      $('#entity-blurb-text').html(text)
+      $('#entity-blurb-pencil').show()
     }
   }
 
-  return $('<input>', { "val": text, "keyup": handleKeyup });
+  return $('<input>', { "val": text, "keyup": handleKeyup })
 
-};
+}
 
 
 entity.editableBlurb = function() {
   $("#editable-blurb").hover(
     function() {
-      $("#entity-blurb-pencil").show();
+      $("#entity-blurb-pencil").show()
     },
     function() {
-      $("#entity-blurb-pencil").hide();
+      $("#entity-blurb-pencil").hide()
     }
-  );
-  $('#entity-blurb-pencil').click(function(x){
-    $(this).hide();
+  )
+  $('#entity-blurb-pencil').click(function(){
+    $(this).hide()
 
     // get existing blurb text
-    var blurb = $('#entity-blurb-text').text() || '';
+    var blurb = $('#entity-blurb-text').text() || ''
 
     // replace current text with input
     $('#entity-blurb-text').html(
       entity._editableBlurbInput(blurb)
-    );
-  });
-};
+    )
+  })
+}

--- a/app/assets/javascripts/pages/entity.js
+++ b/app/assets/javascripts/pages/entity.js
@@ -60,3 +60,34 @@ entity.editableBlurb = function() {
     )
   })
 }
+
+// Validates an entity form via an AJAX call
+entity.validate = function(form, attributes){
+  entity.form = form
+  $.post("/entities/validate", entity.form.serialize(), function(errors) {
+    entity.errors = errors
+    entity.displayErrors(attributes)
+  })
+}
+
+// Display any validation errors in the entity form
+entity.displayErrors = function(attributes){
+  entity.form.find("#error_explanation").remove()
+  var template = $(document.importNode(document.getElementById("validation_errors").content, true))
+  var displayableErrors = false
+
+  for (var i in attributes) {
+    var attribute = attributes[i]
+
+    for (var value in entity.errors[attribute]){
+      if (entity.errors[attribute].hasOwnProperty(value)){
+        template.find("ul").append(`<li>${attribute}: ${entity.errors[attribute][value]}</li>`)
+        displayableErrors = true
+      }
+    }
+  }
+
+  if (displayableErrors) {
+    entity.form.prepend(template)
+  }
+}

--- a/app/views/entities/_new_entity_form.html.erb
+++ b/app/views/entities/_new_entity_form.html.erb
@@ -78,6 +78,13 @@
     </div>
 <% end %>
 
+<template id="validation_errors">
+  <div id="error_explanation" class="alert alert-warning">
+    <ul>
+    </ul>
+  </div>
+</template>
+
 <div id="wait" style="display: none;">
     <br>
     <h3>Wait! Does this entity already exist?</h3>
@@ -103,6 +110,10 @@
        $("#org-types").hide();            
      }
    });
+
+   $('#new_entity input').on("blur", function() {
+     entity.validate($('#new_entity'), ["name"])
+   })
 
    var input = $("#entity_name");
    var typingTimer;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,8 @@ Lilsis::Application.routes.draw do
     end
   end
 
+  post '/entities/validate' => 'entities#validate'
+
   constraints(id: /[0-9]+(-[^\/]+)?/) do
     resources :entities do
       member do

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -520,6 +520,27 @@ describe EntitiesController, type: :controller do
     end
   end # end describe #update
 
+  describe 'validate' do
+    it 'returns validation errors for invalid entities' do
+      post :validate, params: { entity: { name: 'Mr Aesop', blurb: 'Hic Rhodus hic salta', primary_ext: '' } }
+
+      expect(response.status).to eq 200
+
+      body = JSON.parse(response.body)
+      expect(body["name"].first).to eq("Could not find a first name. Mr is a common prefix")
+      expect(body["primary_ext"].first).to eq("can't be blank")
+    end
+
+    it 'returns nothing for valid entities' do
+      post :validate, params: { entity: { name: 'Carl Schmitt', blurb: 'The exception proves everything.', primary_ext: 'org' } }
+
+      expect(response.status).to eq 200
+
+      body = JSON.parse(response.body)
+      expect(body).to eq({})
+    end
+  end
+
   describe '#destory' do
     context 'user is not a deleter' do
       before { delete :destroy, params: { id: '123' } }

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -661,8 +661,7 @@ describe Entity, :tag_helper do
 
       it 'updates last user id and updated_at' do
         expect(entity.last_user_id).to eql initial_user.id
-        entity.update_timestamp_for(new_user)
-        expect(entity.updated_at).to be > 1.second.ago
+        expect{entity.update_timestamp_for(new_user)}.to change {entity.updated_at}
         expect(entity.last_user_id).to eql new_user.id
       end
 


### PR DESCRIPTION
Calls the API for entity validation on form input `blur` and presents the result with the same formatting we would use for a server-side validation.

This is a general-purpose method and will work for anything that can be validated server-side. In the present case, we specify only the `name` attribute for validation.

![Screenshot 2020-04-01 at 21 01 18](https://user-images.githubusercontent.com/25692779/78181293-03ee8d00-745c-11ea-8ad9-0790d6110a04.png)
