### PR TITLE
consistent list page titles

### DIFF
--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + ' - Edit')) %>
+<% content_for(:page_title, sanitize(@list.name + ' - Edit')) %>
 
 <h1>Editing list</h1>
 

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, @list.name + " - Edit") %>
+<% content_for(:page_title, raw(@list.name + ' - Edit')) %>
 
 <h1>Editing list</h1>
 

--- a/app/views/lists/interlocks/companies.html.erb
+++ b/app/views/lists/interlocks/companies.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
+<% content_for(:page_title, sanitize(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :interlocks } %>

--- a/app/views/lists/interlocks/funding.html.erb
+++ b/app/views/lists/interlocks/funding.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
+<% content_for(:page_title, sanitize(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :funding } %>

--- a/app/views/lists/interlocks/giving.html.erb
+++ b/app/views/lists/interlocks/giving.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, "#{@list.name} - Interlocks") %>
+<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :giving } %>

--- a/app/views/lists/interlocks/giving.html.erb
+++ b/app/views/lists/interlocks/giving.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
+<% content_for(:page_title, sanitize(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :giving } %>

--- a/app/views/lists/interlocks/government.html.erb
+++ b/app/views/lists/interlocks/government.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
+<% content_for(:page_title, sanitize(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :interlocks } %>

--- a/app/views/lists/interlocks/index.html.erb
+++ b/app/views/lists/interlocks/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, "#{@list.name} - Interlocks") %>
+<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :interlocks } %>

--- a/app/views/lists/interlocks/index.html.erb
+++ b/app/views/lists/interlocks/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + ' - Interlocks')) %>
+<% content_for(:page_title, sanitize(@list.name + ' - Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :interlocks } %>

--- a/app/views/lists/interlocks/other_orgs.html.erb
+++ b/app/views/lists/interlocks/other_orgs.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, "#{@list.name} - Interlocks") %>
+<% content_for(:page_title, raw(@list.name + '- Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :interlocks } %>

--- a/app/views/lists/interlocks/other_orgs.html.erb
+++ b/app/views/lists/interlocks/other_orgs.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name + '- Interlocks')) %>
+<% content_for(:page_title, sanitize(@list.name + '- Interlocks')) %>
 
 <%= render partial: 'lists/header', locals: { list: @list } %>
 <%= render partial: 'lists/tabs', locals: { list: @list, selected_tab: :interlocks } %>

--- a/app/views/lists/members.html.erb
+++ b/app/views/lists/members.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name)) %>
+<% content_for(:page_title, sanitize(@list.name)) %>
 
 <%= render partial: 'header', locals: { list: @list } %>
 <% if user_signed_in?  %>

--- a/app/views/lists/members.html.erb
+++ b/app/views/lists/members.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, @list.name) %>
+<% content_for(:page_title, raw(@list.name)) %>
 
 <%= render partial: 'header', locals: { list: @list } %>
 <% if user_signed_in?  %>

--- a/app/views/lists/modifications.html.erb
+++ b/app/views/lists/modifications.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name)) %>
+<% content_for(:page_title, sanitize(@list.name)) %>
 
 <%= render partial: 'header', locals: { list: @list } %>
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :edits } %>

--- a/app/views/lists/references.html.erb
+++ b/app/views/lists/references.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, raw(@list.name)) %>
+<% content_for(:page_title, sanitize(@list.name)) %>
 <%= render partial: 'header', locals: { list: @list } %>
 <%= render partial: "lists/tabs", locals: { list: @list, selected_tab: :sources } %>
 


### PR DESCRIPTION
#1673

Might be worth refactor, but now there is a consistency in page titles in the app/views/lists directory:

![image](https://github.com/public-accountability/littlesis-rails/assets/2983073/37266a09-ef67-413b-8538-c627e334975a)

And here is the fixed page title:
![image](https://github.com/public-accountability/littlesis-rails/assets/2983073/f77ad313-b93e-4ec2-a3fb-a8ce5b2c4b24)
