### PR TITLE
fix: command to invoke tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,7 @@ docker compose exec -e RAILS_ENV=test app bundle exec rails assets:precompile
 docker compose exec -e RAILS_ENV=test app bundle exec rails ts:configure
 ```
 
-Run the tests: `docker compose exec -e RAILS_ENV=test app bin/rspec`
+Run the tests: `docker compose exec -e RAILS_ENV=test app rspec`
 
 
 ## bin/littlesis helper


### PR DESCRIPTION
Rspec binary is installed via gems/bundler. Since there is no custom script in bin/ directory just invoke rspec directly on the app container.