### PR TITLE
non-USD payments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'redis'
 # For easy cron scheduling
 gem 'whenever', '~> 1.0.0', :require => false
 
+# handle currencies etc
+gem 'money'
+
 group :development do
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    money (6.13.7)
+      i18n (>= 0.6.4, <= 2)
     msgpack (1.3.3)
     multi_json (1.14.1)
     multi_xml (0.6.0)
@@ -426,6 +428,7 @@ DEPENDENCIES
   kaminari
   memory_profiler
   mini_magick
+  money
   mysql2 (~> 0.5.2)
   nokogiri
   paper_trail (= 10.3.1)

--- a/app/assets/javascripts/pages/bulkAdd.js
+++ b/app/assets/javascripts/pages/bulkAdd.js
@@ -133,9 +133,9 @@
     case 4:
       return [ 'Jane Doe', 'About Jane...', 'Person', '', '', '', '' ];
     case 5:
-      return [ 'Mr. Big Donor', 'Hedge fund manager', 'Person', 'Campaign Contribution', '250000', '2017-05-01', '2017-05-01', '', '', '' ];
+      return [ 'Mr. Big Donor', 'Hedge fund manager', 'Person', 'Campaign Contribution', '250000', 'usd', '2017-05-01', '2017-05-01', '', '', '' ];
     case 6:
-      return [ 'Company X', '', 'Org', 'sold real estate', 'bought real estate', '1996-10-01', '', '', '', '', ''];
+      return [ 'Company X', '', 'Org', 'sold real estate', 'bought real estate', '', '', '1996-10-01', '', '', '', '', ''];
     case 8:
       return [ 'Jane Doe', 'About Jane...', 'Person', 'Friend', 'Friend', '2000-01-01', '2015-04-15', 'NO', '' ];
     case 9:
@@ -347,6 +347,11 @@
     }).append('<option></option><option>Org</option><option>Person</option>');
   }
 
+  function currencySelect() {
+    var template = $('.currency-selector')[0];
+    return template.content.cloneNode(true);
+  }
+
   // trio Boolean Helper
   // .create(option) => return new button element
   // .value(<element>) -> returns selected button
@@ -394,6 +399,8 @@
       //return $('<td>', autocomplete);
     } else if (col[1] === 'primary_ext') {
       return $('<td>').append(primaryExtRadioButtons());
+    } else if (col[1] === 'currency') {
+      return $('<td>').append(currencySelect());
     } else if (col[1] === 'notes') {
       return $('<td>', { css: cssForNotesColumn(col), contenteditable: 'true' });
     } else {

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -40,6 +40,7 @@ class RelationshipsController < ApplicationController
     :description1,
     :description2,
     :amount,
+    :currency,
     :goods,
     :notes,
     :start_date,

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -20,6 +20,7 @@ class RelationshipsController < ApplicationController
     :start_date,
     :end_date,
     :amount,
+    :currency,
     :goods,
     :is_board,
     :is_executive,
@@ -224,6 +225,7 @@ class RelationshipsController < ApplicationController
       goods: relationship.fetch('goods', nil),
       notes: relationship.fetch('notes', nil),
       amount: relationship.fetch('amount', nil),
+      currency: relationship.fetch('currency', nil),
       is_current: relationship.fetch('is_current', nil),
       last_user_id: current_user.id
     }

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -96,4 +96,28 @@ module RelationshipsHelper
     titles_and_entities.reverse! if relationship.is_hierarchy?
     titles_and_entities.map { |x| Struct.new(:title, :entity).new(*x) }
   end
+
+  def options_for_currency_select
+    move_elements_to_start_of_array([:usd, :gbp, :eur], sorted_currencies)
+      .collect { |c| [c[:display], c[:iso]] }
+  end
+
+  private
+
+  def sorted_currencies
+    Money::Currency.table
+      .map { |k, v| { iso: k, display: currency_display_name(v) } }
+      .sort_by { |c| c[:iso] }
+  end
+
+  def currency_display_name(currency)
+    "#{currency[:iso_code]} (#{currency[:name]})"
+  end
+
+  def move_elements_to_start_of_array(elements, array)
+    elements.reverse_each do |e|
+      array.insert(0, array.delete_at(array.index { |c| c[:iso] == e }))
+    end
+    array
+  end
 end

