### PR TITLE
Handle new date format

### DIFF
--- a/app/utility/ls_date.rb
+++ b/app/utility/ls_date.rb
@@ -229,10 +229,10 @@ class LsDate
   end
 
   def set_specificity
-    @specificity = :unknown if @year.nil? && @month.nil? && @day.nil?
-    @specificity = :year if @year.present? && @month.nil? && @day.nil?
-    @specificity = :month if @year.present? && @month.present? && @day.nil?
-    @specificity = :day if @year.present? && @month.present? && @day.present?
+    @specificity = :unknown
+    [:year, :month, :day].each do |sp|
+      @specificity = sp if instance_variable_get("@#{sp}").present?
+    end
   end
 
   def test_if_valid_input(str)

--- a/app/utility/ls_date.rb
+++ b/app/utility/ls_date.rb
@@ -45,36 +45,8 @@ class LsDate
     define_method("sp_#{specificity}?") { @specificity == specificity }
   end
 
-  # ~~~~spaceship method~~~~
   def <=>(other)
-    # one of the dates is unknown
-    return 0 if sp_unknown? && other.sp_unknown?
-    return 1 if !sp_unknown? && other.sp_unknown?
-    return -1 if sp_unknown? && !other.sp_unknown?
-    # If the years are different
-    return -1 if @year < other.year
-    return 1 if @year > other.year
-    # year is the same, specificity is year for both
-    if @year == other.year
-      return 0 if sp_year? && other.sp_year?
-      return -1 if sp_year? && (other.sp_month? || other.sp_day?)
-      return 1 if (sp_month? || sp_day?) && other.sp_year?
-    end
-    # if the months are different
-    return 1 if @month > other.month
-    return -1 if @month < other.month
-    # months are the same, one or both of them are are missing a day
-    if @month == other.month
-      return 0 if sp_month? && other.sp_month?
-      return 1 if sp_day? && other.sp_month?
-      return -1 if sp_month? && other.sp_day?
-    end
-    # if we get here then year and month have to be the same and specificity is :day for both LsDates
-    if sp_day? && other.sp_day?
-      return -1 if @day < other.day
-      return 1 if @day > other.day
-      return 0 if @day == other.day
-    end
+    date_string.to_s <=> other.date_string.to_s
   end
 
   def to_s

--- a/spec/utility/ls_date_spec.rb
+++ b/spec/utility/ls_date_spec.rb
@@ -230,7 +230,7 @@ describe LsDate do
     end
 
     it 'invalid dates' do
-      ['2012-13-01', '1000', 'May 20th'].each do |d|
+      ['Ginuary sometime', '1000', 'today'].each do |d|
         expect(LsDate.valid_date_string?(d)).to be false
       end
     end
@@ -254,6 +254,112 @@ describe LsDate do
   describe 'LsDate.today' do
     specify do
       expect(LsDate.today.to_s).to eq Time.zone.today.iso8601
