### PR TITLE
Links and interlocks as views prototype

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem 'mysql2', '~> 0.5.2'
 gem 'puma', '>= 4.2.0'
 gem 'redis'
 
+# Use SQL views in Rails
+gem 'scenic'
+gem 'scenic-mysql_adapter'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.3', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,12 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scenic (1.5.4)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
+    scenic-mysql_adapter (1.0.1)
+      mysql2
+      scenic (>= 1.4.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -427,6 +433,8 @@ DEPENDENCIES
   rubocop-rspec
   rubyzip
   sassc-rails
+  scenic
+  scenic-mysql_adapter
   selenium-webdriver (>= 3.11.0)
   shoulda-callback-matchers (~> 1.1.4)
   shoulda-matchers (>= 4.0.0)

--- a/config/initializers/scenic.rb
+++ b/config/initializers/scenic.rb
@@ -1,0 +1,5 @@
+require 'scenic/mysql_adapter'
+
+Scenic.configure do |config|
+  config.database = Scenic::Adapters::MySQL.new
+end

--- a/db/migrate/20201029112637_create_links_view.rb
+++ b/db/migrate/20201029112637_create_links_view.rb
@@ -1,0 +1,5 @@
+class CreateLinksView < ActiveRecord::Migration[6.0]
+  def change
+    create_view :links_view
+  end
+end

--- a/db/migrate/20201029120903_create_interlocks_views.rb
+++ b/db/migrate/20201029120903_create_interlocks_views.rb
@@ -1,0 +1,5 @@
+class CreateInterlocksViews < ActiveRecord::Migration[6.0]
+  def change
+    create_view :interlocks_views
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_29_112637) do
+ActiveRecord::Schema.define(version: 2020_10_29_120903) do
 
   create_table "address", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "entity_id", null: false
@@ -1430,5 +1430,8 @@ ActiveRecord::Schema.define(version: 2020_10_29_112637) do
 
   create_view "links_view", sql_definition: <<-SQL
       select `relationship`.`entity1_id` AS `entity1_id`,`relationship`.`entity2_id` AS `entity2_id`,`relationship`.`category_id` AS `category_id`,0 AS `is_reverse`,`relationship`.`id` AS `relationship_id` from `relationship` union select `relationship`.`entity2_id` AS `entity1_id`,`relationship`.`entity1_id` AS `entity2_id`,`relationship`.`category_id` AS `category_id`,1 AS `is_reverse`,`relationship`.`id` AS `relationship_id` from `relationship`
+  SQL
+  create_view "interlocks_views", sql_definition: <<-SQL
+      select `links_view`.`entity1_id` AS `entity_id`,`links_view`.`entity2_id` AS `related_id`,`interlocks`.`entity1_id` AS `interlocked_entity_id` from (`links_view` left join `links_view` `interlocks` on(`interlocks`.`entity2_id` = `links_view`.`entity2_id`))
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_134506) do
+ActiveRecord::Schema.define(version: 2020_10_29_112637) do
 
   create_table "address", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "entity_id", null: false
@@ -1427,4 +1427,8 @@ ActiveRecord::Schema.define(version: 2020_10_21_134506) do
   add_foreign_key "transaction", "entity", column: "contact2_id", name: "transaction_ibfk_2", on_update: :cascade, on_delete: :nullify
   add_foreign_key "transaction", "relationship", name: "transaction_ibfk_1", on_update: :cascade, on_delete: :cascade
   add_foreign_key "user_requests", "users"
+
+  create_view "links_view", sql_definition: <<-SQL
+      select `relationship`.`entity1_id` AS `entity1_id`,`relationship`.`entity2_id` AS `entity2_id`,`relationship`.`category_id` AS `category_id`,0 AS `is_reverse`,`relationship`.`id` AS `relationship_id` from `relationship` union select `relationship`.`entity2_id` AS `entity1_id`,`relationship`.`entity1_id` AS `entity2_id`,`relationship`.`category_id` AS `category_id`,1 AS `is_reverse`,`relationship`.`id` AS `relationship_id` from `relationship`
+  SQL
 end

--- a/db/views/interlocks_views_v01.sql
+++ b/db/views/interlocks_views_v01.sql
@@ -1,0 +1,7 @@
+SELECT
+  links_view.entity1_id AS entity_id,
+  links_view.entity2_id AS related_id,
+  interlocks.entity1_id AS interlocked_entity_id
+FROM links_view
+  LEFT JOIN links_view interlocks
+  ON interlocks.entity2_id = links_view.entity2_id

--- a/db/views/links_view_v01.sql
+++ b/db/views/links_view_v01.sql
@@ -1,0 +1,17 @@
+SELECT
+  entity1_id,
+  entity2_id,
+  category_id,
+  false AS is_reverse,
+  id AS relationship_id
+FROM relationship
+
+UNION
+
+SELECT
+  entity2_id AS entity1_id,
+  entity1_id AS entity2_id,
+  category_id,
+  true AS is_reverse,
+  id AS relationship_id
+FROM relationship


### PR DESCRIPTION
This gives us a view that could replace the links table which can be queried simply like so, and which could be represented as a model if required:

```
MariaDB [littlesis]> select * from links_view limit 1;
+------------+------------+-------------+------------+-----------------+
| entity1_id | entity2_id | category_id | is_reverse | relationship_id |
+------------+------------+-------------+------------+-----------------+
|       1006 |          1 |           1 |          0 |               1 |
+------------+------------+-------------+------------+-----------------+

```

And a view for interlocks which should probably be represented as a model:

```
MariaDB [littlesis]> select * from interlocks_views limit 1;
+-----------+------------+-----------------------+
| entity_id | related_id | interlocked_entity_id |
+-----------+------------+-----------------------+
|      1006 |          1 |                     2 |
+-----------+------------+-----------------------+
```

The lack of materialized views in MySQL does mean there **is** an efficiency problem with this, but it is easy enough to construct a rough equivalent by having the same queries populate tables that are automatically refreshed at a given interval.

It would of course be better for this sort of thing if we were using postgres, but there are workarounds.