--- a/app/javascript/packs/common/utility.js
+++ b/app/javascript/packs/common/utility.js
@@ -134,6 +134,7 @@ export function relationshipDetails(category) {
   var endDate = ['End date', 'end_date', 'date' ];
   var type = ['Type', 'description1', 'text'];
   var amount = ['Amount', 'amount', 'money'];
+  var currency = ['Currency', 'currency', 'text'];
   var goods = ['Goods', 'goods', 'text'];
   var d1 = ['entity 1 is __ of entity 2', 'description1', 'text'];
   var d2 = ['entity 2 is __ of entity 1', 'description2', 'text'];
@@ -161,9 +162,9 @@ export function relationshipDetails(category) {
   case 4: // family
     return [ d1, d2, startDate, endDate, isCurrent ];
   case 5: // donation
-    return [ type, amount, startDate, endDate, isCurrent, goods ];
+    return [ type, amount, currency, startDate, endDate, isCurrent, goods ];
   case 6: // transaction
-    return [ d1, d2, amount, startDate, endDate, isCurrent, goods ];
+    return [ d1, d2, amount, currency, startDate, endDate, isCurrent, goods ];
   case 7: // lobby
     throw 'Lobbying relationships are not currently supposed by the bulk add tool';
   case 8: // social

--- a/app/presenters/relationship_details.rb
+++ b/app/presenters/relationship_details.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class RelationshipDetails
+  include ActiveSupport::NumberHelper
+
   attr_accessor :details
 
   @@bool = lambda { |x| x ? 'yes' : 'no' }
-  @@money = lambda { |x| ActiveSupport::NumberHelper.number_to_currency(x, precision: 0) }
   @@percent = lambda { |x| x.to_s + '%' }
   @@human_int = lambda { |x| ActiveSupport::NumberHelper.number_to_human(x) }
 
@@ -55,7 +56,7 @@ class RelationshipDetails
       .add_field(:is_board, 'Board member', @@bool)
       .add_field(:is_executive, 'Executive', @@bool)
       .add_field(:is_employee, 'Employee', @@bool)
-      .add_field(:compensation, 'Compensation', @@money)
+      .add_field(:compensation, 'Compensation', format_in_usd)
       .add_field(:notes, 'Notes')
   end
 
@@ -74,7 +75,7 @@ class RelationshipDetails
       .add_field(:start_date, 'Start Date')
       .add_field(:end_date, 'End Date')
       .add_field(:is_current, 'Is Current', @@bool)
-      .add_field(:membership_dues, 'Dues', @@money)
+      .add_field(:membership_dues, 'Dues', format_in_usd)
       .add_field(:notes, 'Notes')
   end
 
@@ -92,7 +93,7 @@ class RelationshipDetails
       .add_field(:start_date, 'Start Date')
       .add_field(:end_date, 'End Date')
       .add_field(:is_current, 'Is Current', @@bool)
-      .add_field(:amount, 'Amount', @@money)
+      .add_field(:amount, 'Amount', format_with_currency)
       .add_field(:filings, filings_text)
       .add_field(:goods, 'Goods')
       .add_field(:notes, 'Notes')
@@ -104,7 +105,7 @@ class RelationshipDetails
       .add_field(:start_date, 'Start Date')
       .add_field(:end_date, 'End Date')
       .add_field(:is_current, 'Is Current', @@bool)
-      .add_field(:amount, 'Amount', @@money)
+      .add_field(:amount, 'Amount', format_with_currency)
       .add_field(:goods, 'Goods')
       .add_field(:notes, 'Notes')
   end
@@ -114,7 +115,7 @@ class RelationshipDetails
       .add_field(:start_date, 'Start Date')
       .add_field(:end_date, 'End Date')
       .add_field(:is_current, 'Is Current', @@bool)
-      .add_field(:amount, 'Amount', @@money)
+      .add_field(:amount, 'Amount', format_with_currency)
       .add_field(:filings, 'LDA Filings')
       .add_field(:notes, 'Notes')
   end
@@ -240,5 +241,20 @@ class RelationshipDetails
     else
       'FEC Filings'
     end
+  end
+
+  def format_with_currency
+    proc do |_x|
+      number_to_currency(
+        @rel.amount,
+        unit: @rel.currency.upcase,
+        precision: 0,
+        format: '%n %u'
+      )
+    end
+  end
+
+  def format_in_usd
+    ->(x) { number_to_currency(x, unit: 'USD', precision: 0, format: '%n %u') }
   end
 end

--- a/app/presenters/relationship_label.rb
+++ b/app/presenters/relationship_label.rb
@@ -3,6 +3,8 @@
 # Provides a short label for a Relationship.
 # Used by Link and Oligrapher.
 class RelationshipLabel < SimpleDelegator
+  include ActiveSupport::NumberHelper
+
   attr_reader :is_reverse
 
   def initialize(relationship, is_reverse = false)
@@ -129,6 +131,6 @@ class RelationshipLabel < SimpleDelegator
   end
 
   def amount_display
-    ActiveSupport::NumberHelper.number_to_currency(amount, precision: 0)
+    number_to_currency(amount, unit: currency.upcase, precision: 0, format: '%n %u')
   end
 end

--- a/app/views/relationships/bulk_add.html.erb
+++ b/app/views/relationships/bulk_add.html.erb
@@ -117,3 +117,7 @@
    bulkAdd.init(<%= raw current_user.bulker? %>);
  });
 </script>