+    end
+  end
+
+  describe 'handling arbitrary date formats' do
+    let(:same_date) { described_class.new('2010-06-01') }
+    let(:previous_date) { described_class.new('2009-05-01') }
+    let(:future_date) { described_class.new('2020-08-12') }
+
+    context 'with 1st June 2010' do
+      let(:input_string) { '1st June 2010' }
+      let(:date) { described_class.new(input_string) }
+
+      it "doesn't raise an exception" do
+        expect { date }.not_to raise_error
+      end
+
+      it 'is considered valid' do
+        expect(described_class.valid_date_string?(input_string)).to be true
+      end
+
+      it 'performs correctly in spaceship comparisons' do
+        expect(date.<=> same_date).to be(0)
+        expect(date.<=> previous_date).to be(1)
+        expect(date.<=> future_date).to be(-1)
+      end
+
+      it 'is parsed correctly into component elements' do
+        expect(date.year).to be 2010
+        expect(date.month).to be 6
+        expect(date.day).to be 1
+      end
+    end
+
+    context 'with 1 June, 2010' do
+      let(:input_string) { '1 June, 2010' }
+      let(:date) { described_class.new(input_string) }
+
+      it "doesn't raise an exception" do
+        expect { date }.not_to raise_error
+      end
+
+      it 'is considered valid' do
+        expect(described_class.valid_date_string?(input_string)).to be true
+      end
+
+      it 'performs correctly in spaceship comparisons' do
+        expect(date.<=> same_date).to be(0)
+        expect(date.<=> previous_date).to be(1)
+        expect(date.<=> future_date).to be(-1)
+      end
+
+      it 'is parsed correctly into component elements' do
+        expect(date.year).to be 2010
+        expect(date.month).to be 6
+        expect(date.day).to be 1
+      end
+    end
+
+    context 'with June 1, 2010' do
+      let(:input_string) { 'June 1, 2010' }
+      let(:date) { described_class.new(input_string) }
+
+      it "doesn't raise an exception" do
+        expect { date }.not_to raise_error
+      end
+
+      it 'is considered valid' do
+        expect(described_class.valid_date_string?(input_string)).to be true
+      end
+
+      it 'performs correctly in spaceship comparisons' do
+        expect(date.<=> same_date).to be(0)
+        expect(date.<=> previous_date).to be(1)
+        expect(date.<=> future_date).to be(-1)
+      end
+
+      it 'is parsed correctly into component elements' do
+        expect(date.year).to be 2010
+        expect(date.month).to be 6
+        expect(date.day).to be 1
+      end
+    end
+
+    context 'with June 1 2010' do
+      let(:input_string) { 'June 1 2010' }
+      let(:date) { described_class.new(input_string) }
+
+      it "doesn't raise an exception" do
+        expect { date }.not_to raise_error
+      end
+
+      it 'is considered valid' do
+        expect(described_class.valid_date_string?(input_string)).to be true
+      end
+
+      it 'performs correctly in spaceship comparisons' do
+        expect(date.<=> same_date).to be(0)
+        expect(date.<=> previous_date).to be(1)
+        expect(date.<=> future_date).to be(-1)
+      end
+
+      it 'is parsed correctly into component elements' do
+        expect(date.year).to be 2010
+        expect(date.month).to be 6
+        expect(date.day).to be 1
+      end
     end
   end
 end

--- a/spec/utility/ls_date_spec.rb
+++ b/spec/utility/ls_date_spec.rb
@@ -104,6 +104,10 @@ describe LsDate do
       expect(LsDate.convert('Feb-18')).to eq '2018-02-00'
     end
 
+    it 'converts MONTH-YY (December-07)' do
+      expect(LsDate.convert('December-07')).to eq '2007-12-00'
+    end
+
     # '12/2007'
     # ''Dec-07'
     it 'returns input if it can\'t convert' do # rubocop:disable RSpec/ExampleLength

--- a/spec/utility/ls_date_spec.rb
+++ b/spec/utility/ls_date_spec.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Lint/UselessComparison, RSpec/Multipleexpectations
+# rubocop:disable Lint/UselessComparison
 
 describe LsDate do
   describe 'initialize' do
@@ -19,47 +19,47 @@ describe LsDate do
 
     it 'sets date string' do
       d = LsDate.new('1999-01-01')
-      expect(d.date_string).to eql '1999-01-01'
+      expect(d.date_string).to eq '1999-01-01'
     end
 
     describe 'set_year_month day' do
       it 'sets @year, @month, and @day for full date' do
         d = LsDate.new('2001-02-14')
-        expect(d.year).to eql 2001
-        expect(d.month).to eql 2
-        expect(d.day).to eql 14
+        expect(d.year).to be 2001
+        expect(d.month).to be 2
+        expect(d.day).to be 14
       end
 
       it 'sets @year, @month, and @day when missing day' do
         d = LsDate.new('2001-02-00')
-        expect(d.year).to eql 2001
-        expect(d.month).to eql 2
-        expect(d.day).to eql nil
+        expect(d.year).to be 2001
+        expect(d.month).to be 2
+        expect(d.day).to be nil
       end
 
       it 'sets @year, @month, and @day when missing day and month' do
         d = LsDate.new('2001-00-00')
-        expect(d.year).to eql 2001
-        expect(d.month).to eql nil
-        expect(d.day).to eql nil
+        expect(d.year).to be 2001
+        expect(d.month).to be nil
+        expect(d.day).to be nil
       end
     end
 
     describe 'specificity' do
       it 'has correct specificity :day when full date' do
