### PR TITLE
EntityConnectionsQuery.category() accepts category id as string

### DIFF
--- a/app/queries/entity_connections_query.rb
+++ b/app/queries/entity_connections_query.rb
@@ -13,7 +13,7 @@ class EntityConnectionsQuery
   def category(category_id)
     @category_id = category_id&.to_i
 
-    unless @category_id.nil? || (1..12).cover?(category_id)
+    unless @category_id.nil? || (1..12).cover?(@category_id)
       raise Exceptions::InvalidRelationshipCategoryError
     end
 
@@ -38,6 +38,6 @@ class EntityConnectionsQuery
       .where(@category_id ? "link.category_id = #{@category_id}" : nil)
       .order(link_count: :desc)
       .page(@page)
-      .per(@per_page || PER_PAGE)
+      .per(@per_page)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # see: https://github.com/rails/web-console for info on web_console configuruation
-  config.web_console.whitelisted_ips = ['172.21.0.0/16', '172.19.0.0/16']
+  config.web_console.whitelisted_ips = ['172.0.0.0/8']
   config.web_console.whiny_requests = false
 
   # In the development environment your application's code is reloaded on

--- a/spec/queries/entity_connections_query_spec.rb
+++ b/spec/queries/entity_connections_query_spec.rb
@@ -44,4 +44,12 @@ describe EntityConnectionsQuery do
       ).to eq 1
     end
   end
+
+  describe 'accepts category ids as strings' do
+    specify do
+      expect(
+        query.category(Relationship::DONATION_CATEGORY.to_s).page(1).run.size
+      ).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
It seems that `EntityConnectionsQuery.category()` was already meant to accept strings but there was a bug in implementation.

This branch also modifies the web-console whitelist to accept the full range of docker IP addresses.