+
+<template class="currency-selector">
+  <%= select_tag(:currency, options_for_select(options_for_currency_select), { include_blank: true, class: 'selectpicker' }) %>
+</template>

--- a/app/views/relationships/edit.html.erb
+++ b/app/views/relationships/edit.html.erb
@@ -117,6 +117,12 @@
     <div class="form-row">
       <%= relationship_form_tag( f.label(:amount, 'Amount', class: label_class), f.number_field(:amount) )%>
     </div>
+    <div class="form-row">
+      <%= relationship_form_tag(
+        f.label(:currency, 'Currency', class: label_class),
+        f.select(:currency, options_for_currency_select, { include_blank: true }, { class: 'selectpicker' })
+      ) %>
+    </div>
   <% end %>
 
   <% if @relationship.is_donation? || @relationship.is_transaction? %>

--- a/db/migrate/20200528185753_add_currency_to_relationship.rb
+++ b/db/migrate/20200528185753_add_currency_to_relationship.rb
@@ -1,0 +1,12 @@
+class AddCurrencyToRelationship < ActiveRecord::Migration[6.0]
+  def up
+    add_column :relationship, :currency, :string, after: :amount
+
+    # Assume all existing financial data is USD
+    Relationship.where.not(amount: nil).update_all(currency: 'USD')
+  end
+
+  def down
+    remove_column :relationship, :currency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_162459) do
+ActiveRecord::Schema.define(version: 2020_05_28_185753) do
 
   create_table "address", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "entity_id", null: false
@@ -1124,6 +1124,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_162459) do
     t.string "description1", limit: 100
     t.string "description2", limit: 100
     t.bigint "amount"
+    t.string "currency"
     t.text "goods", size: :long
     t.bigint "filings"
     t.text "notes", size: :long

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1660,6 +1660,7 @@ CREATE TABLE `relationship` (
   `description1` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `description2` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `amount` bigint(20) DEFAULT NULL,
+  `currency` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `goods` longtext COLLATE utf8_unicode_ci DEFAULT NULL,
   `filings` bigint(20) DEFAULT NULL,
   `notes` longtext COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -2228,6 +2229,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200504215855'),
 ('20200505171235'),
 ('20200511192227'),
-('20200518162459');
+('20200518162459'),
+('20200528185753');
 
 

--- a/spec/presenters/relationship_details_spec.rb
+++ b/spec/presenters/relationship_details_spec.rb
@@ -12,6 +12,7 @@ describe RelationshipDetails do
           start_date: '1900',
           end_date: '2000',
           amount: 7000,
+          currency: :usd,
           filings: 2)
   end
 
