### PR TITLE
fix "USD" currency validation bugs

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -544,8 +544,10 @@ class Relationship < ApplicationRecord
   end
 
   def set_currency_default
-    unless currency
-      self.currency = amount ? :usd : nil
+    if currency.present?
+      self.currency = currency.to_s.downcase
+    elsif amount.present?
+      self.currency = 'usd'
     end
   end
 end

--- a/db/migrate/20200528185753_add_currency_to_relationship.rb
+++ b/db/migrate/20200528185753_add_currency_to_relationship.rb
@@ -3,7 +3,7 @@ class AddCurrencyToRelationship < ActiveRecord::Migration[6.0]
     add_column :relationship, :currency, :string, after: :amount
 
     # Assume all existing financial data is USD
-    Relationship.where.not(amount: nil).update_all(currency: 'USD')
+    Relationship.where.not(amount: nil).update_all(currency: 'usd')
   end
 
   def down

--- a/spec/features/relationship_deletion_spec.rb
+++ b/spec/features/relationship_deletion_spec.rb
@@ -1,10 +1,31 @@
 describe 'deleting relationships' do
   let(:user1) { create_basic_user }
   let(:user2) { create_basic_user }
+  let(:admin) { create_admin_user }
+  let(:person) { create(:entity_person) }
+  let(:org) { create(:entity_org) }
 
-  describe 'relationship history page' do
-    let(:person) { create(:entity_person) }
-    let(:org) { create(:entity_org) }
+  describe 'request to removed relationship' do
+    before { login_as(admin, scope: :user) }
+
+    after { logout(:user) }
+
+    let(:relationship) do
+      create(:donation_relationship, entity: person, related: org, currency: 'USD', amount: 2)
+    end
+
+    scenario 'deleting relationship via "remove" button' do
+      visit relationship_path(relationship)
+      expect(page.status_code).to eq 200
+      expect do
+        page.driver.submit :delete, relationship_path(relationship), {}
+      end.to change(Relationship, :count).by(-1)
+      visit relationship_path(relationship)
+      expect(page.status_code).to eq 404
+    end
+  end
+
+  describe 'history on associated entity profile pages' do
     let(:relationship) do
       with_versioning_for(user1) do
         Relationship.create!(entity: person, related: org, category_id: 1)

--- a/spec/features/relationship_deletion_spec.rb
+++ b/spec/features/relationship_deletion_spec.rb
@@ -1,40 +1,40 @@
 describe 'deleting relationships' do
-  let(:person) { create(:entity_person) }
-  let(:org) { create(:entity_org) }
-  let(:relationship_params) do
-    { entity: person, related: org, category_id: 1 }
-  end
-
   let(:user1) { create_basic_user }
   let(:user2) { create_basic_user }
 
-  before do
-    with_versioning_for(user1) do
-      @relationship = Relationship.create!(relationship_params)
+  describe 'relationship history page' do
+    let(:person) { create(:entity_person) }
+    let(:org) { create(:entity_org) }
+    let(:relationship) do
+      with_versioning_for(user1) do
+        Relationship.create!(entity: person, related: org, category_id: 1)
+      end
     end
-  end
 
-  it 'shows correct user on entity page' do
-    visit entity_path(person)
-    expect(find('#entity-edited-history').text).to include user1.username
-  end
+    before { relationship }
 
-  context 'when logged in as user2' do
-    before { login_as(user2, :scope => :user) }
-
-    after { logout(:user) }
-
-    it 'shows correct user on entity page after deleting' do
+    it 'shows correct user on entity page' do
       visit entity_path(person)
       expect(find('#entity-edited-history').text).to include user1.username
-      with_versioning_for(user2) do
-        @relationship.current_user = user2
-        @relationship.soft_delete
+    end
+
+    context 'when logged in as user2' do
+      before { login_as(user2, scope: :user) }
+
+      after { logout(:user) }
+
+      it 'shows correct user on entity page after deleting' do
+        visit entity_path(person)
+        expect(find('#entity-edited-history').text).to include user1.username
+        with_versioning_for(user2) do
+          relationship.current_user = user2
+          relationship.soft_delete
+        end
+        visit entity_path(person)
+        expect(find('#entity-edited-history').text).to include user2.username
+        visit entity_path(org)
+        expect(find('#entity-edited-history').text).to include user2.username
       end
-      visit entity_path(person)
-      expect(find('#entity-edited-history').text).to include user2.username
-      visit entity_path(org)
-      expect(find('#entity-edited-history').text).to include user2.username
     end
   end
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -870,6 +870,17 @@ describe Relationship, type: :model do
       end
     end
 
+    context 'with a currency in uppercase' do
+      let(:donation) do
+        build(:donation_relationship, entity: build(:person), related: build(:org), amount: 1, currency: 'USD')
+      end
+
+      it 'downcases the currency before validation' do
+        expect(donation.valid?).to be true
+        expect(donation.currency).to eq 'usd'
+      end
+    end
+
     context 'with a currency and an amount' do
       let(:donation) { build(:loeb_donation, entity: loeb, related: nrsc, filings: 1, amount: 23_000, currency: :usd) }
 


### PR DESCRIPTION
resolves #1155 
resolves #1160 

SQL to run on production:

``` sql
UPDATE relationship SET currency = 'usd' WHERE currency = 'USD'
```