### PR TITLE
fix: (maybe) nginx 503 on unverified email login

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -30,4 +30,8 @@ class Users::SessionsController < Devise::SessionsController
   def signed_in_root_path(resource_or_scope)
     home_dashboard_path
   end
+
+  def after_sign_out_path_for(resource_or_scope)
+    new_user_session_path
+  end
 end


### PR DESCRIPTION
When logging out (and maybe also login failure), redirect to login page instead of root_path.