### PR TITLE
add descriptions to results of oligrapher/find_nodes endpoint

### DIFF
--- a/app/utility/oligrapher.rb
+++ b/app/utility/oligrapher.rb
@@ -44,6 +44,7 @@ module Oligrapher
       {
         id: entity.id.to_s,
         name: entity.name,
+        description: entity.blurb,
         image: entity.featured_image&.image_url('profile'),
         url: Routes.entity_url(entity)
       }

--- a/spec/factories/entities.rb
+++ b/spec/factories/entities.rb
@@ -117,4 +117,8 @@ FactoryBot.define do
   trait :with_org_name do
     name { Faker::Company.name }
   end
+
+  trait :with_org_blurb do
+    blurb { Faker::Company.bs }
+  end
 end

--- a/spec/requests/oligrapher_request_spec.rb
+++ b/spec/requests/oligrapher_request_spec.rb
@@ -197,16 +197,18 @@ describe "Oligrapher", type: :request do
   end
 
   describe 'find_nodes' do
-    let(:nodes) do
-      [build(:org, :with_org_name), build(:org, :with_org_name)]
-    end
+    let(:image) { build(:image, is_featured: true) }
+    let(:org1) { build(:org, :with_org_name, :with_org_blurb) }
+    let(:org2) { build(:org, :with_org_name) }
+    let(:nodes) { [org1, org2] }
 
     it 'responds with bad request if missing query' do
       get '/oligrapher/find_nodes', params: {}
       expect(response).to have_http_status 400
     end
 
-    it 'renders json' do
+    it 'renders json with descriptions and images' do
+      expect(org2).to receive(:featured_image).and_return(image)
       expect(EntitySearchService).to receive(:new)
                                        .once
                                        .with(query: 'abc',
@@ -218,6 +220,9 @@ describe "Oligrapher", type: :request do
 
       expect(response).to have_http_status 200
       expect(json.length).to eq 2
+      expect(json.map { |org| org['description'] }).to eq nodes.map(&:blurb)
+      expect(json.first['image']).to be_nil
+      expect(json.last['image']).not_to be_nil
     end
   end
 end

--- a/spec/utility/oligrapher_spec.rb
+++ b/spec/utility/oligrapher_spec.rb
@@ -9,6 +9,7 @@ describe Oligrapher do
         .to eql(id: entity.id.to_s,
                 name: entity.name,
                 image: nil,
+                description: nil,
                 url: "http://localhost:8080/org/#{entity.to_param}")
     end
   end


### PR DESCRIPTION
so that entity descriptions can be shown in Oligrapher's NodeTool search results

(I don't know why i named this branch oligrapher-find-node-images instead of oligrapher-find-node-descriptions)