-        expect(LsDate.new('2017-01-01').specificity).to eql :day
+        expect(LsDate.new('2017-01-01').specificity).to be :day
       end
 
       it 'has correct specificity :month when missing day' do
-        expect(LsDate.new('2017-01-00').specificity).to eql :month
+        expect(LsDate.new('2017-01-00').specificity).to be :month
       end
 
       it 'has correct specificity :year when missing day and month' do
-        expect(LsDate.new('2017-00-00').specificity).to eql :year
+        expect(LsDate.new('2017-00-00').specificity).to be :year
       end
 
       it 'has correct specificity :unknown when missing day, month, and year' do
-        expect(LsDate.new(nil).specificity).to eql :unknown
+        expect(LsDate.new(nil).specificity).to be :unknown
       end
     end
   end
@@ -78,19 +78,19 @@ describe LsDate do
 
   describe 'convert' do
     it 'converts YYYY to YYYY-00-OO' do
-      expect(LsDate.convert('2019')).to eql '2019-00-00'
+      expect(LsDate.convert('2019')).to eq '2019-00-00'
     end
 
     it 'converts YYYY-MM to YYYY-MM-OO' do
-      expect(LsDate.convert('2019-12')).to eql '2019-12-00'
+      expect(LsDate.convert('2019-12')).to eq '2019-12-00'
     end
 
     it 'converts YYYYMMDD to YYYY-MM-OO' do
-      expect(LsDate.convert('20011231')).to eql '2001-12-31'
+      expect(LsDate.convert('20011231')).to eq '2001-12-31'
     end
 
     it 'converts blank strings to nil' do
-      expect(LsDate.convert('')).to eql nil
+      expect(LsDate.convert('')).to be nil
     end
 
     it 'converts MM/YYYY' do
@@ -106,14 +106,13 @@ describe LsDate do
 
     # '12/2007'
     # ''Dec-07'
-
-    it 'returns input if it can\'t convert' do
-      expect(LsDate.convert('88')).to eql '88'
-      expect(LsDate.convert('1234567')).to eql '1234567'
-      expect(LsDate.convert('2000-04-01')).to eql '2000-04-01'
+    it 'returns input if it can\'t convert' do # rubocop:disable RSpec/ExampleLength
+      expect(LsDate.convert('88')).to eq '88'
+      expect(LsDate.convert('1234567')).to eq '1234567'
+      expect(LsDate.convert('2000-04-01')).to eq '2000-04-01'
       expect(LsDate.convert(nil)).to be nil
-      expect(LsDate.convert('right now')).to eql 'right now'
-      expect(LsDate.convert('13/2000')).to eql '13/2000'
+      expect(LsDate.convert('right now')).to eq 'right now'
+      expect(LsDate.convert('13/2000')).to eq '13/2000'
     end
   end
 
@@ -124,15 +123,15 @@ describe LsDate do
     end
 
     it 'handles years' do
-      expect(LsDate.parse_cmp_date('1960').to_s).to eql '1960-00-00'
+      expect(LsDate.parse_cmp_date('1960').to_s).to eq '1960-00-00'
     end
 
     it 'handles months' do
-      expect(LsDate.parse_cmp_date('04/1970').to_s).to eql '1970-04-00'
+      expect(LsDate.parse_cmp_date('04/1970').to_s).to eq '1970-04-00'
     end
 
     it 'handles full dates' do
-      expect(LsDate.parse_cmp_date('22/04/1970').to_s).to eql '1970-04-22'
+      expect(LsDate.parse_cmp_date('22/04/1970').to_s).to eq '1970-04-22'
     end
 
     it 'returns nil for invalid dates' do
@@ -160,7 +159,7 @@ describe LsDate do
       expect(LsDate.new('2000-00-00') < LsDate.new('2016-10-28')).to be true
     end
 
-    context 'years are the same' do
+    context 'when years are the same' do
       it 'if month is defined, the more specific date wins' do
         expect(LsDate.new('2017-00-00') < LsDate.new('2017-03-00')).to be true
         expect(LsDate.new('2017-00-00') < LsDate.new('2017-01-01')).to be true
@@ -187,19 +186,19 @@ describe LsDate do
 
   describe 'display' do
     it 'displays unknown as ?' do
-      expect(LsDate.new(nil).display).to eql '?'
+      expect(LsDate.new(nil).display).to eq '?'
     end
 
     it "displays :year as 'YY" do
