### PR TITLE
Broken image asset routes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ApplicationRecord
   end
 
   def image_url(type = nil)
-    return '/images/system/anon.png' if image.nil?
+    return ApplicationController.helpers.image_url('system/anon') if image.nil?
 
     type = (image.has_square ? 'square' : 'profile') if type.nil?
     image.image_path(type)

--- a/app/views/entities/_image_table_row.html.erb
+++ b/app/views/entities/_image_table_row.html.erb
@@ -16,7 +16,7 @@
   </td>
 
   <td>
-    <%= link_to("crop", crop_image_path(image)) %><br>
+    <%= link_to("crop", crop_ls_image_path(image)) %><br>
 
     <% unless image.is_featured %>
       <%= link_to("feature", concretize_feature_image_entity_path(@entity, image_id: image.id), method: :post, data: { confirm: "Are you sure?" }) %>

--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -102,7 +102,7 @@
    }
 
    function submit() {
-     return fetch("<%= crop_image_path(@image) %>", {
+     return fetch("<%= crop_ls_image_path(@image) %>", {
        method: "POST",
        cache: "no-cache",
        credentials: "include",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Lilsis::Application.routes.draw do
     resources :entities, only: :create, controller: 'lists/entities'
   end
 
-  resources :images, only: [] do
+  resources :ls_images, only: [], path: 'images', controller: 'images' do
     member do
       get 'crop'
       post 'crop'

--- a/spec/features/images_spec.rb
+++ b/spec/features/images_spec.rb
@@ -72,16 +72,16 @@ describe 'Images' do
 
       before do
         setup_image_path image
-        visit crop_image_path(image)
+        visit crop_ls_image_path(image)
       end
 
       it 'has crop html elements' do
-        successfully_visits_page crop_image_path(image)
+        successfully_visits_page crop_ls_image_path(image)
 
         page_has_selector 'h3', text: 'Crop Image'
         page_has_selector '#image-wrapper > canvas', count: 1
 
-        expect(page.html).to include "return fetch(\"#{crop_image_path(image)}\""
+        expect(page.html).to include "return fetch(\"#{crop_ls_image_path(image)}\""
       end
     end
   end
@@ -91,7 +91,7 @@ describe 'Images' do
 
     before do
       setup_image_path image
-      visit crop_image_path(image)
+      visit crop_ls_image_path(image)
     end
 
     it 'has fields to edit caption'

--- a/spec/features/js/browsing_an_entitys_references_spec.rb
+++ b/spec/features/js/browsing_an_entitys_references_spec.rb
@@ -27,6 +27,7 @@ feature "Browsing an entity's references", type: :feature, js: true do
 
     # Click "back" to view the first list
     find('#source-links-left-arrow').click
+    expect(page).to have_css('#source-links-container a', count: 10)
     new_first_source = first('#source-links-container a').text
     expect(new_first_source).to eq first_source
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -404,6 +404,6 @@ describe User do
   end
 
   describe '#image_url' do
-    specify { expect(build(:user).image_url).to eq '/images/system/anon.png' }
+    specify { expect(build(:user).image_url).to match /\/assets\/system\/anon/ }
   end
 end

--- a/spec/routes/images_spec.rb
+++ b/spec/routes/images_spec.rb
@@ -1,0 +1,21 @@
+describe 'images routes', type: :routing do
+  let(:image) { create(:image, entity: create(:entity_org)) }
+
+  it 'routes /images/ paths to the relevant controller' do
+    expect(get: "/images/#{image.id}/crop").to route_to(
+      controller: 'images',
+      action: 'crop',
+      id: image.id.to_s
+    )
+  end
+
+  it 'defines distinct helpers for images routes' do
+    expect(ApplicationController.helpers.ls_image_path('boffin'))
+      .to eq '/images/boffin/update'
+  end
+
+  it 'does not overwrite image asset routing helpers' do
+    expect { ApplicationController.helpers.image_path('boffin') }
+      .to raise_error(Sprockets::Rails::Helper::AssetNotFound)
+  end
+end


### PR DESCRIPTION
Rails by default [defines asset URL helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html) which enable routing to items in the asset pipeline without knowing what their actual path will be at any given point. Among these are `image_path` and `image_url`.

LittleSis has an `Image` model and associated resource-routed controller. The default routing URL helper-generation logic for this produces helpers named `image_path` and `image_url`, thus over-writing the asset helpers.

This PR thus distinguishes the image resource routing helpers from the asset pipeline image helpers, so that:

* `image_(path|url)` now works as an asset URL helper
* `ls_image_(path|url)` etc route to `images_controller`