### PR TITLE
Allow iframes in HTML content

### DIFF
--- a/config/initializers/html_sanitizer.rb
+++ b/config/initializers/html_sanitizer.rb
@@ -1,0 +1,1 @@
+Rails::Html::WhiteListSanitizer.allowed_tags << 'iframe'


### PR DESCRIPTION
Video iframes have disappeared on the help page since we moved to Trix/ActionText