@@ -37,7 +38,7 @@ describe RelationshipDetails do
 
   it 'returns details for position relationship' do
     position_relationship.position = build(:position, is_board: false, compensation: 25)
-    details = [['Title', 'boss'], ['Start Date', '1624'], ['Is Current', 'yes'], ['Board member', 'no'], ['Compensation', '$25']]
+    details = [['Title', 'boss'], ['Start Date', '1624'], ['Is Current', 'yes'], ['Board member', 'no'], ['Compensation', '25 USD']]
     expect(RelationshipDetails.new(position_relationship).details).to eq details
   end
 
@@ -52,7 +53,7 @@ describe RelationshipDetails do
     rel = build(:relationship, category_id: 3, start_date: '2000', end_date: '2001')
     rel.membership = build(:membership, dues: 100)
     expect(RelationshipDetails.new(rel).details)
-      .to eql [['Title', 'Member'], ['Start Date', '2000'], ['End Date', '2001'], ['Dues', '$100']]
+      .to eql [['Title', 'Member'], ['Start Date', '2000'], ['End Date', '2001'], ['Dues', '100 USD']]
   end
 
   it 'returns details for membership in U.S. house' do
@@ -75,21 +76,21 @@ describe RelationshipDetails do
   it 'returns details for donation relationship' do
     expect(RelationshipDetails.new(donation_rel).details)
       .to eql [['Type', 'Campaign Contribution'], ['Start Date', '1900'],
-               ['End Date', '2000'], ['Amount', '$7,000'], ['FEC Filings', '2']]
+               ['End Date', '2000'], ['Amount', '7,000 USD'], ['FEC Filings', '2']]
   end
 
   it 'returns details for NYS donation relationship' do
-    rel = build(:nys_donation_relationship, filings: 10, amount: 10_000)
+    rel = build(:nys_donation_relationship, filings: 10, amount: 10_000, currency: 'USD')
     expect(RelationshipDetails.new(rel).details)
       .to eql [['Type', 'NYS Campaign Contribution'],
-               ['Amount', '$10,000'], ['Filings', '10']]
+               ['Amount', '10,000 USD'], ['Filings', '10']]
   end
 
   it 'returns details for federal donation relationship' do
-    rel = build(:federal_donation_relationship, filings: 10, amount: 10_000)
+    rel = build(:federal_donation_relationship, filings: 10, amount: 10_000, currency: 'USD')
     expect(RelationshipDetails.new(rel).details)
       .to eql [['Type', 'Campaign Contribution'],
-               ['Amount', '$10,000'], ['FEC Filings', '10']]
+               ['Amount', '10,000 USD'], ['FEC Filings', '10']]
   end
 
   it 'returns details for transaction relationship' do
@@ -99,8 +100,8 @@ describe RelationshipDetails do
   end
 
   it 'returns details for lobbying relationship' do
-    rel = build(:relationship, category_id: 7, amount: 10)
-    expect(RelationshipDetails.new(rel).details).to eql [['Amount', '$10']]
+    rel = build(:relationship, category_id: 7, amount: 10, currency: 'USD')
+    expect(RelationshipDetails.new(rel).details).to eql [['Amount', '10 USD']]
   end
 
   it 'returns details for social relationship' do

--- a/spec/presenters/relationship_label_spec.rb
+++ b/spec/presenters/relationship_label_spec.rb
@@ -19,45 +19,45 @@ describe RelationshipLabel do
     context 'with campaign contribution' do
       let(:relationship) do
         build(:donation_relationship,
-              filings: nil, amount: 2_000_000, description1: "Campaign Contribution")
+              filings: nil, amount: 2_000_000, currency: 'USD', description1: "Campaign Contribution")
       end
 
-      it { is_expected.to eql "Donation · $2,000,000" }
+      it { is_expected.to eql "Donation · 2,000,000 USD" }
     end
 
     context 'with NYS campaign contribution' do
       let(:relationship) do
         build(:donation_relationship,
-              filings: nil, amount: 1_000_000, description1: "NYS Campaign Contribution")
+              filings: nil, amount: 1_000_000, currency: 'USD', description1: "NYS Campaign Contribution")
       end
 