-      expect(LsDate.new('1926-00-00').display).to eql "'26"
+      expect(LsDate.new('1926-00-00').display).to eq "'26"
     end
 
     it "displays :month as 'Mon 'YY" do
-      expect(LsDate.new('1926-11-00').display).to eql "Nov '26"
+      expect(LsDate.new('1926-11-00').display).to eq "Nov '26"
     end
 
     it "displays :year as 'Mon DD, 'YY" do
-      expect(LsDate.new('2008-02-24').display).to eql "Feb 24 '08"
+      expect(LsDate.new('2008-02-24').display).to eq "Feb 24 '08"
     end
   end
 
@@ -219,12 +218,12 @@ describe LsDate do
   end
 
   describe 'to_s' do
-    specify { expect(LsDate.new('2018-10-10').to_s).to eql '2018-10-10' }
+    specify { expect(LsDate.new('2018-10-10').to_s).to eq '2018-10-10' }
   end
 
   describe 'valid_date_string?' do
     it 'valid dates' do
-      ['2012-01-01', '2012-01-00', '2012-00-00'].each do |d|
+      %w[2012-01-01 2012-01-00 2012-00-00].each do |d|
         expect(LsDate.valid_date_string?(d)).to be true
       end
     end
@@ -246,8 +245,8 @@ describe LsDate do
     end
 
     it 'returns valid dates even if month or day is unknown' do
-      expect(LsDate.new('1915-00-00').coerce_to_date).to eql Date.parse('1915-01-01')
-      expect(LsDate.new('1915-02-00').coerce_to_date).to eql Date.parse('1915-02-01')
+      expect(LsDate.new('1915-00-00').coerce_to_date).to eq Date.parse('1915-01-01')
+      expect(LsDate.new('1915-02-00').coerce_to_date).to eq Date.parse('1915-02-01')
     end
   end
 
@@ -363,4 +362,4 @@ describe LsDate do
     end
   end
 end
-# rubocop:enable Lint/UselessComparison, RSpec/Multipleexpectations
+# rubocop:enable Lint/UselessComparison

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -2,15 +2,18 @@
 
 # rubocop:disable RSpec/NamedSubject
 
-describe 'DateValidator' do
-  class DateTester <
-        include ActiveModel::Validations
-    attr_accessor :start_date, :end_date
-    validates :start_date, date: true
-    validates :end_date, date: true
-  end
-
+describe DateValidator do
   subject { DateTester.new }
+
+  before do
+    date_tester = Class.new do
+      include ActiveModel::Validations
+      attr_accessor :start_date, :end_date
+      validates :start_date, date: true
+      validates :end_date, date: true
+    end
+    stub_const('DateTester', date_tester)
+  end
 
   context 'when the date is valid' do
     it 'nil is valid' do

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -37,6 +37,21 @@ describe 'DateValidator' do
       subject.start_date = '2016-08-11'
       expect(subject.valid?).to be true
     end
+
+    it 'May 1st, 1970 is valid' do
+      subject.start_date = 'May 1st, 1970'
+      expect(subject.valid?).to be true
+    end
+
+    it 'April 4, 2000 is valid' do
+      subject.start_date = 'April 4, 2000'
+      expect(subject.valid?).to be true
+    end
+
+    it 'Jan 5th 2010' do
+      subject.start_date = 'Jan 5th 2010'
+      expect(subject.valid?).to be true
+    end
   end
 
   context 'when the date is invalid' do
@@ -67,6 +82,16 @@ describe 'DateValidator' do
 
     it '1234567891 is not valid' do
       subject.start_date = '1234567891'
+      expect(subject.valid?).to be false
+    end
+
+    it 'Gin 1 werp is not valid' do
+      subject.start_date = 'Gin 1 werp'
+      expect(subject.valid?).to be false
+    end
+
+    it 'XXXX-XX-XX is not valid' do
+      subject.start_date = 'XXXX-XX-XX'
       expect(subject.valid?).to be false
     end
   end


### PR DESCRIPTION
Closes #946.

Allows dates in **Month Day, Year** and **Month Day Year** formats.

Note that this uses `DateTime.parse` and then essentially adds to this handling for dates of the format 2000-00-00, and 2000-01-00, which are peculiar to LittleSis.