### PR TITLE
Redirect after authentication

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -153,6 +153,8 @@ class HomeController < ApplicationController
   end
 
   def carousel_entities
+    return unless List.exists?(APP_CONFIG.fetch('carousel_list_id'))
+
     Rails.cache.fetch('home_controller_index_carousel_entities', expires_in: 2.hours) do
       List.find(APP_CONFIG.fetch('carousel_list_id')).entities.to_a
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,7 +10,6 @@ class Users::SessionsController < Devise::SessionsController
 
   # post /resource/sign_in
   def create
-    store_location_for(:user, home_dashboard_path)
     super
   end
 

--- a/app/views/entities/edit.html.erb
+++ b/app/views/entities/edit.html.erb
@@ -1,5 +1,13 @@
 <% content_for(:page_title, 'Edit: ' + @entity.name ) %>
 
+<% if notice %>
+  <div class="row no-gutters mt-5">
+    <div class="col-6">
+      <div class="alert alert-success"><%= notice %></div>
+    </div>
+  </div>
+<% end %>
+
 <%= render partial: 'header', locals: { entity: @entity } %>
 <%= render partial: 'actions', locals: { entity: @entity, current_user: current_user } %>
 

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,0 +1,51 @@
+describe 'Login', type: :feature do
+  let!(:entity) { create(:entity_org) }
+
+  context 'with a logged-out user' do
+    let!(:user) { create_basic_user(password: 'password') }
+
+    after { logout(:user) }
+
+    scenario 'user clicks login and is taken to the dashboard' do
+      visit org_path(entity)
+
+      within '#main-navbar-container' do
+        click_on 'Login'
+      end
+
+      expect(page).to have_css('h2', text: 'Log in')
+
+      within '#new_user' do
+        fill_in 'email', with: user.email
+        fill_in 'password', with: 'password'
+        click_on 'Log in'
+      end
+
+      expect(page).to show_success('Signed in successfully.')
+
+      expect(page).to have_css('h1', text: 'LittleSis Dashboard')
+    end
+
+    scenario 'user is redirected via login to the entity edit page' do
+      visit org_path(entity)
+
+      expect(page).to have_css('#entity-name', text: entity.name)
+
+      within '#action-buttons' do
+        click_on 'edit'
+      end
+
+      expect(page).to show_warning('You need to sign in or sign up before continuing.')
+
+      within '#new_user' do
+        fill_in 'email', with: user.email
+        fill_in 'password', with: 'password'
+        click_on 'Log in'
+      end
+
+      expect(page).to show_success('Signed in successfully.')
+
+      expect(page).to have_css('form.edit_entity')
+    end
+  end
+end

--- a/spec/support/notice_helpers.rb
+++ b/spec/support/notice_helpers.rb
@@ -1,0 +1,21 @@
+module Features
+  module NoticeHelpers
+    extend RSpec::Matchers::DSL
+
+    matcher :show_success do |expected|
+      match do |actual|
+        expect(actual).to have_css(".alert.alert-success", text: expected)
+      end
+    end
+
+    matcher :show_warning do |expected|
+      match do |actual|
+        expect(actual).to have_css(".alert.alert-warning", text: expected)
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Features::NoticeHelpers, type: :feature
+end


### PR DESCRIPTION
Restores default expected behaviour of a login process, i.e. to take the user back to what they were trying to access before being prompted to log in, rather than sending all users to the dashboard, which is probably not what most people want.