-      it { is_expected.to eql "NYS Campaign Contribution · $1,000,000" }
+      it { is_expected.to eql "NYS Campaign Contribution · 1,000,000 USD" }
     end
 
     context 'with NYS campaign contribution with 2 filings' do
       let(:relationship) do
         build(:donation_relationship,
-              filings: 2, amount: 1_000_000, description1: "NYS Campaign Contribution")
+              filings: 2, amount: 1_000_000, currency: 'USD', description1: "NYS Campaign Contribution")
       end
 
-      it { is_expected.to eql "2 contributions · $1,000,000" }
+      it { is_expected.to eql "2 contributions · 1,000,000 USD" }
     end
 
     context 'with miscellaneous donation' do
       let(:relationship) do
-        build(:donation_relationship, filings: nil, amount: 1000, description1: nil)
+        build(:donation_relationship, filings: nil, amount: 1000, currency: 'USD', description1: nil)
       end
 
-      it { is_expected.to eql "Donation/Grant · $1,000" }
+      it { is_expected.to eql "Donation/Grant · 1,000 USD" }
     end
 
     context 'with miscellaneous donation having a custom type' do
       let(:relationship) do
         build(:donation_relationship,
-              filings: nil, amount: 1000, description1: 'suspicious contribution')
+              filings: nil, amount: 1000, currency: 'USD', description1: 'suspicious contribution')
       end
 
-      it { is_expected.to eql "suspicious contribution · $1,000" }
+      it { is_expected.to eql "suspicious contribution · 1,000 USD" }
     end
   end
 
@@ -135,18 +135,18 @@ describe RelationshipLabel do
     context 'with amount' do
       context 'with description1' do
         let(:relationship) do
-          build(:transaction_relationship, amount: 10_000,  description1: 'Contractor', description2: 'Client')
+          build(:transaction_relationship, amount: 10_000, currency: 'USD', description1: 'Contractor', description2: 'Client')
         end
 
-        it { is_expected.to eql "Client · $10,000" }
+        it { is_expected.to eql "Client · 10,000 USD" }
       end
 
       context 'without description1' do
         let(:relationship) do
-          build(:transaction_relationship, amount: 10_000,  description1: '', description2: '')
+          build(:transaction_relationship, amount: 10_000, currency: 'USD', description1: '', description2: '')
         end
 
-        it { is_expected.to eql "Service/Transaction · $10,000" }
+        it { is_expected.to eql "Service/Transaction · 10,000 USD" }
       end
     end
   end
@@ -207,24 +207,24 @@ describe RelationshipLabel do
     subject { RelationshipLabel.new(relationship).send(:humanize_contributions) }
 
     context 'when donation relationship has filings' do
-      let(:relationship) { build(:donation_relationship, filings: 3, amount: 1000) }
+      let(:relationship) { build(:donation_relationship, filings: 3, amount: 1000, currency: 'USD') }
 
-      it { is_expected.to eql "3 contributions · $1,000" }
+      it { is_expected.to eql "3 contributions · 1,000 USD" }
     end
 
     context 'when filings is nil' do
-      let(:relationship) { build(:donation_relationship, filings: nil, amount: 2_000_000) }
+      let(:relationship) { build(:donation_relationship, filings: nil, amount: 2_000_000, currency: 'USD') }
 
-      it { is_expected.to eql "Donation/Grant · $2,000,000" }
+      it { is_expected.to eql "Donation/Grant · 2,000,000 USD" }
     end
 
     context 'when filing is 0' do
       let(:relationship) do
         build(:donation_relationship,
-              filings: 0, amount: 2_000_000, description1: 'Campaign Contribution')
+              filings: 0, amount: 2_000_000, currency: 'USD', description1: 'Campaign Contribution')
       end
 
-      it { is_expected.to eql "Donation · $2,000,000" }
+      it { is_expected.to eql "Donation · 2,000,000 USD" }
     end
   end
 


### PR DESCRIPTION
Resolves #1106

Requires merge of https://github.com/public-accountability/littlesis-main/pull/30

Note that this only covers financial data directly on the `Relationship` object, which means donations. There are some other places we should probably consider adding currency data:

- positions, which have compensation
- memberships, which have dues 

... but those are another project.